### PR TITLE
feat: extract + genericize pipeline and schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ Homepage = "https://github.com/Kromatic-Innovation/athenaeum"
 Repository = "https://github.com/Kromatic-Innovation/athenaeum"
 Issues = "https://github.com/Kromatic-Innovation/athenaeum/issues"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/athenaeum"]
+
 [tool.ruff]
 target-version = "py311"
 line-length = 100

--- a/src/athenaeum/__init__.py
+++ b/src/athenaeum/__init__.py
@@ -1,3 +1,36 @@
 """Athenaeum — open source knowledge management pipeline."""
 
 __version__ = "0.1.0"
+
+from athenaeum.librarian import discover_raw_files, process_one, rebuild_index, run
+from athenaeum.models import (
+    ClassifiedEntity,
+    EntityAction,
+    EntityIndex,
+    EscalationItem,
+    ProcessingResult,
+    RawFile,
+    WikiEntity,
+    generate_uid,
+    parse_frontmatter,
+    render_frontmatter,
+    slugify,
+)
+
+__all__ = [
+    "ClassifiedEntity",
+    "EntityAction",
+    "EntityIndex",
+    "EscalationItem",
+    "ProcessingResult",
+    "RawFile",
+    "WikiEntity",
+    "discover_raw_files",
+    "generate_uid",
+    "parse_frontmatter",
+    "process_one",
+    "rebuild_index",
+    "render_frontmatter",
+    "run",
+    "slugify",
+]

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -1,7 +1,9 @@
 """Athenaeum CLI entry point."""
 
 import argparse
+import logging
 import sys
+from pathlib import Path
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -12,8 +14,35 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--version", action="version", version=f"%(prog)s {_get_version()}")
     subparsers = parser.add_subparsers(dest="command")
 
-    # Placeholder — init command added in #159
+    # init command — placeholder, implemented in #159
     subparsers.add_parser("init", help="Initialize a new knowledge directory")
+
+    # run command — execute the librarian pipeline
+    run_parser = subparsers.add_parser("run", help="Run the librarian pipeline")
+    run_parser.add_argument(
+        "--raw-root", type=Path, default=None,
+        help="Raw intake directory (default: ~/knowledge/raw)",
+    )
+    run_parser.add_argument(
+        "--wiki-root", type=Path, default=None,
+        help="Wiki output directory (default: ~/knowledge/wiki)",
+    )
+    run_parser.add_argument(
+        "--knowledge-root", type=Path, default=None,
+        help="Knowledge git repo root (default: ~/knowledge)",
+    )
+    run_parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Run pipeline without writing files or committing",
+    )
+    run_parser.add_argument(
+        "--max-files", type=int, default=50,
+        help="Stop after processing this many raw files (default: 50)",
+    )
+    run_parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Enable debug logging",
+    )
 
     args = parser.parse_args(argv)
 
@@ -22,10 +51,31 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "init":
-        print("athenaeum init — not yet implemented (see #159)")
+        print("athenaeum init — not yet implemented")
         return 1
 
+    if args.command == "run":
+        return _cmd_run(args)
+
     return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    from athenaeum.librarian import DEFAULT_KNOWLEDGE_ROOT, DEFAULT_RAW_ROOT, DEFAULT_WIKI_ROOT, run
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    return run(
+        raw_root=args.raw_root or DEFAULT_RAW_ROOT,
+        wiki_root=args.wiki_root or DEFAULT_WIKI_ROOT,
+        knowledge_root=args.knowledge_root or DEFAULT_KNOWLEDGE_ROOT,
+        dry_run=args.dry_run,
+        max_files=args.max_files,
+    )
 
 
 def _get_version() -> str:

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -1,0 +1,356 @@
+"""Knowledge librarian — tiered compilation pipeline.
+
+Processes raw intake files from a knowledge directory's raw/ folder into wiki
+entity pages using a four-tier approach:
+
+  Tier 1: Programmatic entity matching (no LLM)
+  Tier 2: Classification via fast LLM
+  Tier 3: Content writing via capable LLM
+  Tier 4: Human escalation to _pending_questions.md
+
+Usage:
+  athenaeum run [--raw-root PATH] [--wiki-root PATH] [--dry-run]
+
+Environment:
+  ANTHROPIC_API_KEY          Required for Tier 2/3 LLM calls.
+  ATHENAEUM_CLASSIFY_MODEL   Override the Tier 2 model (default: claude-haiku-4-5-20251001)
+  ATHENAEUM_WRITE_MODEL      Override the Tier 3 model (default: claude-sonnet-4-6)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import anthropic
+
+from athenaeum.models import (
+    EntityAction,
+    EntityIndex,
+    ProcessingResult,
+    RawFile,
+    load_schema_list,
+    parse_frontmatter,
+)
+from athenaeum.tiers import (
+    tier1_programmatic_match,
+    tier2_classify,
+    tier3_write,
+    tier4_escalate,
+)
+
+log = logging.getLogger("athenaeum")
+
+# Defaults — can be overridden via CLI args or the run() API
+DEFAULT_KNOWLEDGE_ROOT = Path.home() / "knowledge"
+DEFAULT_RAW_ROOT = DEFAULT_KNOWLEDGE_ROOT / "raw"
+DEFAULT_WIKI_ROOT = DEFAULT_KNOWLEDGE_ROOT / "wiki"
+
+# Fallback valid values if schema files are missing
+FALLBACK_TYPES = [
+    "person", "company", "project", "concept", "tool",
+    "reference", "source", "preference", "principle",
+]
+FALLBACK_ACCESS = ["open", "internal", "confidential", "personal"]
+FALLBACK_TAGS = [
+    "active", "archived", "blocked",
+]
+
+# Raw file naming: {timestamp}-{uuid8}.md
+RAW_FILE_RE = re.compile(r"^(\d{8}T\d{6}Z?)-([0-9a-f]{8})\.md$", re.IGNORECASE)
+
+
+def discover_raw_files(raw_root: Path) -> list[RawFile]:
+    """Find all raw intake files, sorted by timestamp."""
+    files: list[RawFile] = []
+    if not raw_root.exists():
+        return files
+
+    for source_dir in sorted(raw_root.iterdir()):
+        if not source_dir.is_dir():
+            continue
+        source = source_dir.name
+        for fpath in sorted(source_dir.glob("*.md")):
+            if fpath.name == ".gitkeep":
+                continue
+            m = RAW_FILE_RE.match(fpath.name)
+            if m:
+                files.append(RawFile(
+                    path=fpath,
+                    source=source,
+                    timestamp=m.group(1),
+                    uuid8=m.group(2),
+                ))
+            else:
+                files.append(RawFile(
+                    path=fpath,
+                    source=source,
+                    timestamp="",
+                    uuid8="",
+                ))
+    return files
+
+
+def rebuild_index(wiki_root: Path) -> None:
+    """Rebuild _index.md from all entity pages in the wiki."""
+    from datetime import date
+
+    by_type: dict[str, list[tuple[str, str, str]]] = {}
+    for fpath in sorted(wiki_root.glob("*.md")):
+        if fpath.name.startswith("_"):
+            continue
+        try:
+            text = fpath.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        meta, _ = parse_frontmatter(text)
+        if not meta or not meta.get("name"):
+            continue
+        etype = meta.get("type", "unknown")
+        uid = meta.get("uid", "")
+        name = meta.get("name", fpath.stem)
+        by_type.setdefault(etype, []).append((name, uid, fpath.name))
+
+    lines = [
+        "# Knowledge Wiki Index",
+        "",
+        "Auto-maintained by the knowledge librarian. Lists all entity pages",
+        "grouped by type.",
+        "",
+        f"_Last updated: {date.today().isoformat()}_",
+        f"_Total entities: {sum(len(v) for v in by_type.values())}_",
+        "",
+    ]
+    for etype in sorted(by_type.keys()):
+        lines.append(f"## {etype.title()}")
+        lines.append("")
+        for name, uid, filename in sorted(by_type[etype], key=lambda x: x[0].lower()):
+            label = f"`{uid}` " if uid else ""
+            lines.append(f"- {label}[{name}]({filename})")
+        lines.append("")
+
+    (wiki_root / "_index.md").write_text("\n".join(lines), encoding="utf-8")
+    log.info("Rebuilt _index.md with %d entities", sum(len(v) for v in by_type.values()))
+
+
+def git_snapshot(knowledge_root: Path, message: str) -> bool:
+    """Stage all changes and commit if there are any. Returns True if committed."""
+    if not (knowledge_root / ".git").exists():
+        log.warning("No .git in %s — skipping git snapshot", knowledge_root)
+        return False
+
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=str(knowledge_root),
+        capture_output=True, text=True,
+    )
+    if not result.stdout.strip():
+        return False
+
+    subprocess.run(
+        ["git", "add", "-A"],
+        cwd=str(knowledge_root), check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=str(knowledge_root), check=True,
+    )
+    log.info("Git commit: %s", message)
+    return True
+
+
+def process_one(
+    raw: RawFile,
+    index: EntityIndex,
+    wiki_root: Path,
+    client: anthropic.Anthropic,
+    valid_types: list[str],
+    valid_tags: list[str],
+    valid_access: list[str],
+    dry_run: bool = False,
+) -> ProcessingResult:
+    """Process a single raw file through all tiers."""
+    result = ProcessingResult(raw_file=raw)
+
+    # --- Tier 1: Programmatic matching ---
+    matched, _ = tier1_programmatic_match(raw, index)
+    matched_names = [name for name, _, _ in matched]
+
+    for name, uid_or_name, fpath in matched:
+        if index.has_entity_format(fpath):
+            log.info("  T1 match (entity format): %s → %s", name, fpath.name)
+        else:
+            log.info("  T1 match (old format, skip): %s → %s", name, fpath.name)
+            result.skipped.append(name)
+
+    if dry_run:
+        log.info(
+            "  [DRY RUN] T1 matched %d, skipped %d — LLM tiers skipped",
+            len(matched), len(result.skipped),
+        )
+        log.info("  [DRY RUN] Raw content preview: %s", raw.content[:120].replace("\n", " "))
+        return result
+
+    # --- Tier 2: Classification ---
+    classified = tier2_classify(
+        raw, matched_names, valid_types, valid_tags, valid_access, client,
+    )
+    log.info("  T2 classified %d new entities", len(classified))
+
+    # Build actions
+    actions: list[EntityAction] = []
+    for c in classified:
+        actions.append(EntityAction(
+            kind="create",
+            name=c.name,
+            entity_type=c.entity_type,
+            tags=c.tags,
+            access=c.access,
+            existing_uid=c.existing_uid,
+            observations=c.observations or raw.content[:2000],
+        ))
+
+    for name, uid_or_name, fpath in matched:
+        if index.has_entity_format(fpath):
+            actions.append(EntityAction(
+                kind="update",
+                name=name,
+                entity_type="",
+                tags=[],
+                access="",
+                existing_uid=uid_or_name,
+                observations=raw.content[:2000],
+            ))
+
+    if not actions:
+        log.info("  No actions needed for %s", raw.ref)
+        return result
+
+    # --- Tier 3: Content writing ---
+    new_entities, escalations = tier3_write(raw, actions, index, wiki_root, client)
+
+    for entity in new_entities:
+        page_path = wiki_root / entity.filename
+        page_path.write_text(entity.render(), encoding="utf-8")
+        index.register(entity)
+        result.created.append(entity)
+        log.info("  Created: %s → %s", entity.name, entity.filename)
+
+    result.escalated.extend(escalations)
+
+    # --- Tier 4: Escalation ---
+    if escalations:
+        tier4_escalate(escalations, wiki_root / "_pending_questions.md")
+
+    return result
+
+
+def run(
+    raw_root: Path = DEFAULT_RAW_ROOT,
+    wiki_root: Path = DEFAULT_WIKI_ROOT,
+    knowledge_root: Path = DEFAULT_KNOWLEDGE_ROOT,
+    dry_run: bool = False,
+    max_files: int = 50,
+) -> int:
+    """Run the librarian pipeline. Returns 0 on success, 1 on error."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key and not dry_run:
+        log.error("ANTHROPIC_API_KEY not set (required unless dry_run=True)")
+        return 1
+
+    if not wiki_root.exists():
+        log.error("Wiki root does not exist: %s", wiki_root)
+        return 1
+
+    if not dry_run and not (knowledge_root / ".git").exists():
+        log.error(
+            "No .git in %s — refusing to run without a writable git repo. "
+            "The librarian's pre-processing snapshot is load-bearing for raw-file "
+            "recovery. Either point knowledge_root at a real git repo, or pass "
+            "dry_run=True to inspect without writing.",
+            knowledge_root,
+        )
+        return 1
+
+    raw_files = discover_raw_files(raw_root)
+    if not raw_files:
+        log.info("No raw files to process. Nothing to do.")
+        return 0
+
+    log.info("Found %d raw file(s) to process", len(raw_files))
+
+    if len(raw_files) > max_files:
+        log.info(
+            "Budget cap: processing %d of %d files this run",
+            max_files, len(raw_files),
+        )
+        raw_files = raw_files[:max_files]
+
+    schema_path = wiki_root / "_schema"
+    valid_types = load_schema_list(schema_path, "types.md") or FALLBACK_TYPES
+    valid_tags = load_schema_list(schema_path, "tags.md") or FALLBACK_TAGS
+    valid_access = load_schema_list(schema_path, "access-levels.md") or FALLBACK_ACCESS
+
+    index = EntityIndex(wiki_root)
+    log.info("Loaded %d wiki entries into index", len(index._by_name))
+
+    client = anthropic.Anthropic(api_key=api_key) if api_key else None  # type: ignore[arg-type]
+
+    if not dry_run:
+        git_snapshot(knowledge_root, "librarian: pre-processing snapshot")
+
+    total_created = 0
+    total_updated = 0
+    total_escalated = 0
+    total_skipped = 0
+    failed_files: list[str] = []
+
+    for raw in raw_files:
+        log.info("Processing: %s", raw.ref)
+        try:
+            result = process_one(
+                raw, index, wiki_root, client,
+                valid_types, valid_tags, valid_access,
+                dry_run=dry_run,
+            )
+        except Exception:
+            log.exception("Failed to process %s", raw.ref)
+            failed_files.append(raw.ref)
+            continue
+
+        if result.error:
+            log.error("Error processing %s: %s", raw.ref, result.error)
+            failed_files.append(raw.ref)
+            continue
+
+        total_created += len(result.created)
+        total_updated += len(result.updated)
+        total_escalated += len(result.escalated)
+        total_skipped += len(result.skipped)
+
+        if not dry_run and not result.error:
+            raw.path.unlink()
+            log.info("  Deleted: %s", raw.path)
+
+    log.info(
+        "Done: %d created, %d updated, %d escalated, %d skipped, %d failed",
+        total_created, total_updated, total_escalated, total_skipped, len(failed_files),
+    )
+
+    if not dry_run and (total_created > 0 or total_updated > 0):
+        rebuild_index(wiki_root)
+
+    if not dry_run:
+        msg = (
+            f"librarian: processed {len(raw_files)} file(s) "
+            f"({total_created}C {total_updated}U {total_escalated}E {len(failed_files)}F)"
+        )
+        git_snapshot(knowledge_root, msg)
+
+    if failed_files:
+        log.warning("Failed files (will retry next run): %s", ", ".join(failed_files))
+
+    return 0

--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -1,0 +1,239 @@
+"""Data models, YAML frontmatter parsing, and entity index for Athenaeum."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# --- UID generation ---
+
+def generate_uid() -> str:
+    """Generate an 8-character hex UID from uuid4."""
+    return uuid.uuid4().hex[:8]
+
+
+def slugify(name: str) -> str:
+    """Convert a name to a filesystem-safe slug."""
+    slug = name.lower().strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    slug = slug.strip("-")
+    return slug[:60]  # cap length
+
+
+# --- Frontmatter parsing ---
+
+_FM_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Split YAML frontmatter from body. Returns (metadata, body)."""
+    m = _FM_RE.match(text)
+    if not m:
+        return {}, text
+    try:
+        meta = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError:
+        return {}, text
+    body = text[m.end():]
+    return meta, body
+
+
+def render_frontmatter(meta: dict) -> str:
+    """Render a dict as YAML frontmatter block."""
+    dumped = yaml.dump(meta, default_flow_style=False, sort_keys=False, allow_unicode=True)
+    return f"---\n{dumped}---\n"
+
+
+# --- Data classes ---
+
+@dataclass
+class RawFile:
+    """A raw intake file from raw/{source}/{timestamp}-{uuid8}.md."""
+    path: Path
+    source: str
+    timestamp: str
+    uuid8: str
+    _content: str | None = field(default=None, repr=False)
+
+    @property
+    def content(self) -> str:
+        if self._content is None:
+            self._content = self.path.read_text(encoding="utf-8")
+        return self._content
+
+    @property
+    def ref(self) -> str:
+        """Short reference for footnotes."""
+        return f"{self.source}/{self.path.name}"
+
+
+@dataclass
+class WikiEntity:
+    """An entity page in wiki/ using the full entity template format."""
+    uid: str
+    type: str
+    name: str
+    aliases: list[str] = field(default_factory=list)
+    access: str = "internal"
+    tags: list[str] = field(default_factory=list)
+    related: list[dict[str, str]] = field(default_factory=list)
+    created: str = ""
+    updated: str = ""
+    body: str = ""
+
+    @property
+    def filename(self) -> str:
+        return f"{self.uid}-{slugify(self.name)}.md"
+
+    def render(self) -> str:
+        """Render to full markdown with YAML frontmatter."""
+        meta: dict = {
+            "uid": self.uid,
+            "type": self.type,
+            "name": self.name,
+        }
+        if self.aliases:
+            meta["aliases"] = self.aliases
+        meta["access"] = self.access
+        if self.tags:
+            meta["tags"] = self.tags
+        if self.related:
+            meta["related"] = self.related
+        if self.created:
+            meta["created"] = self.created
+        if self.updated:
+            meta["updated"] = self.updated
+        return render_frontmatter(meta) + "\n" + self.body
+
+
+@dataclass
+class ClassifiedEntity:
+    """Output of Tier 2 classification."""
+    name: str
+    entity_type: str
+    tags: list[str]
+    access: str
+    is_new: bool
+    existing_uid: str | None = None
+    observations: str = ""
+
+
+@dataclass
+class EntityAction:
+    """A create or update action for Tier 3."""
+    kind: str  # "create" | "update"
+    name: str
+    entity_type: str
+    tags: list[str]
+    access: str
+    existing_uid: str | None
+    observations: str
+
+
+@dataclass
+class EscalationItem:
+    """An item to escalate to _pending_questions.md."""
+    raw_ref: str
+    entity_name: str
+    conflict_type: str  # "principled" | "ambiguous" | "classification_failed"
+    description: str
+
+
+@dataclass
+class ProcessingResult:
+    """Result of processing one raw file."""
+    raw_file: RawFile
+    created: list[WikiEntity] = field(default_factory=list)
+    updated: list[str] = field(default_factory=list)  # UIDs of updated entities
+    skipped: list[str] = field(default_factory=list)
+    escalated: list[EscalationItem] = field(default_factory=list)
+    error: str | None = None
+
+
+# --- Schema loading ---
+
+def load_schema_list(schema_path: Path, filename: str) -> list[str]:
+    """Load a list of valid values from a schema markdown table."""
+    fpath = schema_path / filename
+    if not fpath.exists():
+        return []
+    text = fpath.read_text(encoding="utf-8")
+    values: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        skip_headers = ("|--", "| Level", "| Type", "| Field")
+        if line.startswith("|") and not any(line.startswith(h) for h in skip_headers):
+            cells = [c.strip() for c in line.split("|")]
+            for cell in cells:
+                if cell and cell not in ("---", ""):
+                    values.append(cell)
+                    break
+    return values
+
+
+# --- Entity Index ---
+
+class EntityIndex:
+    """In-memory index of all wiki entities for name/alias lookup."""
+
+    def __init__(self, wiki_root: Path) -> None:
+        self.wiki_root = wiki_root
+        self._by_name: dict[str, tuple[str, Path]] = {}
+        self._entities: dict[str, dict] = {}
+        self._load()
+
+    def _load(self) -> None:
+        for fpath in sorted(self.wiki_root.glob("*.md")):
+            if fpath.name.startswith("_"):
+                continue
+            try:
+                text = fpath.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            meta, _ = parse_frontmatter(text)
+            if not meta:
+                continue
+
+            uid = meta.get("uid", "")
+            name = meta.get("name", "")
+            if not name:
+                continue
+
+            key = name.lower()
+            self._by_name[key] = (uid or name, fpath)
+            if uid:
+                self._entities[uid] = meta
+
+            for alias in meta.get("aliases", []):
+                if alias:
+                    self._by_name[alias.lower()] = (uid or name, fpath)
+
+    def lookup(self, name: str) -> tuple[str, Path] | None:
+        """Look up by name or alias (case-insensitive). Returns (uid_or_name, path) or None."""
+        return self._by_name.get(name.lower())
+
+    def has_entity_format(self, path: Path) -> bool:
+        """Check if a wiki page uses the full entity template format (has uid field)."""
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return False
+        meta, _ = parse_frontmatter(text)
+        return bool(meta.get("uid"))
+
+    def register(self, entity: WikiEntity) -> None:
+        """Add a newly created entity to the index."""
+        key = entity.name.lower()
+        self._by_name[key] = (entity.uid, self.wiki_root / entity.filename)
+        self._entities[entity.uid] = {
+            "uid": entity.uid,
+            "type": entity.type,
+            "name": entity.name,
+        }
+        for alias in entity.aliases:
+            if alias:
+                self._by_name[alias.lower()] = (entity.uid, self.wiki_root / entity.filename)

--- a/src/athenaeum/schema/_entity-template.md
+++ b/src/athenaeum/schema/_entity-template.md
@@ -1,0 +1,87 @@
+# Entity Page Template
+
+Reference template for creating wiki entity pages. The librarian's Tier 3
+uses this structure when writing new pages. Humans can also use it when
+manually adding entities.
+
+## Template
+
+```markdown
+---
+uid: e7a3b1c4                   # 8-char hex, permanent, never changes
+type: person                     # from _schema/types.md
+name: Display Name               # human-readable, CAN be renamed
+aliases: [Alt Name, Nickname]    # for dedup and search
+access: internal                 # from _schema/access-levels.md
+tags: [active]                   # from _schema/tags.md
+related:
+  - uid: f2d4e6a8               # cross-reference by UID
+    role: employer               # freeform relationship label
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+# Display Name
+
+Opening paragraph: who/what this is and why it matters. Claims cite
+sources via footnotes.[^1]
+
+## Section (as appropriate for entity type)
+
+- Key fact or observation[^2]
+- Another fact from a different source[^1][^3]
+
+## Open Questions
+
+- [ ] Unresolved question about this entity
+
+[^1]: [[src-entity-uid|Source Name]] context, date
+[^2]: [[src-other-uid|Other Source]] context, date
+[^3]: Direct observation, date
+```
+
+## Field Reference
+
+### Required (every page)
+
+| Field | Purpose |
+|-------|---------|
+| `uid` | 8-char hex from `uuid4`. Permanent. Never changes. |
+| `type` | Entity type from `_schema/types.md`. |
+| `name` | Human-readable display name. Can be renamed. |
+| `access` | Access level from `_schema/access-levels.md`. |
+
+### Recommended
+
+| Field | Purpose |
+|-------|---------|
+| `aliases` | Alternate names. Librarian checks before creating dupes. |
+| `tags` | Topical tags from `_schema/tags.md`. |
+| `related` | Typed links to other entities by UID + role. |
+| `created` | ISO date when page was first created. |
+| `updated` | ISO date when page was last modified. |
+
+## Sections by Entity Type
+
+| Type | Typical sections |
+|------|-----------------|
+| person | Role/Background, Relationship History, As Information Source, Contact |
+| company | Overview, Relationship History, Key Outcomes, Contacts |
+| project | Overview, Timeline, Outcomes, Lessons Learned |
+| concept | Definition, Usage, Related Concepts |
+| tool | Purpose, Configuration, Opinions |
+| reference | Summary, Key Takeaways, Citations |
+| preference | Current Setting, History, Rationale |
+| principle | Statement, Evidence, Exceptions |
+
+## Trust Model
+
+Trust is NOT a frontmatter field. Instead:
+
+1. Claims cite sources via Wikipedia-style footnotes
+2. Sources are entities with their own pages
+3. Source pages accumulate reliability notes over time
+4. Trust is assessed by following the citation chain
+
+This means trust is contextual: "Alice is reliable on product topics but
+overstates timelines" — not a single confidence score.

--- a/src/athenaeum/schema/access-levels.md
+++ b/src/athenaeum/schema/access-levels.md
@@ -1,0 +1,21 @@
+# Access Levels
+
+Per-page access classification. Every wiki page must have exactly one access
+level. If a page needs mixed access levels, split it into two pages and
+cross-link them.
+
+| Level | Who can see | Example content |
+|-------|------------|-----------------|
+| open | Anyone, safe to publish publicly | Blog content, public frameworks, open-source docs |
+| internal | You and your personal agents | Workflow preferences, tool opinions, internal notes |
+| confidential | You and specific business context | Client engagement details, pricing, strategy |
+| personal | You and trusted individuals only | Home address, health, family matters |
+
+## Rules
+
+- Default new pages to `internal` unless the source material clearly indicates
+  another level.
+- Agents read all access levels for reasoning but must respect access level
+  when producing output (e.g., never include `confidential` content in public-facing
+  text).
+- When publishing, only `open` pages are eligible for export.

--- a/src/athenaeum/schema/observation-filter.md
+++ b/src/athenaeum/schema/observation-filter.md
@@ -1,0 +1,44 @@
+# Observation Filter
+
+Meta-memory: guides what the system notices and saves. This file is both
+configuration and a living document — the librarian updates it during
+consolidation when patterns emerge in incoming data.
+
+## Always Capture
+
+These categories are always worth saving when encountered:
+
+- **People**: names, roles, relationships, contact details, reliability notes
+- **Decisions**: architectural choices, tool selections, process changes, and their rationale
+- **Corrections**: when the user corrects the agent's understanding — the correction AND the wrong assumption
+- **Preferences**: communication style, workflow preferences, scheduling patterns, tool opinions
+- **Principles**: stated values, guiding rules, axioms the user operates by
+
+## Capture When Reinforced
+
+These categories are saved when the user signals they matter (by explicitly
+asking to remember, or when three or more related observations accumulate):
+
+- **Food & dining**: restaurant preferences, dietary constraints
+- **Travel**: frequent destinations, airline/hotel preferences
+- **Health**: relevant context for scheduling or energy management
+- **Hobbies & interests**: non-work topics the user engages with
+
+## Decay Rules
+
+- Short-term filter items (added by the librarian from pattern detection)
+  decay after 30 days unless reinforced by new observations.
+- Items in "Always Capture" do not decay.
+- Items promoted from "Capture When Reinforced" to "Always Capture" require
+  human approval.
+
+## Pattern Detection
+
+During consolidation, the librarian analyzes the last N raw intake files
+and proposes filter additions when:
+
+- 3+ observations in the same category arrive within 7 days
+- A user explicitly says "remember X" about a topic not yet in the filter
+- A source entity accumulates 5+ citations (signals the source is important)
+
+Proposed additions are appended to `_pending_questions.md` for human review.

--- a/src/athenaeum/schema/tags.md
+++ b/src/athenaeum/schema/tags.md
@@ -1,0 +1,14 @@
+# Tags
+
+Controlled vocabulary for wiki entity tags. Tags are topical classifiers,
+not access-related (access is a separate frontmatter field). The librarian
+validates against this list. New tags can be proposed by the LLM; frequently
+proposed tags should be added here.
+
+## Status Tags
+
+| Tag | Usage |
+|-----|-------|
+| active | Currently relevant or in-progress |
+| archived | No longer active but retained for reference |
+| blocked | Waiting on external dependency or decision |

--- a/src/athenaeum/schema/types.md
+++ b/src/athenaeum/schema/types.md
@@ -1,0 +1,17 @@
+# Entity Types
+
+Controlled vocabulary for wiki entity types. The librarian validates against this
+table. Add new types when three or more entities are awkwardly forced into an
+existing type (rule of three). New types proposed by the LLM require human approval.
+
+| Type | Description | Example |
+|------|------------|---------|
+| person | A human being | Alice, Bob |
+| company | An organization or business entity | Acme Corp, Initech |
+| project | A bounded engagement, initiative, or product | Website redesign, Q4 launch |
+| concept | A framework, method, methodology, or idea | Lean startup, Bayesian reasoning |
+| tool | Software, service, or physical tool | VS Code, Obsidian, Figma |
+| reference | An article, book, paper, video, or external resource | "Thinking Fast and Slow" |
+| source | An information source (may overlap with person) | Web article, API doc, meeting notes |
+| preference | A personal preference, configuration, or behavioral pattern | Calendar rules, communication style |
+| principle | An axiom, guiding rule, or value (can be revised) | "Prioritize honesty", "Ship fast" |

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -1,0 +1,411 @@
+"""Tiered processing pipeline for the knowledge librarian.
+
+Tier 1: Programmatic entity matching (no LLM)
+Tier 2: Classification via fast LLM (default: Haiku)
+Tier 3: Content writing via capable LLM (default: Sonnet)
+Tier 4: Human escalation
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import date
+from pathlib import Path
+
+import anthropic
+
+from athenaeum.models import (
+    ClassifiedEntity,
+    EntityAction,
+    EntityIndex,
+    EscalationItem,
+    RawFile,
+    WikiEntity,
+    generate_uid,
+)
+
+log = logging.getLogger("athenaeum")
+
+# Model defaults — override via environment variables
+DEFAULT_CLASSIFY_MODEL = "claude-haiku-4-5-20251001"
+DEFAULT_WRITE_MODEL = "claude-sonnet-4-6"
+
+
+def _get_classify_model() -> str:
+    return os.environ.get("ATHENAEUM_CLASSIFY_MODEL", DEFAULT_CLASSIFY_MODEL)
+
+
+def _get_write_model() -> str:
+    return os.environ.get("ATHENAEUM_WRITE_MODEL", DEFAULT_WRITE_MODEL)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — Programmatic matching
+# ---------------------------------------------------------------------------
+
+def tier1_programmatic_match(
+    raw: RawFile,
+    index: EntityIndex,
+) -> tuple[list[tuple[str, str, Path]], list[str]]:
+    """Match entity names in raw content against the wiki index.
+
+    Returns:
+        matched: list of (name, uid_or_name, path) for entities found in index
+        unmatched_content: the raw content (passed through for Tier 2)
+    """
+    matched: list[tuple[str, str, Path]] = []
+    content_lower = raw.content.lower()
+
+    for name_key, (uid_or_name, fpath) in index._by_name.items():
+        # Only match names that are at least 3 chars to avoid false positives
+        if len(name_key) < 3:
+            continue
+        if name_key in content_lower:
+            # Verify it's a word boundary match (not a substring)
+            pattern = re.compile(r"\b" + re.escape(name_key) + r"\b", re.IGNORECASE)
+            if pattern.search(raw.content):
+                matched.append((name_key, uid_or_name, fpath))
+
+    return matched, []
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — Classification (fast LLM)
+# ---------------------------------------------------------------------------
+
+CLASSIFY_SYSTEM = """You are a knowledge librarian assistant. You analyze raw observation text
+and extract structured entity information.
+
+You will receive:
+1. Raw observation text from an AI agent session
+2. A list of valid entity types, tags, and access levels
+3. A list of entity names that already exist in the wiki (matched programmatically)
+
+Your job: identify entities mentioned in the raw text that should become wiki pages.
+
+Rules:
+- Only extract entities that are substantive enough to warrant their own page.
+  A passing mention ("I talked to Bob") is not enough — there must be meaningful
+  information worth recording.
+- Do NOT extract the same entity that's already in the "already matched" list.
+- For each entity, classify: name, type, tags, access level.
+- If the raw text is purely procedural (build logs, error traces, CI output)
+  with no entity-worthy content, return an empty array."""
+
+CLASSIFY_USER_TEMPLATE = """## Raw observation
+{content}
+
+## Already matched entities (skip these)
+{matched_names}
+
+## Valid entity types
+{valid_types}
+
+## Valid tags
+{valid_tags}
+
+## Valid access levels
+{valid_access}
+
+## Instructions
+Extract entities from the raw observation. Return a JSON array of objects:
+```json
+[
+  {{
+    "name": "Entity Name",
+    "entity_type": "person",
+    "tags": ["active"],
+    "access": "internal",
+    "observations": "Key facts about this entity extracted from the raw text"
+  }}
+]
+```
+
+If no entities worth creating, return `[]`.
+Return ONLY the JSON array, no other text."""
+
+
+def tier2_classify(
+    raw: RawFile,
+    matched_names: list[str],
+    valid_types: list[str],
+    valid_tags: list[str],
+    valid_access: list[str],
+    client: anthropic.Anthropic,
+) -> list[ClassifiedEntity]:
+    """Use a fast LLM to classify entities in the raw text.
+
+    Returns list of ClassifiedEntity with is_new=True (Tier 2 only finds new entities).
+    """
+    if not raw.content.strip():
+        return []
+
+    user_msg = CLASSIFY_USER_TEMPLATE.format(
+        content=raw.content[:4000],
+        matched_names=", ".join(matched_names) if matched_names else "(none)",
+        valid_types=", ".join(valid_types),
+        valid_tags=", ".join(valid_tags),
+        valid_access=", ".join(valid_access),
+    )
+
+    response = client.messages.create(
+        model=_get_classify_model(),
+        max_tokens=1024,
+        system=CLASSIFY_SYSTEM,
+        messages=[{"role": "user", "content": user_msg}],
+    )
+
+    text = response.content[0].text.strip()
+
+    json_match = re.search(r"\[.*\]", text, re.DOTALL)
+    if not json_match:
+        log.warning("Classification returned no JSON for %s: %s", raw.ref, text[:200])
+        return []
+
+    try:
+        items = json.loads(json_match.group())
+    except json.JSONDecodeError:
+        log.warning("Classification returned invalid JSON for %s: %s", raw.ref, text[:200])
+        return []
+
+    results: list[ClassifiedEntity] = []
+    for item in items:
+        if not isinstance(item, dict) or not item.get("name"):
+            continue
+        entity_type = item.get("entity_type", "reference")
+        if entity_type not in valid_types:
+            entity_type = "reference"
+        access = item.get("access", "internal")
+        if access not in valid_access:
+            access = "internal"
+        tags = [t for t in item.get("tags", []) if t in valid_tags]
+
+        results.append(ClassifiedEntity(
+            name=item["name"],
+            entity_type=entity_type,
+            tags=tags,
+            access=access,
+            is_new=True,
+            observations=item.get("observations", ""),
+        ))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — Content writing (capable LLM)
+# ---------------------------------------------------------------------------
+
+CREATE_SYSTEM = """You are a knowledge librarian. You create entity wiki pages from
+raw observations.
+
+Write a clean, factual entity page in markdown. Follow these rules:
+- Start with `# Entity Name`
+- Include only facts supported by the raw observation
+- Use footnotes to cite the source: [^1]: source reference
+- Keep it concise — 3-10 lines of content is typical for a new entity
+- Do NOT include YAML frontmatter — that is handled separately
+- If there are open questions or uncertainties, add an `## Open Questions` section
+  with checkbox items
+- Write in a neutral, encyclopedic tone"""
+
+CREATE_TEMPLATE = """## Entity to create
+Name: {name}
+Type: {entity_type}
+Tags: {tags}
+Access: {access}
+
+## Raw observation (source: {source_ref})
+{observations}
+
+## Instructions
+Write the body content (no frontmatter) for this entity's wiki page.
+Use footnotes citing the source as: [^1]: {source_ref}"""
+
+MERGE_SYSTEM = """You are a knowledge librarian. You merge new observations into
+existing entity wiki pages.
+
+Rules:
+- Preserve all existing content
+- Add new information in the appropriate section
+- Add footnotes for new claims, citing the source
+- If the new observation contradicts existing content:
+  - Factual contradiction (verifiable fact): keep the more reliable source, note the discrepancy
+  - Contextual difference (opinions, preferences): capture both with context
+  - Principled tension (values, axioms): flag for human review — return ESCALATE:
+- Do NOT modify YAML frontmatter — return body content only"""
+
+MERGE_TEMPLATE = """## Existing page content
+{existing_body}
+
+## New observation (source: {source_ref})
+{observations}
+
+## Instructions
+Return the updated body content (no frontmatter). Merge the new observation
+into the existing page. If you detect a principled contradiction that needs
+human review, start your response with exactly `ESCALATE:` followed by a
+description of the conflict, then provide the merged body below a `---` separator."""
+
+
+def tier3_create(
+    action: EntityAction,
+    source_ref: str,
+    client: anthropic.Anthropic,
+) -> WikiEntity:
+    """Use a capable LLM to create a new entity page."""
+    user_msg = CREATE_TEMPLATE.format(
+        name=action.name,
+        entity_type=action.entity_type,
+        tags=", ".join(action.tags),
+        access=action.access,
+        source_ref=source_ref,
+        observations=action.observations[:3000],
+    )
+
+    response = client.messages.create(
+        model=_get_write_model(),
+        max_tokens=2048,
+        system=CREATE_SYSTEM,
+        messages=[{"role": "user", "content": user_msg}],
+    )
+
+    body = response.content[0].text.strip()
+    today = date.today().isoformat()
+
+    return WikiEntity(
+        uid=generate_uid(),
+        type=action.entity_type,
+        name=action.name,
+        aliases=[],
+        access=action.access,
+        tags=action.tags,
+        created=today,
+        updated=today,
+        body=body,
+    )
+
+
+def tier3_merge(
+    action: EntityAction,
+    existing_body: str,
+    source_ref: str,
+    client: anthropic.Anthropic,
+) -> tuple[str | None, EscalationItem | None]:
+    """Use a capable LLM to merge observations into an existing entity page.
+
+    Returns (updated_body, escalation_item).
+    """
+    user_msg = MERGE_TEMPLATE.format(
+        existing_body=existing_body[:4000],
+        source_ref=source_ref,
+        observations=action.observations[:3000],
+    )
+
+    response = client.messages.create(
+        model=_get_write_model(),
+        max_tokens=2048,
+        system=MERGE_SYSTEM,
+        messages=[{"role": "user", "content": user_msg}],
+    )
+
+    text = response.content[0].text.strip()
+    escalation = None
+
+    if text.startswith("ESCALATE:"):
+        parts = text.split("---", 1)
+        esc_desc = parts[0].replace("ESCALATE:", "").strip()
+        escalation = EscalationItem(
+            raw_ref=source_ref,
+            entity_name=action.name,
+            conflict_type="principled",
+            description=esc_desc,
+        )
+        if len(parts) > 1:
+            text = parts[1].strip()
+        else:
+            return None, escalation
+
+    return text, escalation
+
+
+def tier3_write(
+    raw: RawFile,
+    actions: list[EntityAction],
+    index: EntityIndex,
+    wiki_root: Path,
+    client: anthropic.Anthropic,
+) -> tuple[list[WikiEntity], list[EscalationItem]]:
+    """Process all entity actions for a raw file through the capable LLM.
+
+    Returns (new_entities, escalation_items).
+    """
+    new_entities: list[WikiEntity] = []
+    escalations: list[EscalationItem] = []
+
+    for action in actions:
+        if action.kind == "create":
+            new_entities.append(tier3_create(action, raw.ref, client))
+
+        elif action.kind == "update" and action.existing_uid:
+            existing_path = None
+            for p in wiki_root.glob("*.md"):
+                if p.name.startswith(action.existing_uid):
+                    existing_path = p
+                    break
+
+            if not existing_path:
+                log.warning("Could not find existing page for uid %s", action.existing_uid)
+                continue
+
+            from athenaeum.models import parse_frontmatter, render_frontmatter
+            text = existing_path.read_text(encoding="utf-8")
+            meta, existing_body = parse_frontmatter(text)
+
+            updated_body, esc = tier3_merge(action, existing_body, raw.ref, client)
+            if esc:
+                escalations.append(esc)
+            if updated_body:
+                meta["updated"] = date.today().isoformat()
+                existing_path.write_text(
+                    render_frontmatter(meta) + "\n" + updated_body,
+                    encoding="utf-8",
+                )
+
+    return new_entities, escalations
+
+
+# ---------------------------------------------------------------------------
+# Tier 4 — Human escalation
+# ---------------------------------------------------------------------------
+
+def tier4_escalate(items: list[EscalationItem], pending_path: Path) -> None:
+    """Append escalation items to _pending_questions.md."""
+    if not items:
+        return
+
+    today = date.today().isoformat()
+    sections: list[str] = []
+    for item in items:
+        sections.append(
+            f"## [{today}] Entity: \"{item.entity_name}\" (from {item.raw_ref})\n\n"
+            f"**Conflict type**: {item.conflict_type}\n"
+            f"**Description**: {item.description}\n"
+        )
+
+    new_content = "\n---\n\n".join(sections)
+
+    if pending_path.exists():
+        existing = pending_path.read_text(encoding="utf-8")
+        if existing.strip():
+            new_content = existing.rstrip() + "\n\n---\n\n" + new_content
+        else:
+            new_content = "# Pending Questions\n\n" + new_content
+    else:
+        new_content = "# Pending Questions\n\n" + new_content
+
+    pending_path.write_text(new_content + "\n", encoding="utf-8")
+    log.info("Escalated %d items to %s", len(items), pending_path)


### PR DESCRIPTION
## Summary

- Extract librarian pipeline (models, tiers, librarian) from code-workspace-config into athenaeum
- Genericize all paths — `~/knowledge/` as configurable default, no hardcoded home dirs
- Strip Kromatic-specific references from schema, tags, access levels, entity template
- Make LLM model names configurable via `ATHENAEUM_CLASSIFY_MODEL` / `ATHENAEUM_WRITE_MODEL` env vars
- Remove skill-change-proposal handling (Kromatic-internal workflow)
- Wire up `athenaeum run` CLI subcommand with `--dry-run`, `--raw-root`, `--wiki-root` options
- Expose public API: `from athenaeum import WikiEntity, EntityIndex, run`

## Test plan

- [x] `pip install -e ".[dev]"` succeeds
- [x] `pytest tests/ -v` passes
- [x] `ruff check src/ tests/` clean
- [x] `athenaeum run --dry-run` works against real ~/knowledge/
- [x] `from athenaeum import WikiEntity, EntityIndex, run` imports cleanly

Closes Kromatic-Innovation/code-workspace-config#158
