### PR TITLE
feat: athenaeum init CLI command

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -14,8 +14,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--version", action="version", version=f"%(prog)s {_get_version()}")
     subparsers = parser.add_subparsers(dest="command")
 
-    # init command — placeholder, implemented in #159
-    subparsers.add_parser("init", help="Initialize a new knowledge directory")
+    # init command
+    init_parser = subparsers.add_parser("init", help="Initialize a new knowledge directory")
+    init_parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path("~/knowledge"),
+        help="Target directory (default: ~/knowledge)",
+    )
 
     # run command — execute the librarian pipeline
     run_parser = subparsers.add_parser("run", help="Run the librarian pipeline")
@@ -51,12 +57,19 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.command == "init":
-        print("athenaeum init — not yet implemented")
-        return 1
+        return _cmd_init(args)
 
     if args.command == "run":
         return _cmd_run(args)
 
+    return 0
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    from athenaeum.init import init_knowledge_dir
+
+    target = init_knowledge_dir(args.path)
+    print(f"Initialized knowledge directory at {target}")
     return 0
 
 

--- a/src/athenaeum/init.py
+++ b/src/athenaeum/init.py
@@ -1,0 +1,76 @@
+"""Initialize a new knowledge directory with standard structure and schema files."""
+
+from __future__ import annotations
+
+import importlib.resources
+import subprocess
+from pathlib import Path
+
+# Schema files bundled in the package that get copied to wiki/_schema/
+_SCHEMA_FILES = [
+    "_entity-template.md",
+    "access-levels.md",
+    "observation-filter.md",
+    "tags.md",
+    "types.md",
+]
+
+# Standard subdirectories created during init
+_SUBDIRS = [
+    "raw",
+    "raw/sessions",
+    "wiki",
+    "wiki/_schema",
+]
+
+_INDEX_CONTENT = """\
+---
+title: Master Index
+---
+
+<!-- This file is the master index for the knowledge wiki. -->
+"""
+
+
+def init_knowledge_dir(path: Path) -> Path:
+    """Create and initialize a knowledge directory at *path*.
+
+    The function is **idempotent**: calling it twice on the same directory
+    will not overwrite existing files or lose data.
+
+    Returns the resolved *path* for convenience.
+    """
+    path = path.expanduser().resolve()
+
+    # 1. Create directory tree
+    for subdir in _SUBDIRS:
+        (path / subdir).mkdir(parents=True, exist_ok=True)
+
+    # 2. Copy bundled schema files (skip if already present)
+    schema_dest = path / "wiki" / "_schema"
+    schema_pkg = importlib.resources.files("athenaeum.schema")
+    for fname in _SCHEMA_FILES:
+        dest = schema_dest / fname
+        if dest.exists():
+            continue
+        source = schema_pkg / fname
+        dest.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    # 3. Create master index (skip if already present)
+    index_file = path / "wiki" / "_index.md"
+    if not index_file.exists():
+        index_file.write_text(_INDEX_CONTENT, encoding="utf-8")
+
+    # 4. Initialize git repo and create initial commit
+    git_dir = path / ".git"
+    if not git_dir.exists():
+        subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+        subprocess.run(["git", "add", "."], cwd=path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initialize knowledge directory"],
+            cwd=path,
+            check=True,
+            capture_output=True,
+        )
+
+    return path

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,116 @@
+"""Tests for ``athenaeum init`` command and ``init_knowledge_dir``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from athenaeum.init import _INDEX_CONTENT, _SCHEMA_FILES, _SUBDIRS, init_knowledge_dir
+
+
+def test_fresh_init_creates_dirs(tmp_path: Path) -> None:
+    """A fresh init creates all expected subdirectories."""
+    target = tmp_path / "knowledge"
+    init_knowledge_dir(target)
+
+    for subdir in _SUBDIRS:
+        assert (target / subdir).is_dir(), f"missing subdir: {subdir}"
+
+
+def test_fresh_init_creates_schema_files(tmp_path: Path) -> None:
+    """Schema files are copied into wiki/_schema/."""
+    target = tmp_path / "knowledge"
+    init_knowledge_dir(target)
+
+    schema_dir = target / "wiki" / "_schema"
+    for fname in _SCHEMA_FILES:
+        f = schema_dir / fname
+        assert f.is_file(), f"missing schema file: {fname}"
+        assert f.read_text(encoding="utf-8").strip(), f"schema file is empty: {fname}"
+
+
+def test_fresh_init_creates_index(tmp_path: Path) -> None:
+    """wiki/_index.md is created with default content."""
+    target = tmp_path / "knowledge"
+    init_knowledge_dir(target)
+
+    index = target / "wiki" / "_index.md"
+    assert index.is_file()
+    assert index.read_text(encoding="utf-8") == _INDEX_CONTENT
+
+
+def test_fresh_init_creates_git_repo(tmp_path: Path) -> None:
+    """A git repo is initialized with an initial commit."""
+    target = tmp_path / "knowledge"
+    init_knowledge_dir(target)
+
+    assert (target / ".git").is_dir()
+
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=target,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Initialize knowledge directory" in result.stdout
+
+
+def test_idempotent_preserves_content(tmp_path: Path) -> None:
+    """Running init twice does not overwrite user content."""
+    target = tmp_path / "knowledge"
+    init_knowledge_dir(target)
+
+    # Add custom content to existing files
+    custom_index = "# My Custom Index\n"
+    (target / "wiki" / "_index.md").write_text(custom_index, encoding="utf-8")
+
+    custom_schema = "# Custom types\n"
+    (target / "wiki" / "_schema" / "types.md").write_text(custom_schema, encoding="utf-8")
+
+    # Add a user file in raw/
+    (target / "raw" / "my-notes.md").write_text("my notes\n", encoding="utf-8")
+
+    # Run init again
+    init_knowledge_dir(target)
+
+    # Verify nothing was overwritten
+    assert (target / "wiki" / "_index.md").read_text(encoding="utf-8") == custom_index
+    assert (target / "wiki" / "_schema" / "types.md").read_text(encoding="utf-8") == custom_schema
+    assert (target / "raw" / "my-notes.md").read_text(encoding="utf-8") == "my notes\n"
+
+
+def test_custom_path(tmp_path: Path) -> None:
+    """--path flag directs init to a custom location."""
+    custom = tmp_path / "my" / "custom" / "dir"
+    result = init_knowledge_dir(custom)
+
+    assert result == custom.resolve()
+    assert (custom / "wiki" / "_schema").is_dir()
+    assert (custom / "raw" / "sessions").is_dir()
+
+
+def test_cli_init_default(tmp_path: Path, monkeypatch) -> None:
+    """CLI ``athenaeum init --path <dir>`` creates a knowledge dir."""
+    from athenaeum.cli import main
+
+    target = tmp_path / "knowledge"
+    exit_code = main(["init", "--path", str(target)])
+
+    assert exit_code == 0
+    assert (target / "wiki" / "_index.md").is_file()
+
+
+def test_schema_files_match_bundled(tmp_path: Path) -> None:
+    """Copied schema files match the bundled originals byte-for-byte."""
+    import importlib.resources
+
+    target = tmp_path / "knowledge"
+    init_knowledge_dir(target)
+
+    schema_pkg = importlib.resources.files("athenaeum.schema")
+    for fname in _SCHEMA_FILES:
+        bundled = (schema_pkg / fname).read_text(encoding="utf-8")
+        copied = (target / "wiki" / "_schema" / fname).read_text(encoding="utf-8")
+        assert copied == bundled, f"schema mismatch: {fname}"


### PR DESCRIPTION
## Summary

- Implement `athenaeum init [--path]` CLI command that bootstraps a knowledge directory
- Creates subdirs (wiki/, raw/, raw/sessions/, wiki/_schema/), copies bundled schema files
- Initializes git repo with initial commit
- Idempotent: second run preserves existing content

## Test plan

- [x] Fresh init creates all dirs and files
- [x] Schema files copied and match bundled originals
- [x] Idempotent: second run preserves user-modified files
- [x] Custom `--path` works
- [x] CLI integration test
- [x] `ruff check` clean, all tests pass

Closes Kromatic-Innovation/code-workspace-config#159
