### PR TITLE
fix: address reviewer findings from audit (#161-#164)

### DIFF
--- a/src/athenaeum/__init__.py
+++ b/src/athenaeum/__init__.py
@@ -2,6 +2,7 @@
 
 __version__ = "0.1.0"
 
+from athenaeum.init import init_knowledge_dir
 from athenaeum.librarian import discover_raw_files, process_one, rebuild_index, run
 from athenaeum.models import (
     ClassifiedEntity,
@@ -27,6 +28,7 @@ __all__ = [
     "WikiEntity",
     "discover_raw_files",
     "generate_uid",
+    "init_knowledge_dir",
     "parse_frontmatter",
     "process_one",
     "rebuild_index",

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -74,7 +74,7 @@ def _cmd_init(args: argparse.Namespace) -> int:
 
 
 def _cmd_run(args: argparse.Namespace) -> int:
-    from athenaeum.librarian import DEFAULT_KNOWLEDGE_ROOT, DEFAULT_RAW_ROOT, DEFAULT_WIKI_ROOT, run
+    from athenaeum.librarian import DEFAULT_KNOWLEDGE_ROOT, run
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
@@ -82,10 +82,14 @@ def _cmd_run(args: argparse.Namespace) -> int:
         datefmt="%H:%M:%S",
     )
 
+    knowledge_root = args.knowledge_root or DEFAULT_KNOWLEDGE_ROOT
+    raw_root = args.raw_root or (knowledge_root / "raw")
+    wiki_root = args.wiki_root or (knowledge_root / "wiki")
+
     return run(
-        raw_root=args.raw_root or DEFAULT_RAW_ROOT,
-        wiki_root=args.wiki_root or DEFAULT_WIKI_ROOT,
-        knowledge_root=args.knowledge_root or DEFAULT_KNOWLEDGE_ROOT,
+        raw_root=raw_root,
+        wiki_root=wiki_root,
+        knowledge_root=knowledge_root,
         dry_run=args.dry_run,
         max_files=args.max_files,
     )

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -176,7 +176,7 @@ def process_one(
     result = ProcessingResult(raw_file=raw)
 
     # --- Tier 1: Programmatic matching ---
-    matched, _ = tier1_programmatic_match(raw, index)
+    matched = tier1_programmatic_match(raw, index)
     matched_names = [name for name, _, _ in matched]
 
     for name, uid_or_name, fpath in matched:
@@ -352,5 +352,6 @@ def run(
 
     if failed_files:
         log.warning("Failed files (will retry next run): %s", ", ".join(failed_files))
+        return 1
 
     return 0

--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -157,21 +157,41 @@ class ProcessingResult:
 # --- Schema loading ---
 
 def load_schema_list(schema_path: Path, filename: str) -> list[str]:
-    """Load a list of valid values from a schema markdown table."""
+    """Load a list of valid values from a schema markdown table.
+
+    Parses standard markdown tables, extracting the first cell from each
+    data row. Header and separator rows are skipped.
+    """
     fpath = schema_path / filename
     if not fpath.exists():
         return []
     text = fpath.read_text(encoding="utf-8")
+    lines = text.splitlines()
     values: list[str] = []
-    for line in text.splitlines():
-        line = line.strip()
-        skip_headers = ("|--", "| Level", "| Type", "| Field")
-        if line.startswith("|") and not any(line.startswith(h) for h in skip_headers):
-            cells = [c.strip() for c in line.split("|")]
-            for cell in cells:
-                if cell and cell not in ("---", ""):
-                    values.append(cell)
-                    break
+    # Collect separator row indices so we can skip headers
+    separator_indices: set[int] = set()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("|") and all(
+            c in "-| " for c in stripped
+        ):
+            separator_indices.add(i)
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        # Skip separator rows
+        if i in separator_indices:
+            continue
+        # Skip header rows (the row immediately before a separator)
+        if (i + 1) in separator_indices:
+            continue
+        cells = [c.strip() for c in stripped.split("|")]
+        for cell in cells:
+            if cell:
+                values.append(cell)
+                break
     return values
 
 

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -25,6 +25,8 @@ from athenaeum.models import (
     RawFile,
     WikiEntity,
     generate_uid,
+    parse_frontmatter,
+    render_frontmatter,
 )
 
 log = logging.getLogger("athenaeum")
@@ -49,12 +51,10 @@ def _get_write_model() -> str:
 def tier1_programmatic_match(
     raw: RawFile,
     index: EntityIndex,
-) -> tuple[list[tuple[str, str, Path]], list[str]]:
+) -> list[tuple[str, str, Path]]:
     """Match entity names in raw content against the wiki index.
 
-    Returns:
-        matched: list of (name, uid_or_name, path) for entities found in index
-        unmatched_content: the raw content (passed through for Tier 2)
+    Returns list of (name, uid_or_name, path) for entities found in index.
     """
     matched: list[tuple[str, str, Path]] = []
     content_lower = raw.content.lower()
@@ -69,7 +69,7 @@ def tier1_programmatic_match(
             if pattern.search(raw.content):
                 matched.append((name_key, uid_or_name, fpath))
 
-    return matched, []
+    return matched
 
 
 # ---------------------------------------------------------------------------
@@ -361,7 +361,6 @@ def tier3_write(
                 log.warning("Could not find existing page for uid %s", action.existing_uid)
                 continue
 
-            from athenaeum.models import parse_frontmatter, render_frontmatter
             text = existing_path.read_text(encoding="utf-8")
             meta, existing_body = parse_frontmatter(text)
 

--- a/tests/test_librarian.py
+++ b/tests/test_librarian.py
@@ -315,7 +315,7 @@ class TestRunIntegration:
         monkeypatch.setattr(
             anthropic_mod, "Anthropic", lambda **kwargs: failing_client,
         )
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake-for-test")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-fake-api-key-not-real")
 
         caplog.set_level(logging.DEBUG, logger="athenaeum")
 
@@ -357,4 +357,5 @@ class TestRunIntegration:
             "pre-processing snapshot was not taken"
         )
 
-        assert exit_code == 0
+        # run() returns 1 when any files failed (partial failure)
+        assert exit_code == 1

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -111,27 +111,27 @@ class TestTier1:
     def test_matches_known_entity(self, wiki_dir: Path) -> None:
         index = EntityIndex(wiki_dir)
         raw = _make_raw("Met with the team at Acme Corp about their product.")
-        matched, _ = tier1_programmatic_match(raw, index)
+        matched = tier1_programmatic_match(raw, index)
         names = [name for name, _, _ in matched]
         assert any("acme" in n for n in names)
 
     def test_matches_alias(self, wiki_dir: Path) -> None:
         index = EntityIndex(wiki_dir)
         raw = _make_raw("Got an email from Acme Corporation today.")
-        matched, _ = tier1_programmatic_match(raw, index)
+        matched = tier1_programmatic_match(raw, index)
         assert len(matched) > 0
 
     def test_no_match(self, wiki_dir: Path) -> None:
         index = EntityIndex(wiki_dir)
         raw = _make_raw("Nothing relevant here about any known entities.")
-        matched, _ = tier1_programmatic_match(raw, index)
+        matched = tier1_programmatic_match(raw, index)
         assert len(matched) == 0
 
     def test_word_boundary(self, wiki_dir: Path) -> None:
         index = EntityIndex(wiki_dir)
         # "acme" appears as substring in "pharmacme" -- should NOT match
         raw = _make_raw("The pharmacme product line is interesting.")
-        matched, _ = tier1_programmatic_match(raw, index)
+        matched = tier1_programmatic_match(raw, index)
         acme_matches = [n for n, _, _ in matched if "acme" in n]
         assert len(acme_matches) == 0
 
@@ -141,7 +141,7 @@ class TestTier1:
         # Register a short-name entity
         index._by_name["ai"] = ("short-uid", wiki_dir / "short.md")
         raw = _make_raw("AI is transforming the industry.")
-        matched, _ = tier1_programmatic_match(raw, index)
+        matched = tier1_programmatic_match(raw, index)
         ai_matches = [n for n, _, _ in matched if n == "ai"]
         assert len(ai_matches) == 0
 


### PR DESCRIPTION
## Summary

Addresses must-fix findings from three independent reviewer audits (#161, #162, #163):

- `--knowledge-root` now derives `--raw-root`/`--wiki-root` (was requiring all three flags)
- `init_knowledge_dir` exported from top-level package
- `load_schema_list` properly skips markdown table headers (was including "Tag" as a value)
- `run()` returns 1 on partial failure (was always returning 0)
- Removed dead code: `unmatched_content` return, inline import in tier3_write
- Renamed fake API key prefix to avoid automated scanner false positives
- Cleaned up stale worktree branches

## Secrets Audit Result

**CONDITIONAL GO** — zero secrets, credentials, or personal data in tracked source files. Advisory items (commit message internal repo refs) accepted as benign.

## Test plan

- [x] 84 tests pass
- [x] `ruff check` clean
- [x] `athenaeum run --dry-run --knowledge-root ~/knowledge` works
- [x] `athenaeum init --path /tmp/test` works
- [x] Stale worktree branches deleted

Closes Kromatic-Innovation/code-workspace-config#164
