### PR TITLE
fix(models): type safety, CRLF, index lookup, py.typed (#14,#15,#8,#16)

### DIFF
--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -6,6 +6,7 @@ import re
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 import yaml
 
@@ -26,7 +27,7 @@ def slugify(name: str) -> str:
 
 # --- Frontmatter parsing ---
 
-_FM_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_FM_RE = re.compile(r"^---\s*\r?\n(.*?)\r?\n---\s*\r?\n", re.DOTALL)
 
 
 def parse_frontmatter(text: str) -> tuple[dict, str]:
@@ -125,7 +126,7 @@ class ClassifiedEntity:
 @dataclass
 class EntityAction:
     """A create or update action for Tier 3."""
-    kind: str  # "create" | "update"
+    kind: Literal["create", "update"]
     name: str
     entity_type: str
     tags: list[str]
@@ -204,6 +205,7 @@ class EntityIndex:
         self.wiki_root = wiki_root
         self._by_name: dict[str, tuple[str, Path]] = {}
         self._entities: dict[str, dict] = {}
+        self._entity_format_paths: set[Path] = set()
         self._load()
 
     def _load(self) -> None:
@@ -227,6 +229,7 @@ class EntityIndex:
             self._by_name[key] = (uid or name, fpath)
             if uid:
                 self._entities[uid] = meta
+                self._entity_format_paths.add(fpath)
 
             for alias in meta.get("aliases", []):
                 if alias:
@@ -238,22 +241,19 @@ class EntityIndex:
 
     def has_entity_format(self, path: Path) -> bool:
         """Check if a wiki page uses the full entity template format (has uid field)."""
-        try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            return False
-        meta, _ = parse_frontmatter(text)
-        return bool(meta.get("uid"))
+        return path in self._entity_format_paths
 
     def register(self, entity: WikiEntity) -> None:
         """Add a newly created entity to the index."""
         key = entity.name.lower()
-        self._by_name[key] = (entity.uid, self.wiki_root / entity.filename)
+        path = self.wiki_root / entity.filename
+        self._by_name[key] = (entity.uid, path)
         self._entities[entity.uid] = {
             "uid": entity.uid,
             "type": entity.type,
             "name": entity.name,
         }
+        self._entity_format_paths.add(path)
         for alias in entity.aliases:
             if alias:
-                self._by_name[alias.lower()] = (entity.uid, self.wiki_root / entity.filename)
+                self._by_name[alias.lower()] = (entity.uid, path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from athenaeum.models import (
+    EntityAction,
     EntityIndex,
     WikiEntity,
     generate_uid,
@@ -114,6 +115,12 @@ class TestParseFrontmatter:
         assert meta["uid"] == "abc12345"
         assert meta["aliases"] == ["AC", "AcmeCo"]
         assert "# Acme Corp" in body
+
+    def test_crlf_frontmatter(self) -> None:
+        text = "---\r\nname: Test\r\ntype: person\r\n---\r\n\r\nBody content."
+        meta, body = parse_frontmatter(text)
+        assert meta == {"name": "Test", "type": "person"}
+        assert "Body content." in body
 
     def test_invalid_yaml(self) -> None:
         text = "---\n: bad: yaml: [unclosed\n---\n\nBody."
@@ -274,6 +281,12 @@ class TestEntityIndex:
         assert index.has_entity_format(entity_page) is True
         assert index.has_entity_format(old_page) is False
 
+    def test_has_entity_format_after_register(self, wiki_dir: Path) -> None:
+        index = EntityIndex(wiki_dir)
+        entity = WikiEntity(uid="reg12345", type="tool", name="New Tool")
+        index.register(entity)
+        assert index.has_entity_format(wiki_dir / entity.filename) is True
+
     def test_register(self, wiki_dir: Path) -> None:
         index = EntityIndex(wiki_dir)
         entity = WikiEntity(
@@ -321,3 +334,14 @@ class TestLoadSchemaList:
     def test_missing_file(self, tmp_path: Path) -> None:
         result = load_schema_list(tmp_path, "nonexistent.md")
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# EntityAction type annotation
+# ---------------------------------------------------------------------------
+
+
+class TestEntityAction:
+    def test_kind_literal_annotation(self) -> None:
+        annotation = EntityAction.__dataclass_fields__["kind"].type
+        assert "Literal" in annotation

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -13,3 +13,10 @@ def test_version_format():
     parts = __version__.split(".")
     assert len(parts) == 3
     assert all(p.isdigit() for p in parts)
+
+
+def test_py_typed_marker():
+    import importlib.resources
+
+    marker = importlib.resources.files("athenaeum") / "py.typed"
+    assert marker.is_file()


### PR DESCRIPTION
## Summary

- **#14**: `EntityAction.kind` → `Literal["create", "update"]` for type safety (silent typo bugs like `"Create"` now caught by type checkers)
- **#15**: Frontmatter regex `_FM_RE` updated to handle `\r\n` (CRLF/Windows) line endings
- **#8**: `has_entity_format()` now checks an in-memory set built during `_load()` instead of re-reading files from disk — eliminates redundant I/O
- **#16**: Added `py.typed` PEP 561 marker so downstream consumers get type information via mypy/pyright

## Test plan

- [x] 88 tests pass (4 new tests added)
- [x] `ruff check src/ tests/` clean
- [x] New test: CRLF frontmatter parsing
- [x] New test: `has_entity_format` after `register()`
- [x] New test: `EntityAction.kind` Literal annotation
- [x] New test: `py.typed` marker discoverable via `importlib.resources`

Parent epic: Kromatic-Innovation/code-workspace-config#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)
