### PR TITLE
fix(tests): deduplicate wiki_dir fixture + CI coverage (#13,#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
         run: ruff check src/ tests/
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short
+        run: pytest tests/ -v --tb=short --cov=athenaeum --cov-report=term-missing --cov-fail-under=75

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,65 @@
+"""Shared test fixtures for athenaeum test suite."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def wiki_dir(tmp_path: Path) -> Path:
+    """Create a minimal wiki directory with sample entity pages."""
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+
+    # Old-format page (no uid field)
+    (wiki / "feedback_keychain_auth.md").write_text(textwrap.dedent("""\
+        ---
+        name: Auth tokens must use system keychain
+        description: Never store auth tokens as plaintext env vars.
+        type: feedback
+        ---
+
+        Always use the system keychain for storing auth tokens.
+    """))
+
+    # Entity-template format page
+    (wiki / "a1b2c3d4-acme-corp.md").write_text(textwrap.dedent("""\
+        ---
+        uid: a1b2c3d4
+        type: company
+        name: Acme Corp
+        aliases:
+          - Acme
+          - Acme Corporation
+        access: confidential
+        tags:
+          - client
+          - fintech
+        created: '2024-03-15'
+        updated: '2024-04-06'
+        ---
+
+        # Acme Corp
+
+        Fintech startup, Series B.
+    """))
+
+    # Another old-format page
+    (wiki / "project_knowledge_architecture.md").write_text(textwrap.dedent("""\
+        ---
+        name: Knowledge architecture project
+        description: Unified knowledge system.
+        type: project
+        ---
+
+        The knowledge architecture unifies fragmented memory scopes.
+    """))
+
+    # Files that should be skipped by EntityIndex
+    (wiki / "_index.md").write_text("# Index\n")
+    (wiki / "MEMORY.md").write_text("# Memory Index\n")
+
+    return wiki

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,15 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure git identity is available for tests that run git commit."""
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test Runner")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test Runner")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+
+
 @pytest.fixture
 def wiki_dir(tmp_path: Path) -> Path:
     """Create a minimal wiki directory with sample entity pages."""

--- a/tests/test_librarian.py
+++ b/tests/test_librarian.py
@@ -4,7 +4,6 @@ process_one, and the run() pipeline with mocked LLM."""
 from __future__ import annotations
 
 import subprocess
-import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -15,59 +14,6 @@ from athenaeum.models import RawFile
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def wiki_dir(tmp_path: Path) -> Path:
-    """Create a minimal wiki directory with sample entity pages."""
-    wiki = tmp_path / "wiki"
-    wiki.mkdir()
-
-    (wiki / "feedback_keychain_auth.md").write_text(textwrap.dedent("""\
-        ---
-        name: Auth tokens must use system keychain
-        description: Never store auth tokens as plaintext env vars.
-        type: feedback
-        ---
-
-        Always use the system keychain for storing auth tokens.
-    """))
-
-    (wiki / "a1b2c3d4-acme-corp.md").write_text(textwrap.dedent("""\
-        ---
-        uid: a1b2c3d4
-        type: company
-        name: Acme Corp
-        aliases:
-          - Acme
-          - Acme Corporation
-        access: confidential
-        tags:
-          - client
-          - fintech
-        created: '2024-03-15'
-        updated: '2024-04-06'
-        ---
-
-        # Acme Corp
-
-        Fintech startup, Series B.
-    """))
-
-    (wiki / "project_knowledge_architecture.md").write_text(textwrap.dedent("""\
-        ---
-        name: Knowledge architecture project
-        description: Unified knowledge system.
-        type: project
-        ---
-
-        The knowledge architecture unifies fragmented memory scopes.
-    """))
-
-    (wiki / "_index.md").write_text("# Index\n")
-    (wiki / "MEMORY.md").write_text("# Memory Index\n")
-
-    return wiki
 
 
 @pytest.fixture

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,63 +23,6 @@ from athenaeum.models import (
 
 
 @pytest.fixture
-def wiki_dir(tmp_path: Path) -> Path:
-    """Create a minimal wiki directory with sample entity pages."""
-    wiki = tmp_path / "wiki"
-    wiki.mkdir()
-
-    # Old-format page (no uid field)
-    (wiki / "feedback_keychain_auth.md").write_text(textwrap.dedent("""\
-        ---
-        name: Auth tokens must use system keychain
-        description: Never store auth tokens as plaintext env vars.
-        type: feedback
-        ---
-
-        Always use the system keychain for storing auth tokens.
-    """))
-
-    # Entity-template format page
-    (wiki / "a1b2c3d4-acme-corp.md").write_text(textwrap.dedent("""\
-        ---
-        uid: a1b2c3d4
-        type: company
-        name: Acme Corp
-        aliases:
-          - Acme
-          - Acme Corporation
-        access: confidential
-        tags:
-          - client
-          - fintech
-        created: '2024-03-15'
-        updated: '2024-04-06'
-        ---
-
-        # Acme Corp
-
-        Fintech startup, Series B.
-    """))
-
-    # Another old-format page
-    (wiki / "project_knowledge_architecture.md").write_text(textwrap.dedent("""\
-        ---
-        name: Knowledge architecture project
-        description: Unified knowledge system.
-        type: project
-        ---
-
-        The knowledge architecture unifies fragmented memory scopes.
-    """))
-
-    # Files that should be skipped by EntityIndex
-    (wiki / "_index.md").write_text("# Index\n")
-    (wiki / "MEMORY.md").write_text("# Memory Index\n")
-
-    return wiki
-
-
-@pytest.fixture
 def schema_dir(tmp_path: Path) -> Path:
     """Create a minimal _schema directory with markdown tables."""
     schema = tmp_path / "_schema"

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -4,7 +4,6 @@ tier3 create/merge/write (mocked LLM), tier4 escalation."""
 from __future__ import annotations
 
 import json
-import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -27,59 +26,6 @@ from athenaeum.tiers import (
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def wiki_dir(tmp_path: Path) -> Path:
-    """Create a minimal wiki directory with sample entity pages."""
-    wiki = tmp_path / "wiki"
-    wiki.mkdir()
-
-    (wiki / "feedback_keychain_auth.md").write_text(textwrap.dedent("""\
-        ---
-        name: Auth tokens must use system keychain
-        description: Never store auth tokens as plaintext env vars.
-        type: feedback
-        ---
-
-        Always use the system keychain for storing auth tokens.
-    """))
-
-    (wiki / "a1b2c3d4-acme-corp.md").write_text(textwrap.dedent("""\
-        ---
-        uid: a1b2c3d4
-        type: company
-        name: Acme Corp
-        aliases:
-          - Acme
-          - Acme Corporation
-        access: confidential
-        tags:
-          - client
-          - fintech
-        created: '2024-03-15'
-        updated: '2024-04-06'
-        ---
-
-        # Acme Corp
-
-        Fintech startup, Series B.
-    """))
-
-    (wiki / "project_knowledge_architecture.md").write_text(textwrap.dedent("""\
-        ---
-        name: Knowledge architecture project
-        description: Unified knowledge system.
-        type: project
-        ---
-
-        The knowledge architecture unifies fragmented memory scopes.
-    """))
-
-    (wiki / "_index.md").write_text("# Index\n")
-    (wiki / "MEMORY.md").write_text("# Memory Index\n")
-
-    return wiki
 
 
 def _make_raw(content: str) -> RawFile:


### PR DESCRIPTION
## Summary

- **#13**: Moved shared `wiki_dir` fixture from 3 test files to `tests/conftest.py`, removing ~160 lines of duplication
- **#18**: Added `--cov=athenaeum --cov-report=term-missing --cov-fail-under=75` to CI pytest command for coverage enforcement

## Test plan

- [x] 84 tests pass (no new tests — this is test infrastructure)
- [x] `ruff check src/ tests/` clean
- [x] Verified `wiki_dir` fixture auto-discovered from conftest.py
- [x] Removed unused `textwrap` imports from test_tiers.py and test_librarian.py

Parent epic: Kromatic-Innovation/code-workspace-config#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)
