### PR TITLE
fix(core): transactional writes, client typing, UID lookup (#7,#11,#12)

### DIFF
--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -166,7 +166,7 @@ def process_one(
     raw: RawFile,
     index: EntityIndex,
     wiki_root: Path,
-    client: anthropic.Anthropic,
+    client: anthropic.Anthropic | None,
     valid_types: list[str],
     valid_tags: list[str],
     valid_access: list[str],
@@ -230,7 +230,10 @@ def process_one(
         return result
 
     # --- Tier 3: Content writing ---
-    new_entities, escalations = tier3_write(raw, actions, index, wiki_root, client)
+    assert client is not None, "client required for non-dry-run"
+    new_entities, updated_uids, escalations = tier3_write(
+        raw, actions, index, wiki_root, client,
+    )
 
     for entity in new_entities:
         page_path = wiki_root / entity.filename
@@ -239,6 +242,7 @@ def process_one(
         result.created.append(entity)
         log.info("  Created: %s → %s", entity.name, entity.filename)
 
+    result.updated.extend(updated_uids)
     result.escalated.extend(escalations)
 
     # --- Tier 4: Escalation ---
@@ -297,7 +301,9 @@ def run(
     index = EntityIndex(wiki_root)
     log.info("Loaded %d wiki entries into index", len(index._by_name))
 
-    client = anthropic.Anthropic(api_key=api_key) if api_key else None  # type: ignore[arg-type]
+    client: anthropic.Anthropic | None = (
+        anthropic.Anthropic(api_key=api_key) if api_key else None
+    )
 
     if not dry_run:
         git_snapshot(knowledge_root, "librarian: pre-processing snapshot")
@@ -321,17 +327,12 @@ def run(
             failed_files.append(raw.ref)
             continue
 
-        if result.error:
-            log.error("Error processing %s: %s", raw.ref, result.error)
-            failed_files.append(raw.ref)
-            continue
-
         total_created += len(result.created)
         total_updated += len(result.updated)
         total_escalated += len(result.escalated)
         total_skipped += len(result.skipped)
 
-        if not dry_run and not result.error:
+        if not dry_run:
             raw.path.unlink()
             log.info("  Deleted: %s", raw.path)
 

--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -149,10 +149,9 @@ class ProcessingResult:
     """Result of processing one raw file."""
     raw_file: RawFile
     created: list[WikiEntity] = field(default_factory=list)
-    updated: list[str] = field(default_factory=list)  # UIDs of updated entities
+    updated: list[str] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)
     escalated: list[EscalationItem] = field(default_factory=list)
-    error: str | None = None
 
 
 # --- Schema loading ---
@@ -205,6 +204,7 @@ class EntityIndex:
         self.wiki_root = wiki_root
         self._by_name: dict[str, tuple[str, Path]] = {}
         self._entities: dict[str, dict] = {}
+        self._by_uid: dict[str, Path] = {}
         self._entity_format_paths: set[Path] = set()
         self._load()
 
@@ -229,6 +229,7 @@ class EntityIndex:
             self._by_name[key] = (uid or name, fpath)
             if uid:
                 self._entities[uid] = meta
+                self._by_uid[uid] = fpath
                 self._entity_format_paths.add(fpath)
 
             for alias in meta.get("aliases", []):
@@ -238,6 +239,10 @@ class EntityIndex:
     def lookup(self, name: str) -> tuple[str, Path] | None:
         """Look up by name or alias (case-insensitive). Returns (uid_or_name, path) or None."""
         return self._by_name.get(name.lower())
+
+    def get_by_uid(self, uid: str) -> Path | None:
+        """Look up entity file path by UID. Returns None if not found."""
+        return self._by_uid.get(uid)
 
     def has_entity_format(self, path: Path) -> bool:
         """Check if a wiki page uses the full entity template format (has uid field)."""
@@ -253,6 +258,7 @@ class EntityIndex:
             "type": entity.type,
             "name": entity.name,
         }
+        self._by_uid[entity.uid] = path
         self._entity_format_paths.add(path)
         for alias in entity.aliases:
             if alias:

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -338,12 +338,17 @@ def tier3_write(
     index: EntityIndex,
     wiki_root: Path,
     client: anthropic.Anthropic,
-) -> tuple[list[WikiEntity], list[EscalationItem]]:
+) -> tuple[list[WikiEntity], list[str], list[EscalationItem]]:
     """Process all entity actions for a raw file through the capable LLM.
 
-    Returns (new_entities, escalation_items).
+    All LLM calls are made first; disk writes are deferred until all
+    actions succeed, preventing partial writes on mid-processing failure.
+
+    Returns (new_entities, updated_uids, escalation_items).
     """
     new_entities: list[WikiEntity] = []
+    pending_updates: list[tuple[Path, str]] = []
+    updated_uids: list[str] = []
     escalations: list[EscalationItem] = []
 
     for action in actions:
@@ -351,13 +356,9 @@ def tier3_write(
             new_entities.append(tier3_create(action, raw.ref, client))
 
         elif action.kind == "update" and action.existing_uid:
-            existing_path = None
-            for p in wiki_root.glob("*.md"):
-                if p.name.startswith(action.existing_uid):
-                    existing_path = p
-                    break
+            existing_path = index.get_by_uid(action.existing_uid)
 
-            if not existing_path:
+            if not existing_path or not existing_path.exists():
                 log.warning("Could not find existing page for uid %s", action.existing_uid)
                 continue
 
@@ -369,12 +370,17 @@ def tier3_write(
                 escalations.append(esc)
             if updated_body:
                 meta["updated"] = date.today().isoformat()
-                existing_path.write_text(
+                pending_updates.append((
+                    existing_path,
                     render_frontmatter(meta) + "\n" + updated_body,
-                    encoding="utf-8",
-                )
+                ))
+                updated_uids.append(action.existing_uid)
 
-    return new_entities, escalations
+    # All LLM calls succeeded — apply updates atomically
+    for path, content in pending_updates:
+        path.write_text(content, encoding="utf-8")
+
+    return new_entities, updated_uids, escalations
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -281,6 +281,24 @@ class TestEntityIndex:
         assert index.has_entity_format(entity_page) is True
         assert index.has_entity_format(old_page) is False
 
+    def test_get_by_uid(self, wiki_dir: Path) -> None:
+        index = EntityIndex(wiki_dir)
+        path = index.get_by_uid("a1b2c3d4")
+        assert path is not None
+        assert path.name == "a1b2c3d4-acme-corp.md"
+
+    def test_get_by_uid_missing(self, wiki_dir: Path) -> None:
+        index = EntityIndex(wiki_dir)
+        assert index.get_by_uid("nonexistent") is None
+
+    def test_get_by_uid_after_register(self, wiki_dir: Path) -> None:
+        index = EntityIndex(wiki_dir)
+        entity = WikiEntity(uid="newuid01", type="tool", name="New Tool")
+        index.register(entity)
+        path = index.get_by_uid("newuid01")
+        assert path is not None
+        assert path.name == entity.filename
+
     def test_has_entity_format_after_register(self, wiki_dir: Path) -> None:
         index = EntityIndex(wiki_dir)
         entity = WikiEntity(uid="reg12345", type="tool", name="New Tool")

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -512,10 +512,13 @@ class TestTier3Write:
         client = MagicMock()
         client.messages.create.side_effect = [create_response, merge_response]
 
-        new_entities, escalations = tier3_write(raw, actions, index, wiki_dir, client)
+        new_entities, updated_uids, escalations = tier3_write(
+            raw, actions, index, wiki_dir, client,
+        )
 
         assert len(new_entities) == 1
         assert new_entities[0].name == "Alice Zhang"
+        assert updated_uids == ["a1b2c3d4"]
         assert len(escalations) == 0
         # Verify the update was written to the existing file
         acme_content = (wiki_dir / "a1b2c3d4-acme-corp.md").read_text()
@@ -548,6 +551,77 @@ class TestTier3Write:
 
         with pytest.raises(anthropic_mod.APIError):
             tier3_write(raw, actions, index, wiki_dir, client)
+
+    def test_no_disk_write_on_partial_failure(self, wiki_dir: Path) -> None:
+        """If the second action fails, the first action's update must not be written."""
+        import anthropic as anthropic_mod
+
+        raw = _make_raw("Info about Acme and a new person.")
+        index = EntityIndex(wiki_dir)
+
+        actions = [
+            EntityAction(
+                kind="update",
+                name="Acme Corp",
+                entity_type="company",
+                tags=[],
+                access="",
+                existing_uid="a1b2c3d4",
+                observations="Should NOT be written.",
+            ),
+            EntityAction(
+                kind="create",
+                name="Crash Entity",
+                entity_type="person",
+                tags=[],
+                access="internal",
+                existing_uid=None,
+                observations="text",
+            ),
+        ]
+
+        # First call (merge) succeeds, second call (create) fails
+        merge_response = MagicMock()
+        merge_response.content = [MagicMock(text="# Acme Corp\n\nSHOULD NOT APPEAR")]
+        client = MagicMock()
+        client.messages.create.side_effect = [
+            merge_response,
+            anthropic_mod.APIError(message="Crash", request=MagicMock(), body=None),
+        ]
+
+        acme_before = (wiki_dir / "a1b2c3d4-acme-corp.md").read_text()
+
+        with pytest.raises(anthropic_mod.APIError):
+            tier3_write(raw, actions, index, wiki_dir, client)
+
+        acme_after = (wiki_dir / "a1b2c3d4-acme-corp.md").read_text()
+        assert acme_after == acme_before, "update was written despite subsequent failure"
+
+    def test_uid_lookup_instead_of_glob(self, wiki_dir: Path) -> None:
+        """tier3_write uses EntityIndex UID lookup, not filesystem glob."""
+        raw = _make_raw("Update info about Acme.")
+        index = EntityIndex(wiki_dir)
+
+        actions = [
+            EntityAction(
+                kind="update",
+                name="Acme Corp",
+                entity_type="company",
+                tags=[],
+                access="",
+                existing_uid="a1b2c3d4",
+                observations="New info.",
+            ),
+        ]
+
+        client = _mock_client("# Acme Corp\n\nUpdated content.")
+        new_entities, updated_uids, escalations = tier3_write(
+            raw, actions, index, wiki_dir, client,
+        )
+
+        assert updated_uids == ["a1b2c3d4"]
+        acme_content = (wiki_dir / "a1b2c3d4-acme-corp.md").read_text()
+        assert "Updated content" in acme_content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#7**: `tier3_write` is now transactional — all LLM calls complete before any disk writes. On partial failure, no entity files are left half-written. Removed dead `ProcessingResult.error` field; `result.updated` now populated with UIDs.
- **#11**: `process_one` client parameter typed as `Anthropic | None` with proper guard. Removed `# type: ignore` from `run()`.
- **#12**: Added `EntityIndex.get_by_uid()` for O(1) UID lookup. `tier3_write` uses index instead of glob scan.

## Test plan

- [x] 93 tests pass (5 new tests added)
- [x] `ruff check src/ tests/` clean
- [x] New test: partial failure does not write updates to disk
- [x] New test: UID lookup via index instead of glob
- [x] New test: `get_by_uid` returns path for known UIDs
- [x] New test: `get_by_uid` returns None for unknown UIDs
- [x] New test: `get_by_uid` works after `register()`

Parent epic: Kromatic-Innovation/code-workspace-config#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)
