### PR TITLE
feat: token tracking, schema integration, status command, README (#9, #17, #19, #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,79 @@ athenaeum init
 athenaeum init --path ~/my-knowledge
 ```
 
+## Usage
+
+### Running the pipeline
+
+```bash
+# Run the librarian pipeline (processes raw files into wiki entities)
+athenaeum run
+
+# Dry run — inspect what would happen without writing files
+athenaeum run --dry-run
+
+# Custom paths and limits
+athenaeum run \
+  --raw-root ~/knowledge/raw \
+  --wiki-root ~/knowledge/wiki \
+  --knowledge-root ~/knowledge \
+  --max-files 50 \
+  --max-api-calls 200 \
+  --verbose
+```
+
+### Checking status
+
+```bash
+# Show knowledge base status (entity counts, pending files, last run)
+athenaeum status
+athenaeum status --path ~/my-knowledge
+```
+
+### Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ANTHROPIC_API_KEY` | Yes (unless `--dry-run`) | API key for Tier 2/3 LLM calls |
+| `ATHENAEUM_CLASSIFY_MODEL` | No | Override Tier 2 model (default: `claude-haiku-4-5-20251001`) |
+| `ATHENAEUM_WRITE_MODEL` | No | Override Tier 3 model (default: `claude-sonnet-4-6`) |
+
+### Raw file format
+
+Raw intake files live in `raw/{source}/*.md` and follow the naming convention:
+
+```
+{timestamp}-{uuid8}.md
+```
+
+Example: `20240406T120000Z-aabb0011.md`
+
+Each file is a plain markdown document containing observations, notes, or session
+transcripts. The `{source}` directory name (e.g., `sessions`, `imports`) identifies
+the origin of the data.
+
+### Output
+
+The pipeline produces wiki entity pages in `wiki/` with YAML frontmatter:
+
+```yaml
+---
+uid: a1b2c3d4
+type: person
+name: Alice Zhang
+aliases: [Alice]
+access: internal
+tags: [active]
+created: '2024-04-06'
+updated: '2024-04-06'
+---
+```
+
+Entity pages are indexed in `wiki/_index.md`, grouped by type.
+Conflicts requiring human review are appended to `wiki/_pending_questions.md`.
+
+At the end of each run, token usage and estimated costs are logged.
+
 ## Development
 
 ```bash

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -23,6 +23,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Target directory (default: ~/knowledge)",
     )
 
+    # status command
+    status_parser = subparsers.add_parser("status", help="Show knowledge base status")
+    status_parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path("~/knowledge"),
+        help="Knowledge directory (default: ~/knowledge)",
+    )
+
     # run command — execute the librarian pipeline
     run_parser = subparsers.add_parser("run", help="Run the librarian pipeline")
     run_parser.add_argument(
@@ -63,6 +72,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "init":
         return _cmd_init(args)
 
+    if args.command == "status":
+        return _cmd_status(args)
+
     if args.command == "run":
         return _cmd_run(args)
 
@@ -74,6 +86,18 @@ def _cmd_init(args: argparse.Namespace) -> int:
 
     target = init_knowledge_dir(args.path)
     print(f"Initialized knowledge directory at {target}")
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    from athenaeum.status import format_status, status
+
+    target = args.path.expanduser().resolve()
+    if not target.exists():
+        print(f"Knowledge directory not found: {target}")
+        return 1
+    info = status(target)
+    print(format_status(info))
     return 0
 
 

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -32,6 +32,7 @@ from athenaeum.models import (
     EntityIndex,
     ProcessingResult,
     RawFile,
+    TokenUsage,
     load_schema_list,
     parse_frontmatter,
 )
@@ -171,6 +172,7 @@ def process_one(
     valid_tags: list[str],
     valid_access: list[str],
     dry_run: bool = False,
+    usage: TokenUsage | None = None,
 ) -> ProcessingResult:
     """Process a single raw file through all tiers."""
     result = ProcessingResult(raw_file=raw)
@@ -197,6 +199,7 @@ def process_one(
     # --- Tier 2: Classification ---
     classified = tier2_classify(
         raw, matched_names, valid_types, valid_tags, valid_access, client,
+        wiki_root=wiki_root, usage=usage,
     )
     log.info("  T2 classified %d new entities", len(classified))
 
@@ -232,7 +235,7 @@ def process_one(
     # --- Tier 3: Content writing ---
     assert client is not None, "client required for non-dry-run"
     new_entities, updated_uids, escalations = tier3_write(
-        raw, actions, index, wiki_root, client,
+        raw, actions, index, wiki_root, client, usage=usage,
     )
 
     for entity in new_entities:
@@ -309,18 +312,18 @@ def run(
     if not dry_run:
         git_snapshot(knowledge_root, "librarian: pre-processing snapshot")
 
+    usage = TokenUsage()
     total_created = 0
     total_updated = 0
     total_escalated = 0
     total_skipped = 0
-    total_api_calls = 0
     failed_files: list[str] = []
 
     for raw in raw_files:
-        if not dry_run and total_api_calls >= max_api_calls:
+        if not dry_run and usage.api_calls >= max_api_calls:
             log.warning(
                 "API call budget exhausted (%d/%d) — stopping early",
-                total_api_calls, max_api_calls,
+                usage.api_calls, max_api_calls,
             )
             break
 
@@ -330,15 +333,12 @@ def run(
                 raw, index, wiki_root, client,
                 valid_types, valid_tags, valid_access,
                 dry_run=dry_run,
+                usage=usage,
             )
         except Exception:
             log.exception("Failed to process %s", raw.ref)
             failed_files.append(raw.ref)
             continue
-
-        # Estimate API calls: 1 for classify + 1 per created + 1 per updated
-        calls_this_file = 1 + len(result.created) + len(result.updated) if not dry_run else 0
-        total_api_calls += calls_this_file
 
         total_created += len(result.created)
         total_updated += len(result.updated)
@@ -350,10 +350,17 @@ def run(
             log.info("  Deleted: %s", raw.path)
 
     log.info(
-        "Done: %d created, %d updated, %d escalated, %d skipped, %d failed, ~%d API calls",
+        "Done: %d created, %d updated, %d escalated, %d skipped, %d failed",
         total_created, total_updated, total_escalated, total_skipped,
-        len(failed_files), total_api_calls,
+        len(failed_files),
     )
+    if usage.api_calls > 0:
+        log.info(
+            "Token usage: %d API calls, %d input + %d output = %d total"
+            " (~$%.4f estimated)",
+            usage.api_calls, usage.input_tokens, usage.output_tokens,
+            usage.total_tokens, usage.estimated_cost_usd,
+        )
 
     if not dry_run and (total_created > 0 or total_updated > 0):
         rebuild_index(wiki_root)

--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -145,6 +145,35 @@ class EscalationItem:
 
 
 @dataclass
+class TokenUsage:
+    """Accumulated API token usage for a pipeline run."""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    api_calls: int = 0
+
+    def add(self, input_tokens: int, output_tokens: int) -> None:
+        """Record tokens from one API call."""
+        self.input_tokens += input_tokens
+        self.output_tokens += output_tokens
+        self.api_calls += 1
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+    @property
+    def estimated_cost_usd(self) -> float:
+        """Estimate cost using Haiku/Sonnet blended rates.
+
+        Uses a conservative blended rate: $1.50/M input, $7.50/M output.
+        """
+        return (
+            self.input_tokens * 1.50 / 1_000_000
+            + self.output_tokens * 7.50 / 1_000_000
+        )
+
+
+@dataclass
 class ProcessingResult:
     """Result of processing one raw file."""
     raw_file: RawFile

--- a/src/athenaeum/status.py
+++ b/src/athenaeum/status.py
@@ -1,0 +1,94 @@
+"""Athenaeum status — inspect current state of a knowledge base."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from athenaeum.librarian import discover_raw_files
+from athenaeum.models import parse_frontmatter
+
+
+def status(knowledge_root: Path) -> dict:
+    """Gather status information about a knowledge base.
+
+    Returns a dict with:
+      raw_pending, entity_count, entities_by_type,
+      last_commit_date, last_commit_message, pending_questions
+    """
+    wiki_root = knowledge_root / "wiki"
+    raw_root = knowledge_root / "raw"
+
+    # Raw files pending
+    raw_files = discover_raw_files(raw_root)
+    raw_pending = len(raw_files)
+
+    # Entity counts
+    entities_by_type: dict[str, int] = {}
+    entity_count = 0
+    if wiki_root.exists():
+        for fpath in sorted(wiki_root.glob("*.md")):
+            if fpath.name.startswith("_"):
+                continue
+            try:
+                text = fpath.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            meta, _ = parse_frontmatter(text)
+            if not meta or not meta.get("name"):
+                continue
+            entity_count += 1
+            etype = meta.get("type", "unknown")
+            entities_by_type[etype] = entities_by_type.get(etype, 0) + 1
+
+    # Last git commit
+    last_commit_date = ""
+    last_commit_message = ""
+    if (knowledge_root / ".git").exists():
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%ai|||%s"],
+            cwd=str(knowledge_root),
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            parts = result.stdout.strip().split("|||", 1)
+            last_commit_date = parts[0].strip()
+            last_commit_message = parts[1].strip() if len(parts) > 1 else ""
+
+    # Pending questions
+    pending_questions = 0
+    pq_path = wiki_root / "_pending_questions.md"
+    if pq_path.exists():
+        text = pq_path.read_text(encoding="utf-8")
+        pending_questions = text.count("## [")
+
+    return {
+        "raw_pending": raw_pending,
+        "entity_count": entity_count,
+        "entities_by_type": entities_by_type,
+        "last_commit_date": last_commit_date,
+        "last_commit_message": last_commit_message,
+        "pending_questions": pending_questions,
+    }
+
+
+def format_status(info: dict) -> str:
+    """Format status dict as human-readable output."""
+    lines = ["Athenaeum Status", "=" * 40]
+
+    lines.append(f"Raw files pending:    {info['raw_pending']}")
+    lines.append(f"Wiki entities:        {info['entity_count']}")
+
+    if info["entities_by_type"]:
+        for etype in sorted(info["entities_by_type"]):
+            lines.append(f"  {etype}: {info['entities_by_type'][etype]}")
+
+    lines.append(f"Pending questions:    {info['pending_questions']}")
+
+    if info["last_commit_date"]:
+        lines.append(f"Last commit:          {info['last_commit_date']}")
+        lines.append(f"  {info['last_commit_message']}")
+    else:
+        lines.append("Last commit:          (no git history)")
+
+    return "\n".join(lines)

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -23,6 +23,7 @@ from athenaeum.models import (
     EntityIndex,
     EscalationItem,
     RawFile,
+    TokenUsage,
     WikiEntity,
     generate_uid,
     parse_frontmatter,
@@ -42,6 +43,28 @@ def _get_classify_model() -> str:
 
 def _get_write_model() -> str:
     return os.environ.get("ATHENAEUM_WRITE_MODEL", DEFAULT_WRITE_MODEL)
+
+
+def _record_usage(
+    response: anthropic.types.Message, usage: TokenUsage | None,
+) -> None:
+    """Record token usage from an API response if tracking is enabled."""
+    if usage is not None and hasattr(response, "usage"):
+        usage.add(
+            response.usage.input_tokens,
+            response.usage.output_tokens,
+        )
+
+
+def _load_schema_text(wiki_root: Path, filename: str) -> str:
+    """Load a bundled schema file's content, returning '' if not found."""
+    path = wiki_root / "_schema" / filename
+    if path.exists():
+        try:
+            return path.read_text(encoding="utf-8")
+        except OSError:
+            pass
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +138,7 @@ CLASSIFY_USER_TEMPLATE = """## Raw observation
 
 ## Valid access levels
 {valid_access}
-
+{observation_filter_section}
 ## Instructions
 Extract entities from the raw observation. Return a JSON array of objects:
 ```json
@@ -141,6 +164,8 @@ def tier2_classify(
     valid_tags: list[str],
     valid_access: list[str],
     client: anthropic.Anthropic,
+    wiki_root: Path | None = None,
+    usage: TokenUsage | None = None,
 ) -> list[ClassifiedEntity]:
     """Use a fast LLM to classify entities in the raw text.
 
@@ -149,12 +174,22 @@ def tier2_classify(
     if not raw.content.strip():
         return []
 
+    obs_filter = ""
+    if wiki_root:
+        obs_text = _load_schema_text(wiki_root, "observation-filter.md")
+        if obs_text:
+            obs_filter = (
+                "\n## Observation filter (what to capture)\n"
+                f"{obs_text}\n"
+            )
+
     user_msg = CLASSIFY_USER_TEMPLATE.format(
         content=raw.content[:4000],
         matched_names=", ".join(matched_names) if matched_names else "(none)",
         valid_types=", ".join(valid_types),
         valid_tags=", ".join(valid_tags),
         valid_access=", ".join(valid_access),
+        observation_filter_section=obs_filter,
     )
 
     response = client.messages.create(
@@ -163,6 +198,7 @@ def tier2_classify(
         system=CLASSIFY_SYSTEM,
         messages=[{"role": "user", "content": user_msg}],
     )
+    _record_usage(response, usage)
 
     text = response.content[0].text.strip()
 
@@ -228,7 +264,7 @@ Access: {access}
 <user_document>
 {observations}
 </user_document>
-
+{entity_template_section}
 ## Instructions
 Write the body content (no frontmatter) for this entity's wiki page.
 Use footnotes citing the source as: [^1]: {source_ref}
@@ -269,8 +305,19 @@ def tier3_create(
     action: EntityAction,
     source_ref: str,
     client: anthropic.Anthropic,
+    wiki_root: Path | None = None,
+    usage: TokenUsage | None = None,
 ) -> WikiEntity:
     """Use a capable LLM to create a new entity page."""
+    tmpl_section = ""
+    if wiki_root:
+        tmpl_text = _load_schema_text(wiki_root, "_entity-template.md")
+        if tmpl_text:
+            tmpl_section = (
+                "\n## Entity template (follow this structure)\n"
+                f"{tmpl_text}\n"
+            )
+
     user_msg = CREATE_TEMPLATE.format(
         name=action.name,
         entity_type=action.entity_type,
@@ -278,6 +325,7 @@ def tier3_create(
         access=action.access,
         source_ref=source_ref,
         observations=action.observations[:3000],
+        entity_template_section=tmpl_section,
     )
 
     response = client.messages.create(
@@ -286,6 +334,7 @@ def tier3_create(
         system=CREATE_SYSTEM,
         messages=[{"role": "user", "content": user_msg}],
     )
+    _record_usage(response, usage)
 
     body = response.content[0].text.strip()
     today = date.today().isoformat()
@@ -308,6 +357,7 @@ def tier3_merge(
     existing_body: str,
     source_ref: str,
     client: anthropic.Anthropic,
+    usage: TokenUsage | None = None,
 ) -> tuple[str | None, EscalationItem | None]:
     """Use a capable LLM to merge observations into an existing entity page.
 
@@ -325,6 +375,7 @@ def tier3_merge(
         system=MERGE_SYSTEM,
         messages=[{"role": "user", "content": user_msg}],
     )
+    _record_usage(response, usage)
 
     text = response.content[0].text.strip()
     escalation = None
@@ -352,6 +403,7 @@ def tier3_write(
     index: EntityIndex,
     wiki_root: Path,
     client: anthropic.Anthropic,
+    usage: TokenUsage | None = None,
 ) -> tuple[list[WikiEntity], list[str], list[EscalationItem]]:
     """Process all entity actions for a raw file through the capable LLM.
 
@@ -367,7 +419,12 @@ def tier3_write(
 
     for action in actions:
         if action.kind == "create":
-            new_entities.append(tier3_create(action, raw.ref, client))
+            new_entities.append(
+                tier3_create(
+                    action, raw.ref, client,
+                    wiki_root=wiki_root, usage=usage,
+                )
+            )
 
         elif action.kind == "update" and action.existing_uid:
             existing_path = index.get_by_uid(action.existing_uid)
@@ -379,7 +436,9 @@ def tier3_write(
             text = existing_path.read_text(encoding="utf-8")
             meta, existing_body = parse_frontmatter(text)
 
-            updated_body, esc = tier3_merge(action, existing_body, raw.ref, client)
+            updated_body, esc = tier3_merge(
+                action, existing_body, raw.ref, client, usage=usage,
+            )
             if esc:
                 escalations.append(esc)
             if updated_body:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -359,6 +359,35 @@ class TestLoadSchemaList:
 # ---------------------------------------------------------------------------
 
 
+class TestTokenUsage:
+    def test_add_accumulates(self) -> None:
+        from athenaeum.models import TokenUsage
+
+        usage = TokenUsage()
+        usage.add(100, 50)
+        usage.add(200, 75)
+        assert usage.input_tokens == 300
+        assert usage.output_tokens == 125
+        assert usage.api_calls == 2
+        assert usage.total_tokens == 425
+
+    def test_estimated_cost(self) -> None:
+        from athenaeum.models import TokenUsage
+
+        usage = TokenUsage()
+        usage.add(1_000_000, 1_000_000)
+        # $1.50/M input + $7.50/M output = $9.00
+        assert abs(usage.estimated_cost_usd - 9.0) < 0.01
+
+    def test_empty_usage(self) -> None:
+        from athenaeum.models import TokenUsage
+
+        usage = TokenUsage()
+        assert usage.api_calls == 0
+        assert usage.total_tokens == 0
+        assert usage.estimated_cost_usd == 0.0
+
+
 class TestEntityAction:
     def test_kind_literal_annotation(self) -> None:
         annotation = EntityAction.__dataclass_fields__["kind"].type

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,110 @@
+"""Tests for athenaeum status command."""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+from athenaeum.status import format_status, status
+
+
+class TestStatus:
+    def _seed_knowledge(self, tmp_path: Path) -> Path:
+        """Create a minimal knowledge directory for status tests."""
+        root = tmp_path / "knowledge"
+        wiki = root / "wiki"
+        (wiki / "_schema").mkdir(parents=True)
+        raw = root / "raw" / "sessions"
+        raw.mkdir(parents=True)
+
+        # Entity page
+        (wiki / "a1b2c3d4-acme-corp.md").write_text(textwrap.dedent("""\
+            ---
+            uid: a1b2c3d4
+            type: company
+            name: Acme Corp
+            access: internal
+            ---
+
+            # Acme Corp
+        """))
+
+        (wiki / "b2c3d4e5-alice.md").write_text(textwrap.dedent("""\
+            ---
+            uid: b2c3d4e5
+            type: person
+            name: Alice Zhang
+            access: internal
+            ---
+
+            # Alice Zhang
+        """))
+
+        # Pending questions
+        (wiki / "_pending_questions.md").write_text(
+            "# Pending Questions\n\n"
+            "## [2024-04-06] Entity: \"Acme\" (from ref)\n\nConflict.\n\n"
+            "---\n\n"
+            "## [2024-04-07] Entity: \"Bob\" (from ref2)\n\nAnother.\n"
+        )
+
+        # Raw file pending
+        (raw / "20240410T120000Z-aabbccdd.md").write_text("Some raw.\n")
+
+        # Init git
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "seed"],
+            cwd=root, check=True,
+        )
+
+        return root
+
+    def test_status_counts(self, tmp_path: Path) -> None:
+        root = self._seed_knowledge(tmp_path)
+        info = status(root)
+        assert info["raw_pending"] == 1
+        assert info["entity_count"] == 2
+        assert info["entities_by_type"]["company"] == 1
+        assert info["entities_by_type"]["person"] == 1
+        assert info["pending_questions"] == 2
+        assert info["last_commit_date"] != ""
+
+    def test_status_empty_knowledge(self, tmp_path: Path) -> None:
+        root = tmp_path / "knowledge"
+        (root / "wiki").mkdir(parents=True)
+        (root / "raw").mkdir(parents=True)
+        info = status(root)
+        assert info["raw_pending"] == 0
+        assert info["entity_count"] == 0
+        assert info["pending_questions"] == 0
+
+    def test_format_status(self) -> None:
+        info = {
+            "raw_pending": 3,
+            "entity_count": 10,
+            "entities_by_type": {"person": 5, "company": 3, "concept": 2},
+            "last_commit_date": "2024-04-06 12:00:00 -0700",
+            "last_commit_message": "librarian: processed 5 file(s)",
+            "pending_questions": 1,
+        }
+        output = format_status(info)
+        assert "Raw files pending:    3" in output
+        assert "Wiki entities:        10" in output
+        assert "person: 5" in output
+        assert "Pending questions:    1" in output
+
+    def test_cli_status(self, tmp_path: Path) -> None:
+        from athenaeum.cli import main
+
+        root = self._seed_knowledge(tmp_path)
+        exit_code = main(["status", "--path", str(root)])
+        assert exit_code == 0
+
+    def test_cli_status_missing_dir(self, tmp_path: Path) -> None:
+        from athenaeum.cli import main
+
+        exit_code = main(["status", "--path", str(tmp_path / "nope")])
+        assert exit_code == 1

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -115,6 +115,53 @@ class TestTier2:
         system_msg = call_args.kwargs["system"]
         assert "untrusted user data" in system_msg
 
+    def test_classify_includes_observation_filter(
+        self, wiki_dir: Path,
+    ) -> None:
+        """Issue #17: observation-filter.md should be injected into classify prompt."""
+        from athenaeum.tiers import tier2_classify
+
+        schema_dir = wiki_dir / "_schema"
+        schema_dir.mkdir(exist_ok=True)
+        (schema_dir / "observation-filter.md").write_text(
+            "# Observation Filter\n\n## Always Capture\n- People\n"
+        )
+
+        raw = _make_raw("Some content about people.")
+        client = _mock_client("[]")
+
+        tier2_classify(
+            raw, [], ["person"], [], ["internal"], client,
+            wiki_root=wiki_dir,
+        )
+        call_args = client.messages.create.call_args
+        user_msg = call_args.kwargs["messages"][0]["content"]
+        assert "Observation filter" in user_msg
+        assert "Always Capture" in user_msg
+
+    def test_classify_records_token_usage(self) -> None:
+        """Issue #9: token usage should be recorded from API responses."""
+        from athenaeum.models import TokenUsage
+        from athenaeum.tiers import tier2_classify
+
+        raw = _make_raw("Some content.")
+        client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="[]")]
+        mock_response.usage = MagicMock(
+            input_tokens=150, output_tokens=20,
+        )
+        client.messages.create.return_value = mock_response
+
+        usage = TokenUsage()
+        tier2_classify(
+            raw, [], ["person"], [], ["internal"], client,
+            usage=usage,
+        )
+        assert usage.input_tokens == 150
+        assert usage.output_tokens == 20
+        assert usage.api_calls == 1
+
     def test_extracts_new_entity(self) -> None:
         from athenaeum.tiers import tier2_classify
 
@@ -334,6 +381,35 @@ class TestTier3Create:
         assert "<user_document>" in user_msg
         assert "</user_document>" in user_msg
         assert "data only" in user_msg
+
+    def test_create_includes_entity_template(
+        self, wiki_dir: Path,
+    ) -> None:
+        """Issue #17: _entity-template.md should be fed to Tier 3 create."""
+        schema_dir = wiki_dir / "_schema"
+        schema_dir.mkdir(exist_ok=True)
+        (schema_dir / "_entity-template.md").write_text(
+            "# Entity Page Template\n\n## Template\nuid, type, name\n"
+        )
+
+        action = EntityAction(
+            kind="create",
+            name="Test",
+            entity_type="person",
+            tags=[],
+            access="internal",
+            existing_uid=None,
+            observations="Some info.",
+        )
+        client = _mock_client("# Test\n\nContent.")
+
+        tier3_create(
+            action, "ref.md", client, wiki_root=wiki_dir,
+        )
+        call_args = client.messages.create.call_args
+        user_msg = call_args.kwargs["messages"][0]["content"]
+        assert "Entity template" in user_msg
+        assert "Entity Page Template" in user_msg
 
     def test_creates_entity_from_action(self) -> None:
         action = EntityAction(


### PR DESCRIPTION
## Summary

- **#9 Token usage tracking**: Accumulate `input_tokens` and `output_tokens` from all API responses via new `TokenUsage` dataclass. Log a summary with estimated cost at end of each `athenaeum run`.
- **#17 Schema integration**: Feed `observation-filter.md` into Tier 2 classify prompts (guides what to capture) and `_entity-template.md` into Tier 3 create prompts (structural consistency for new pages).
- **#20 Status command**: New `athenaeum status` subcommand reporting pending raw files, entity counts by type, pending questions count, and last git commit info.
- **#19 README docs**: Add Usage section documenting `athenaeum run` flags, `athenaeum status`, environment variables, raw file format, and output format.

Closes #9, closes #17, closes #19, closes #20

## Test plan

- [x] `TestTokenUsage` — add/accumulate, estimated cost, empty state (3 tests)
- [x] `test_classify_includes_observation_filter` — observation-filter.md injected into classify prompt
- [x] `test_classify_records_token_usage` — token tracking from API response
- [x] `test_create_includes_entity_template` — _entity-template.md injected into create prompt
- [x] `TestStatus` — counts, empty knowledge, format, CLI success, CLI missing dir (5 tests)
- [x] 110 tests passing, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
