### PR TITLE
feat: MCP memory server with remember + recall tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+mcp = [
+    "fastmcp>=2.0.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.4.0",
+    "fastmcp>=2.0.0",
 ]
 
 [project.scripts]

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -32,6 +32,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Knowledge directory (default: ~/knowledge)",
     )
 
+    # serve command — start the MCP memory server
+    serve_parser = subparsers.add_parser("serve", help="Start the MCP memory server")
+    serve_parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path("~/knowledge"),
+        help="Knowledge directory (default: ~/knowledge)",
+    )
+
     # run command — execute the librarian pipeline
     run_parser = subparsers.add_parser("run", help="Run the librarian pipeline")
     run_parser.add_argument(
@@ -75,6 +84,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "status":
         return _cmd_status(args)
 
+    if args.command == "serve":
+        return _cmd_serve(args)
+
     if args.command == "run":
         return _cmd_run(args)
 
@@ -98,6 +110,23 @@ def _cmd_status(args: argparse.Namespace) -> int:
         return 1
     info = status(target)
     print(format_status(info))
+    return 0
+
+
+def _cmd_serve(args: argparse.Namespace) -> int:
+    from athenaeum.mcp_server import create_server
+
+    target = args.path.expanduser().resolve()
+    raw_root = target / "raw"
+    wiki_root = target / "wiki"
+
+    if not target.exists():
+        print(f"Knowledge directory not found: {target}")
+        print("Run 'athenaeum init' first to create a knowledge directory.")
+        return 1
+
+    server = create_server(raw_root=raw_root, wiki_root=wiki_root)
+    server.run()
     return 0
 
 

--- a/src/athenaeum/mcp_server.py
+++ b/src/athenaeum/mcp_server.py
@@ -1,0 +1,235 @@
+"""MCP memory server — read/write gate for an Athenaeum knowledge base.
+
+Tools:
+  remember  — append-only write to raw/
+  recall    — keyword search over wiki/
+
+Requires the ``mcp`` extra: ``pip install athenaeum[mcp]``
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from athenaeum.models import parse_frontmatter
+
+# ---------------------------------------------------------------------------
+# Recall helpers
+# ---------------------------------------------------------------------------
+
+
+def _tokenize_query(query: str) -> list[str]:
+    """Split query into lowercase keyword tokens (>=2 chars)."""
+    return [t for t in re.split(r"\W+", query.lower()) if len(t) >= 2]
+
+
+def _score_page(
+    tokens: list[str], frontmatter: dict, body: str
+) -> float:
+    """Score a wiki page against query tokens.
+
+    Frontmatter matches (name, aliases, tags) are weighted 3x vs body matches.
+    """
+    if not tokens:
+        return 0.0
+
+    fm_parts: list[str] = []
+    for key in ("name", "aliases", "tags", "description", "title"):
+        val = frontmatter.get(key, "")
+        if isinstance(val, list):
+            fm_parts.append(" ".join(str(v) for v in val))
+        else:
+            fm_parts.append(str(val))
+    fm_text = " ".join(fm_parts).lower()
+    body_lower = body.lower()
+
+    score = 0.0
+    for token in tokens:
+        if token in fm_text:
+            score += 3.0
+        if token in body_lower:
+            score += 1.0
+    return score
+
+
+def _snippet(body: str, tokens: list[str], max_chars: int = 400) -> str:
+    """Extract a relevant snippet from body around the first token match."""
+    body_lower = body.lower()
+    best_pos = len(body)
+    for token in tokens:
+        pos = body_lower.find(token)
+        if 0 <= pos < best_pos:
+            best_pos = pos
+
+    if best_pos >= len(body):
+        return body[:max_chars].strip() + ("\u2026" if len(body) > max_chars else "")
+
+    start = max(0, best_pos - 80)
+    end = min(len(body), start + max_chars)
+    prefix = "\u2026" if start > 0 else ""
+    suffix = "\u2026" if end < len(body) else ""
+    return prefix + body[start:end].strip() + suffix
+
+
+# ---------------------------------------------------------------------------
+# Public API (usable without FastMCP for testing)
+# ---------------------------------------------------------------------------
+
+
+def recall_search(
+    wiki_root: Path, query: str, top_k: int = 5
+) -> str:
+    """Search the knowledge wiki for pages relevant to *query*.
+
+    Returns a formatted string of matching wiki pages with relevance scores
+    and content snippets.
+    """
+    if not wiki_root.is_dir():
+        return f"Wiki directory not found at {wiki_root}."
+
+    tokens = _tokenize_query(query)
+    if not tokens:
+        return "Query too short \u2014 provide at least one keyword (2+ characters)."
+
+    scored: list[tuple[float, Path, dict, str]] = []
+
+    for md_file in wiki_root.rglob("*.md"):
+        if md_file.name.startswith("_"):
+            continue
+        try:
+            text = md_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        fm, body = parse_frontmatter(text)
+        score = _score_page(tokens, fm, body)
+
+        if score > 0:
+            scored.append((score, md_file, fm, body))
+
+    if not scored:
+        return f"No wiki pages matched query: {query!r}"
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    top = scored[:top_k]
+
+    parts: list[str] = [f"Found {len(scored)} matching pages (showing top {len(top)}):\n"]
+    for rank, (score, path, fm, body) in enumerate(top, 1):
+        name = fm.get("name", path.stem)
+        rel_path = path.relative_to(wiki_root)
+        tags = fm.get("tags", "\u2014")
+        if isinstance(tags, list):
+            tags = ", ".join(tags)
+        snip = _snippet(body, tokens)
+        parts.append(
+            f"### {rank}. {name} (score: {score:.1f})\n"
+            f"**Path:** wiki/{rel_path}\n"
+            f"**Tags:** {tags}\n\n"
+            f"{snip}\n"
+        )
+
+    return "\n".join(parts)
+
+
+def remember_write(
+    raw_root: Path,
+    content: str,
+    source: str = "claude-session",
+    *,
+    wiki_root: Path | None = None,
+) -> str:
+    """Save a piece of knowledge to the raw intake directory.
+
+    Returns a confirmation message with the file path, or an error string.
+    """
+    safe_source = "".join(c for c in source if c.isalnum() or c in "-_")
+    if not safe_source:
+        return "Error: source must contain at least one alphanumeric character."
+
+    target_dir = (raw_root / safe_source).resolve()
+
+    # Guard: must stay inside raw_root, never touch wiki
+    if not str(target_dir).startswith(str(raw_root.resolve())):
+        return "Error: path traversal detected \u2014 writes are restricted to raw/."
+    if wiki_root and str(target_dir).startswith(str(wiki_root.resolve())):
+        return "Error: writes to wiki/ are not allowed."
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    short_id = uuid.uuid4().hex[:8]
+    filename = f"{timestamp}-{short_id}.md"
+    filepath = target_dir / filename
+
+    if filepath.exists():
+        return f"Error: file already exists at {filepath}. This should not happen."
+
+    filepath.write_text(content, encoding="utf-8")
+    return f"Saved to {filepath}"
+
+
+# ---------------------------------------------------------------------------
+# MCP server factory
+# ---------------------------------------------------------------------------
+
+
+def create_server(
+    raw_root: Path, wiki_root: Path
+) -> "FastMCP":  # noqa: F821 — lazy import
+    """Create and return a configured FastMCP server instance.
+
+    Requires ``fastmcp`` to be installed (``pip install athenaeum[mcp]``).
+    """
+    try:
+        from fastmcp import FastMCP
+    except ImportError as exc:
+        raise ImportError(
+            "FastMCP is required for the MCP server. "
+            "Install it with: pip install athenaeum[mcp]"
+        ) from exc
+
+    mcp = FastMCP(
+        "athenaeum",
+        instructions=(
+            "Knowledge memory server powered by Athenaeum. "
+            "Use `remember` to save information to raw intake for later compilation. "
+            "Use `recall` to search the compiled wiki for relevant knowledge."
+        ),
+    )
+
+    @mcp.tool()
+    def recall(query: str, top_k: int = 5) -> str:
+        """Search the knowledge wiki for pages relevant to a query.
+
+        Uses keyword matching against frontmatter (name, aliases, tags) and
+        body text. Frontmatter matches are weighted higher for relevance.
+
+        Args:
+            query: Search query string (keywords, names, topics).
+            top_k: Maximum number of results to return (default 5).
+
+        Returns:
+            Matching wiki pages with relevance scores and content snippets.
+        """
+        return recall_search(wiki_root, query, top_k)
+
+    @mcp.tool()
+    def remember(content: str, source: str = "claude-session") -> str:
+        """Save a piece of knowledge to the raw intake directory.
+
+        The content is written as an append-only raw file. It will be compiled
+        into the wiki on the next pipeline run.
+
+        Args:
+            content: The knowledge to save (markdown string).
+            source: Origin label, e.g. "claude-session", "manual".
+
+        Returns:
+            Confirmation message with the file path.
+        """
+        return remember_write(raw_root, content, source, wiki_root=wiki_root)
+
+    return mcp

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,262 @@
+"""Tests for the MCP memory server module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athenaeum.mcp_server import (
+    _score_page,
+    _snippet,
+    _tokenize_query,
+    recall_search,
+    remember_write,
+)
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+
+class TestTokenizeQuery:
+    def test_basic_split(self) -> None:
+        assert _tokenize_query("hello world") == ["hello", "world"]
+
+    def test_filters_short_tokens(self) -> None:
+        assert _tokenize_query("a is the go") == ["is", "the", "go"]
+
+    def test_lowercases(self) -> None:
+        assert _tokenize_query("Acme Corp") == ["acme", "corp"]
+
+    def test_splits_on_punctuation(self) -> None:
+        assert _tokenize_query("foo-bar/baz") == ["foo", "bar", "baz"]
+
+    def test_empty_string(self) -> None:
+        assert _tokenize_query("") == []
+
+
+# ---------------------------------------------------------------------------
+# Score page
+# ---------------------------------------------------------------------------
+
+
+class TestScorePage:
+    def test_frontmatter_match_weighted(self) -> None:
+        score = _score_page(
+            ["acme"], {"name": "Acme Corp", "tags": ["fintech"]}, "Some body text"
+        )
+        assert score >= 3.0  # frontmatter hit
+
+    def test_body_only_match(self) -> None:
+        score = _score_page(["pipeline"], {}, "The pipeline processes raw files")
+        assert score == 1.0
+
+    def test_both_match(self) -> None:
+        score = _score_page(
+            ["acme"], {"name": "Acme Corp"}, "Acme is a company"
+        )
+        assert score == 4.0  # 3 (frontmatter) + 1 (body)
+
+    def test_no_match(self) -> None:
+        score = _score_page(["xyz"], {"name": "Acme"}, "No match here")
+        assert score == 0.0
+
+    def test_empty_tokens(self) -> None:
+        assert _score_page([], {"name": "Acme"}, "body") == 0.0
+
+    def test_list_tags_scored(self) -> None:
+        score = _score_page(
+            ["fintech"], {"tags": ["fintech", "client"]}, "body"
+        )
+        assert score >= 3.0
+
+
+# ---------------------------------------------------------------------------
+# Snippet
+# ---------------------------------------------------------------------------
+
+
+class TestSnippet:
+    def test_returns_context_around_match(self) -> None:
+        body = "x" * 200 + " KEYWORD " + "y" * 200
+        snip = _snippet(body, ["keyword"], max_chars=100)
+        assert "keyword" in snip.lower()
+
+    def test_returns_start_when_no_match(self) -> None:
+        body = "abcdef" * 50
+        snip = _snippet(body, ["zzz"], max_chars=20)
+        assert snip.startswith("abcdef")
+
+    def test_short_body(self) -> None:
+        snip = _snippet("short", ["short"])
+        assert snip == "short"
+
+
+# ---------------------------------------------------------------------------
+# Recall
+# ---------------------------------------------------------------------------
+
+
+class TestRecall:
+    def test_recall_finds_matching_page(self, wiki_dir: Path) -> None:
+        result = recall_search(wiki_dir, "Acme")
+        assert "Acme Corp" in result
+        assert "score:" in result
+
+    def test_recall_no_match(self, wiki_dir: Path) -> None:
+        result = recall_search(wiki_dir, "xyznonexistent")
+        assert "No wiki pages matched" in result
+
+    def test_recall_missing_dir(self, tmp_path: Path) -> None:
+        result = recall_search(tmp_path / "nonexistent", "test")
+        assert "not found" in result
+
+    def test_recall_short_query(self, wiki_dir: Path) -> None:
+        result = recall_search(wiki_dir, "a")
+        assert "too short" in result.lower()
+
+    def test_recall_skips_underscore_files(self, wiki_dir: Path) -> None:
+        result = recall_search(wiki_dir, "Index")
+        # _index.md should be skipped, so no match from that file
+        assert "score:" not in result or "_index" not in result
+
+    def test_recall_top_k(self, wiki_dir: Path) -> None:
+        result = recall_search(wiki_dir, "knowledge architecture", top_k=1)
+        assert "showing top 1" in result
+
+    def test_recall_shows_tags(self, wiki_dir: Path) -> None:
+        result = recall_search(wiki_dir, "Acme fintech")
+        assert "fintech" in result
+
+
+# ---------------------------------------------------------------------------
+# Remember
+# ---------------------------------------------------------------------------
+
+
+class TestRemember:
+    def test_writes_raw_file(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        result = remember_write(raw, "Test observation about Acme")
+        assert result.startswith("Saved to")
+        # Verify file exists and has content
+        files = list((raw / "claude-session").glob("*.md"))
+        assert len(files) == 1
+        assert files[0].read_text() == "Test observation about Acme"
+
+    def test_custom_source(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        result = remember_write(raw, "content", source="manual")
+        assert "Saved to" in result
+        assert (raw / "manual").is_dir()
+
+    def test_filename_format(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        remember_write(raw, "content")
+        files = list((raw / "claude-session").glob("*.md"))
+        # filename: 20260416T123456Z-abcd1234.md
+        import re
+        assert re.match(r"\d{8}T\d{6}Z-[0-9a-f]{8}\.md", files[0].name)
+
+    def test_rejects_empty_source(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        result = remember_write(raw, "content", source="!!!")
+        assert "Error" in result
+
+    def test_sanitizes_path_traversal(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        # "../../../etc" is sanitized to "etc" (dots and slashes stripped),
+        # so it writes safely to raw/etc/ — the sanitization IS the defense
+        result = remember_write(raw, "content", source="../../../etc")
+        assert "Saved" in result
+        assert (raw / "etc").is_dir()
+
+    def test_sanitizes_wiki_traversal(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        wiki = tmp_path / "wiki"
+        raw.mkdir()
+        wiki.mkdir()
+        # "../wiki" is sanitized to "wiki", writing to raw/wiki/ (not the
+        # actual wiki root) — safely contained inside raw/
+        result = remember_write(
+            raw, "content", source="../wiki", wiki_root=wiki
+        )
+        assert "Saved" in result
+        assert (raw / "wiki").is_dir()
+
+    def test_creates_source_dir(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        remember_write(raw, "content", source="new-source")
+        assert (raw / "new-source").is_dir()
+
+    def test_append_only(self, tmp_path: Path) -> None:
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        r1 = remember_write(raw, "first")
+        r2 = remember_write(raw, "second")
+        assert "Saved" in r1
+        assert "Saved" in r2
+        files = list((raw / "claude-session").glob("*.md"))
+        assert len(files) == 2
+
+
+# ---------------------------------------------------------------------------
+# Server factory
+# ---------------------------------------------------------------------------
+
+
+class TestCreateServer:
+    def test_creates_server_instance(self, tmp_path: Path) -> None:
+        pytest.importorskip("fastmcp")
+        from athenaeum.mcp_server import create_server
+
+        raw = tmp_path / "raw"
+        wiki = tmp_path / "wiki"
+        raw.mkdir()
+        wiki.mkdir()
+        server = create_server(raw_root=raw, wiki_root=wiki)
+        assert server is not None
+
+    def test_import_error_without_fastmcp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib
+        import sys
+
+        # Temporarily hide fastmcp
+        saved = sys.modules.get("fastmcp")
+        monkeypatch.setitem(sys.modules, "fastmcp", None)
+        try:
+            # Re-import to trigger the ImportError path
+            import athenaeum.mcp_server as mod
+            importlib.reload(mod)  # force fresh import of the function
+
+            with pytest.raises(ImportError, match="FastMCP is required"):
+                mod.create_server(
+                    raw_root=tmp_path / "raw", wiki_root=tmp_path / "wiki"
+                )
+        finally:
+            if saved is not None:
+                monkeypatch.setitem(sys.modules, "fastmcp", saved)
+            else:
+                monkeypatch.delitem(sys.modules, "fastmcp", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestCLIServe:
+    def test_serve_missing_dir(self, tmp_path: Path) -> None:
+        from athenaeum.cli import main
+
+        code = main(["serve", "--path", str(tmp_path / "nonexistent")])
+        assert code == 1


### PR DESCRIPTION
## Summary

- Adds `athenaeum serve` subcommand that starts a FastMCP server with `remember` (append-only write to raw/) and `recall` (keyword search over wiki/) tools
- FastMCP is an optional dependency: `pip install athenaeum[mcp]` — core pipeline works without it
- Reuses athenaeum's `parse_frontmatter` for consistency; recall uses frontmatter-weighted scoring (name/aliases/tags = 3x, body = 1x)
- Path traversal sanitization on `remember` writes; source labels are restricted to alphanumeric + `-_`
- 31 new tests covering tokenizer, scoring, snippets, recall, remember, server factory, and CLI integration (141 total, all passing)

## Usage

```json
// .claude/settings.json — auto-starts with Claude Code
"mcpServers": {
  "athenaeum": {
    "command": "athenaeum",
    "args": ["serve", "--path", "~/knowledge"]
  }
}
```

## Test plan

- [x] 31 new tests covering all public functions + edge cases
- [x] Path traversal sanitization verified (source strings sanitized before path construction)
- [x] Full test suite: 141 passed, 1 skipped, ruff clean
- [x] CLI `serve --path /nonexistent` returns error code 1 with helpful message
- [ ] CI pipeline green on PR

Closes Kromatic-Innovation/code-workspace-config#165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
