### PR TITLE
fix(search): nuke vector_dir on rebuild to recover from stale state

### DIFF
--- a/src/athenaeum/search.py
+++ b/src/athenaeum/search.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import sqlite3
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
-
 
 # ---------------------------------------------------------------------------
 # Protocol
@@ -205,14 +205,26 @@ class VectorBackend:
         chromadb = self._get_chromadb()
 
         vector_dir = cache_dir / _VECTOR_DIR
+        # Nuke any prior on-disk state before opening a PersistentClient.
+        # chromadb's SQLite metadata and the rust binding's collection store
+        # can desync (stale UUIDs, corrupt sqlite, partial writes), causing
+        # create_collection to return a Collection whose UUID the rust layer
+        # then reports as non-existent on the first .add(). A full wipe on
+        # each rebuild is the simplest robust reset — see issue #32.
+        if vector_dir.exists():
+            shutil.rmtree(vector_dir)
         vector_dir.mkdir(parents=True, exist_ok=True)
 
+        # chromadb caches PersistentClient systems per-path at the module
+        # level. When rebuild runs in a long-lived process (or the same
+        # interpreter invoked it before) a cached system will still know
+        # about the old "wiki" collection after we rmtree'd the dir,
+        # causing create_collection to fail with "already exists". Clear
+        # the cache so the new PersistentClient sees a fresh filesystem.
+        from chromadb.api.client import SharedSystemClient
+        SharedSystemClient.clear_system_cache()
+
         client = chromadb.PersistentClient(path=str(vector_dir))
-        # Delete and recreate to ensure a clean rebuild
-        try:
-            client.delete_collection(_VECTOR_COLLECTION)
-        except Exception:
-            pass
         collection = client.create_collection(_VECTOR_COLLECTION)
 
         ids: list[str] = []

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,8 +10,8 @@ from athenaeum.search import (
     FTS5Backend,
     SearchBackend,
     VectorBackend,
-    get_backend,
     build_fts5_index,
+    get_backend,
     query_fts5_index,
 )
 
@@ -211,6 +211,29 @@ class TestVectorBackend:
         )
         count = backend.build_index(wiki_with_pages, cache)
         assert count == 4
+
+    def test_build_index_recovers_from_corrupt_vector_dir(
+        self, wiki_with_pages: Path, tmp_path: Path
+    ) -> None:
+        """Regression: stale/corrupt on-disk state must not break rebuild.
+
+        Reproduces the scenario from issue #32 where chromadb's SQLite and
+        rust-binding state desynced, causing ``create_collection`` to succeed
+        but ``collection.add`` to raise ``NotFoundError``. The fix wipes
+        ``vector_dir`` wholesale on each rebuild.
+        """
+        cache = tmp_path / "cache"
+        vector_dir = cache / "wiki-vectors"
+        vector_dir.mkdir(parents=True)
+        # Garbage that would confuse a freshly-opened PersistentClient
+        (vector_dir / "chroma.sqlite3").write_bytes(b"not a sqlite db")
+        (vector_dir / "stray-file.bin").write_bytes(b"\x00\x01\x02")
+
+        count = VectorBackend().build_index(wiki_with_pages, cache)
+        assert count == 3
+        assert vector_dir.is_dir()
+        # Garbage was replaced, not merged
+        assert not (vector_dir / "stray-file.bin").exists()
 
     def test_query_finds_match(
         self, wiki_with_pages: Path, tmp_path: Path


### PR DESCRIPTION
## Summary

Fixes the `NotFoundError: Collection [<uuid>] does not exist` that
surfaced at SessionStart when `~/.cache/athenaeum/wiki-vectors/` was in a
partially-corrupt state (chromadb's SQLite metadata and the rust binding
desynced).

- Replace the old `try: client.delete_collection(...)` swallowed-error
  pattern with a full `shutil.rmtree(vector_dir)` before opening the
  `PersistentClient`. Matches the intent of the original "clean rebuild"
  comment; the logical delete wasn't enough to actually reset disk state.
- Clear `chromadb.api.client.SharedSystemClient`'s per-path system cache
  between rmtree and the new `PersistentClient(...)`. Without this, a
  long-lived interpreter (or the same process that built the index
  earlier) reuses the cached system which still thinks the "wiki"
  collection exists and fails `create_collection` with `already exists`.
- Ruff-fixes pre-existing I001 import-order warnings in the two files I
  touched. Develop CI is currently red on exactly these warnings; a clean
  PR run requires fixing them.

Refs Kromatic-Innovation/athenaeum#32.

## Test plan

- [x] `.venv/bin/pytest tests/ -q` — 182 passed
- [x] New regression: `test_build_index_recovers_from_corrupt_vector_dir`
      plants garbage bytes as `chroma.sqlite3` + an unrelated stray file,
      calls `VectorBackend().build_index(...)`, and asserts the page
      count + that stray file was erased (not merged).
- [x] Manual repro — corrupted real cache, ran the hook:
      ```
      rm -rf ~/.cache/athenaeum/wiki-vectors
      mkdir -p ~/.cache/athenaeum/wiki-vectors
      echo garbage > ~/.cache/athenaeum/wiki-vectors/chroma.sqlite3
      SEARCH_BACKEND=vector ATHENAEUM_SRC=.../athenaeum \
        ATHENAEUM_PYTHON=.../athenaeum/.venv/bin/python \
        bash scripts/hooks/knowledge-build-index.sh
      ```
      Output: `[Knowledge] Vector index: 3161 wiki pages` — clean, no
      traceback. Verified the rebuilt `chroma.sqlite3` is ~32MB and a
      real UUID-named collection subdir exists.
- [x] `.venv/bin/ruff check src/ tests/` — clean
