### PR TITLE
feat(cli): add rebuild-index subcommand

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -72,6 +72,24 @@ def main(argv: list[str] | None = None) -> int:
         help="Enable debug logging",
     )
 
+    # rebuild-index command — rebuild the search index out-of-band
+    rebuild_parser = subparsers.add_parser(
+        "rebuild-index",
+        help="Rebuild the search index (FTS5 or vector, per config)",
+    )
+    rebuild_parser.add_argument(
+        "--path", type=Path, default=Path("~/knowledge"),
+        help="Knowledge directory (default: ~/knowledge)",
+    )
+    rebuild_parser.add_argument(
+        "--cache-dir", type=Path, default=None,
+        help="Cache directory (default: ~/.cache/athenaeum)",
+    )
+    rebuild_parser.add_argument(
+        "--backend", choices=["fts5", "vector"], default=None,
+        help="Override configured backend (default: read from athenaeum.yaml)",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command is None:
@@ -89,6 +107,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "run":
         return _cmd_run(args)
+
+    if args.command == "rebuild-index":
+        return _cmd_rebuild_index(args)
 
     return 0
 
@@ -154,6 +175,45 @@ def _cmd_run(args: argparse.Namespace) -> int:
         max_files=args.max_files,
         max_api_calls=args.max_api_calls,
     )
+
+
+def _cmd_rebuild_index(args: argparse.Namespace) -> int:
+    from athenaeum.config import load_config
+    from athenaeum.search import build_fts5_index, build_vector_index
+
+    knowledge_root = args.path.expanduser().resolve()
+    wiki_root = knowledge_root / "wiki"
+    cache_dir = (args.cache_dir or Path("~/.cache/athenaeum")).expanduser().resolve()
+
+    if not wiki_root.exists():
+        print(f"Wiki directory not found: {wiki_root}", file=sys.stderr)
+        return 1
+
+    if args.backend is not None:
+        backend = args.backend
+    else:
+        cfg = load_config(knowledge_root)
+        backend = cfg.get("search_backend", "fts5")
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    if backend == "vector":
+        try:
+            count = build_vector_index(wiki_root, cache_dir)
+        except ImportError as exc:
+            print(f"Vector backend unavailable: {exc}", file=sys.stderr)
+            print("Install with: pip install athenaeum[vector]", file=sys.stderr)
+            return 1
+        print(f"Vector index rebuilt: {count} wiki pages")
+        return 0
+
+    if backend == "fts5":
+        count = build_fts5_index(wiki_root, cache_dir)
+        print(f"FTS5 index rebuilt: {count} wiki pages")
+        return 0
+
+    print(f"Unknown search backend: {backend}", file=sys.stderr)
+    return 1
 
 
 def _get_version() -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,106 @@
+"""Tests for the athenaeum CLI command dispatch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athenaeum.cli import main
+
+
+@pytest.fixture
+def knowledge_with_wiki(tmp_path: Path) -> Path:
+    knowledge = tmp_path / "knowledge"
+    wiki = knowledge / "wiki"
+    wiki.mkdir(parents=True)
+
+    (wiki / "lean-startup.md").write_text(
+        "---\n"
+        "name: Lean Startup\n"
+        "tags: [methodology]\n"
+        "description: Build-measure-learn methodology\n"
+        "---\n\n"
+        "The Lean Startup methodology.\n"
+    )
+    (wiki / "customer-development.md").write_text(
+        "---\n"
+        "name: Customer Development\n"
+        "tags: [methodology]\n"
+        "description: Steve Blank's framework\n"
+        "---\n\n"
+        "Customer development is a four-step framework.\n"
+    )
+    return knowledge
+
+
+class TestRebuildIndex:
+    def test_builds_fts5_index(
+        self, knowledge_with_wiki: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cache = tmp_path / "cache"
+        rc = main([
+            "rebuild-index",
+            "--path", str(knowledge_with_wiki),
+            "--cache-dir", str(cache),
+            "--backend", "fts5",
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "FTS5 index rebuilt: 2 wiki pages" in out
+        assert (cache / "wiki-index.db").exists()
+
+    def test_reads_backend_from_config(
+        self, knowledge_with_wiki: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        (knowledge_with_wiki / "athenaeum.yaml").write_text(
+            "auto_recall: true\nsearch_backend: fts5\n"
+        )
+        cache = tmp_path / "cache"
+        rc = main([
+            "rebuild-index",
+            "--path", str(knowledge_with_wiki),
+            "--cache-dir", str(cache),
+        ])
+        assert rc == 0
+        assert "FTS5 index rebuilt" in capsys.readouterr().out
+
+    def test_defaults_to_fts5_when_no_config(
+        self, knowledge_with_wiki: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cache = tmp_path / "cache"
+        rc = main([
+            "rebuild-index",
+            "--path", str(knowledge_with_wiki),
+            "--cache-dir", str(cache),
+        ])
+        assert rc == 0
+        assert "FTS5 index rebuilt" in capsys.readouterr().out
+
+    def test_missing_wiki_returns_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        nonexistent = tmp_path / "does-not-exist"
+        rc = main([
+            "rebuild-index",
+            "--path", str(nonexistent),
+            "--cache-dir", str(tmp_path / "cache"),
+            "--backend", "fts5",
+        ])
+        assert rc == 1
+        assert "Wiki directory not found" in capsys.readouterr().err
+
+    def test_unknown_backend_returns_error(
+        self, knowledge_with_wiki: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        (knowledge_with_wiki / "athenaeum.yaml").write_text(
+            "auto_recall: true\nsearch_backend: nonsense\n"
+        )
+        rc = main([
+            "rebuild-index",
+            "--path", str(knowledge_with_wiki),
+            "--cache-dir", str(tmp_path / "cache"),
+        ])
+        assert rc == 1
+        assert "Unknown search backend" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Add `athenaeum rebuild-index` CLI subcommand for on-demand index rebuilds. Supports both FTS5 and vector backends with the configured backend read from `athenaeum.yaml` by default.

This unblocks cwc#178: the vector index rebuild currently blocks SessionStart for ~46s on 3163 pages. Moving that work to background/cron/on-demand triggers needs an out-of-band rebuild entry point.

## Usage

```bash
athenaeum rebuild-index                    # read backend from athenaeum.yaml
athenaeum rebuild-index --backend vector   # force vector
athenaeum rebuild-index --backend fts5     # force FTS5
athenaeum rebuild-index --path /alt/kb     # alternate knowledge root
```

## Test plan

- [x] `.venv/bin/pytest tests/ -q` — 187 passed
- [x] `.venv/bin/ruff check src/ tests/` — clean
- [x] 5 new CLI dispatch tests: FTS5 build, config read, default fallback, missing wiki, unknown backend

## Related

- Consumer (cwc): Kromatic-Innovation/code-workspace-config#178
- Parent epic: Kromatic-Innovation/code-workspace-config#48
