### PR TITLE
test(hooks): shell hook smoke tests + fix latent python3/anthropic bugs

### DIFF
--- a/examples/claude-code/session-start-recall.sh
+++ b/examples/claude-code/session-start-recall.sh
@@ -21,6 +21,11 @@
 # Environment variables:
 #   KNOWLEDGE_ROOT       Path to knowledge directory (default: ~/knowledge)
 #   KNOWLEDGE_WIKI_PATH  Path to wiki directory (default: $KNOWLEDGE_ROOT/wiki)
+#   ATHENAEUM_PYTHON     Python interpreter with athenaeum deps (default: python3)
+#   ATHENAEUM_SRC        Path to athenaeum source checkout (optional; enables
+#                        importlib-based loading that bypasses the package
+#                        __init__.py — useful when running from a checkout
+#                        where optional deps like anthropic aren't installed)
 
 set -euo pipefail
 
@@ -28,6 +33,7 @@ KNOWLEDGE_ROOT="${KNOWLEDGE_ROOT:-$HOME/knowledge}"
 WIKI_ROOT="${KNOWLEDGE_WIKI_PATH:-$KNOWLEDGE_ROOT/wiki}"
 CACHE_DIR="${HOME}/.cache/athenaeum"
 CONFIG_ENV="${CACHE_DIR}/config.env"
+PYTHON="${ATHENAEUM_PYTHON:-python3}"
 
 if [ ! -d "$WIKI_ROOT" ]; then
   exit 0
@@ -39,10 +45,19 @@ mkdir -p "$CACHE_DIR"
 # Try athenaeum Python module; fall back to pure-shell YAML parsing.
 _read_config_ok=false
 
-if python3 -c "
-import sys, os
-sys.path.insert(0, os.path.join(os.environ.get('ATHENAEUM_SRC', ''), 'src'))
-from athenaeum.config import load_config
+if "$PYTHON" -c "
+import sys, os, importlib.util
+src = os.environ.get('ATHENAEUM_SRC', '')
+# Prefer importlib loader from a source checkout (avoids package __init__.py
+# pulling in anthropic/librarian when only the config module is needed).
+cfg_path = os.path.join(src, 'src/athenaeum/config.py') if src else ''
+if cfg_path and os.path.isfile(cfg_path):
+    spec = importlib.util.spec_from_file_location('athenaeum_config_only', cfg_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    load_config = mod.load_config
+else:
+    from athenaeum.config import load_config
 cfg = load_config(sys.argv[1] if len(sys.argv) > 1 else None)
 env_path = sys.argv[2]
 with open(env_path, 'w') as f:
@@ -86,11 +101,17 @@ source "$CONFIG_ENV"
 
 # ── Build search index ─────────────────────────────────────────────────────
 if [ "$SEARCH_BACKEND" = "fts5" ]; then
-  # pip install athenaeum provides the search module
-  python3 -c "
-import sys, os
-sys.path.insert(0, os.path.join(os.environ.get('ATHENAEUM_SRC', ''), 'src'))
-from athenaeum.search import build_fts5_index
+  "$PYTHON" -c "
+import sys, os, importlib.util
+src = os.environ.get('ATHENAEUM_SRC', '')
+search_path = os.path.join(src, 'src/athenaeum/search.py') if src else ''
+if search_path and os.path.isfile(search_path):
+    spec = importlib.util.spec_from_file_location('athenaeum_search_only', search_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    build_fts5_index = mod.build_fts5_index
+else:
+    from athenaeum.search import build_fts5_index
 count = build_fts5_index(sys.argv[1], sys.argv[2])
 print(f'[Knowledge] FTS5 index: {count} wiki pages', file=sys.stderr)
 " "$WIKI_ROOT" "$CACHE_DIR" 2>&1 || true

--- a/tests/test_shell_hooks.py
+++ b/tests/test_shell_hooks.py
@@ -1,0 +1,189 @@
+"""Smoke tests for the Claude Code example hooks in ``examples/claude-code/``.
+
+These hooks are load-bearing for the sidecar experience — a regression would
+silently break auto-recall for all future sessions. They're shipped to users
+via copy-paste, so the CI contract is: each hook must be exit-clean against
+a minimal synthetic wiki on a standard POSIX box with ``bash``, ``jq``, and
+``sqlite3`` available.
+
+The tests shell out with an isolated ``HOME`` so they never touch the
+developer's real ``~/.cache/athenaeum`` or ``~/knowledge``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).parent.parent / "examples" / "claude-code"
+SESSION_START = HOOKS_DIR / "session-start-recall.sh"
+USER_PROMPT = HOOKS_DIR / "user-prompt-recall.sh"
+PRE_COMPACT = HOOKS_DIR / "pre-compact-save.sh"
+
+
+def _require(tool: str) -> None:
+    if shutil.which(tool) is None:
+        pytest.skip(f"{tool} not available on this runner")
+
+
+@pytest.fixture
+def hook_env(tmp_path: Path) -> dict[str, str]:
+    """Isolated env for hook subprocesses.
+
+    Points HOME at a tmp dir so hooks touch ``$tmp/.cache/athenaeum``
+    instead of the developer's real cache, and points KNOWLEDGE_ROOT at a
+    synthetic wiki. Inherits PATH so bash/jq/sqlite3 remain discoverable.
+    """
+    knowledge = tmp_path / "knowledge"
+    wiki = knowledge / "wiki"
+    wiki.mkdir(parents=True)
+
+    (wiki / "lean-startup.md").write_text(
+        "---\n"
+        "name: Lean Startup\n"
+        "tags: [methodology]\n"
+        "description: Build-measure-learn methodology\n"
+        "---\n\n"
+        "The Lean Startup methodology emphasizes rapid iteration and customer feedback.\n"
+    )
+    (wiki / "customer-development.md").write_text(
+        "---\n"
+        "name: Customer Development\n"
+        "tags: [methodology]\n"
+        "description: Steve Blank's four-step framework\n"
+        "---\n\n"
+        "Customer Development is Steve Blank's framework for startup discovery.\n"
+    )
+
+    (knowledge / "athenaeum.yaml").write_text(
+        "auto_recall: true\nsearch_backend: fts5\n"
+    )
+
+    athenaeum_src = Path(__file__).parent.parent
+
+    env = {
+        "HOME": str(tmp_path),
+        "PATH": os.environ.get("PATH", ""),
+        "KNOWLEDGE_ROOT": str(knowledge),
+        "ATHENAEUM_SRC": str(athenaeum_src),
+        "ATHENAEUM_PYTHON": sys.executable,
+    }
+    return env
+
+
+class TestSessionStartRecall:
+    def test_builds_fts5_index(self, hook_env: dict[str, str], tmp_path: Path) -> None:
+        _require("bash")
+        result = subprocess.run(
+            ["bash", str(SESSION_START)],
+            env=hook_env, capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+
+        config_env = tmp_path / ".cache" / "athenaeum" / "config.env"
+        assert config_env.is_file()
+        body = config_env.read_text()
+        assert "AUTO_RECALL=true" in body
+        assert "SEARCH_BACKEND=fts5" in body
+
+        index_db = tmp_path / ".cache" / "athenaeum" / "wiki-index.db"
+        assert index_db.is_file()
+
+    def test_exits_clean_when_wiki_missing(self, tmp_path: Path) -> None:
+        _require("bash")
+        env = {
+            "HOME": str(tmp_path),
+            "PATH": os.environ.get("PATH", ""),
+            "KNOWLEDGE_ROOT": str(tmp_path / "does-not-exist"),
+        }
+        result = subprocess.run(
+            ["bash", str(SESSION_START)],
+            env=env, capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+
+
+class TestUserPromptRecall:
+    def _seed_index(self, hook_env: dict[str, str]) -> None:
+        subprocess.run(
+            ["bash", str(SESSION_START)],
+            env=hook_env, capture_output=True, text=True, timeout=30, check=True,
+        )
+
+    def test_returns_wiki_match_as_additional_context(
+        self, hook_env: dict[str, str]
+    ) -> None:
+        _require("bash")
+        _require("jq")
+        _require("sqlite3")
+        self._seed_index(hook_env)
+
+        stdin_payload = json.dumps({
+            "prompt": "Tell me about customer development frameworks",
+            "session_id": f"test-{uuid.uuid4().hex}",
+        })
+        result = subprocess.run(
+            ["bash", str(USER_PROMPT)],
+            input=stdin_payload, env=hook_env,
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert result.stdout, "expected additionalContext JSON on stdout"
+
+        payload = json.loads(result.stdout)
+        assert "additionalContext" in payload
+        assert "Customer Development" in payload["additionalContext"]
+
+    def test_silent_on_short_prompt(self, hook_env: dict[str, str]) -> None:
+        _require("bash")
+        _require("jq")
+        _require("sqlite3")
+        self._seed_index(hook_env)
+
+        stdin_payload = json.dumps({
+            "prompt": "hi",
+            "session_id": f"test-{uuid.uuid4().hex}",
+        })
+        result = subprocess.run(
+            ["bash", str(USER_PROMPT)],
+            input=stdin_payload, env=hook_env,
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_exits_clean_with_no_index(self, hook_env: dict[str, str]) -> None:
+        _require("bash")
+        _require("jq")
+        stdin_payload = json.dumps({
+            "prompt": "anything at all with enough characters",
+            "session_id": f"test-{uuid.uuid4().hex}",
+        })
+        result = subprocess.run(
+            ["bash", str(USER_PROMPT)],
+            input=stdin_payload, env=hook_env,
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+
+class TestPreCompactSave:
+    def test_emits_system_message_json(self, tmp_path: Path) -> None:
+        _require("bash")
+        env = {"HOME": str(tmp_path), "PATH": os.environ.get("PATH", "")}
+        result = subprocess.run(
+            ["bash", str(PRE_COMPACT)],
+            env=env, capture_output=True, text=True, timeout=5,
+        )
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        assert "systemMessage" in payload
+        assert "Knowledge checkpoint" in payload["systemMessage"]


### PR DESCRIPTION
## Summary

Closes #27. Adds pytest-based smoke tests for the three example hooks in `examples/claude-code/` so CI fails loudly on regressions instead of users discovering broken auto-recall mid-session.

- `session-start-recall.sh` — builds FTS5 index, writes `config.env`
- `user-prompt-recall.sh` — returns `additionalContext` JSON for a matching prompt, silent on short prompts, clean exit with no index
- `pre-compact-save.sh` — emits valid `systemMessage` JSON

Tests use an isolated `HOME` so they never touch the developer's real `~/.cache/athenaeum`. Unique session IDs per invocation avoid cross-test pollution via `/tmp/knowledge-seen-*`.

Runs as part of the existing `pytest tests/` CI step — no workflow changes required.

## Latent bugs surfaced + fixed in `session-start-recall.sh`

The new tests caught two bugs the manual sidecar test never flagged:

1. **Hard-coded `python3` instead of `${ATHENAEUM_PYTHON:-python3}`.** A user with athenaeum in a venv but not system `python3` would see the Python block silently fail and only the shell-fallback config parse would run — no index build at all.
2. **Package `__init__.py` eagerly imports `librarian` → `anthropic`.** Users running hooks from a source checkout without `anthropic` installed couldn't build an index. Switched to `importlib.util` loading from `$ATHENAEUM_SRC` when set, falling back to package import otherwise.

## Test plan

- [x] `pytest tests/test_shell_hooks.py -v` → 6/6 pass
- [x] `pytest tests/` → 193 pass (up from 187)
- [x] `ruff check src/ tests/` clean
- [ ] CI green across 3.11/3.12/3.13

Generated with Claude Code
