### PR TITLE
feat(sidecar): wire observation filter as the tunable capture authority

### DIFF
--- a/examples/claude-code/CLAUDE.md.example
+++ b/examples/claude-code/CLAUDE.md.example
@@ -22,22 +22,39 @@ When you encounter important facts during a session, proactively call `remember`
 save them to the knowledge base. The user should **never need to say "remember this"**
 -- you should notice and save important information automatically.
 
-**What to remember:**
-- Key decisions and their rationale
-- People, relationships, and organizational roles
-- Project status changes, milestones, and deadlines
-- Technical architecture decisions
-- Meeting outcomes and action items
-- Company/product information learned from conversation
+The authoritative list of **what to capture and what to skip** lives in
+`~/knowledge/wiki/_schema/observation-filter.md`. Read that file at the start of a
+session (or when it's been edited). The sections you care about:
 
-**What NOT to remember:**
-- Code already in version control (the code is the source of truth)
-- Transient debugging state or error messages
-- Information already documented in CLAUDE.md, AGENTS.md, or README files
-- Your own analysis or opinions (save facts, not interpretations)
+- **Always Capture** — save these whenever encountered
+- **Capture When Reinforced** — save these once the user signals they matter
+- The file may also list user-specific exclusions under a **Never Capture** section
+
+A conservative default if the filter file is missing: save decisions, people,
+project status, architecture choices, meeting outcomes; skip code already in
+version control, transient debugging state, and your own interpretations.
+
+### Tuning the observation filter
+
+The filter file is designed to evolve based on user feedback. When the user gives
+you signal about what should or shouldn't be remembered, **update the filter file
+directly** using your Edit tool. Examples of signals:
+
+- "Stop saving X" / "you're being too noisy about Y" → add Y to a **Never Capture**
+  section (create the section if it doesn't exist)
+- "You should have remembered Z" / "make sure to save things like Z" → add Z under
+  **Always Capture** or, if tentative, **Capture When Reinforced**
+- "Remember more about my <hobby/topic>" → promote that topic into the filter
+
+After editing the filter, call `remember` to save a short meta-observation noting
+the change and its rationale (e.g., "Added 'Never Capture: error message snippets'
+per user feedback 2026-04-17"). This creates an audit trail in raw/ so the tuning
+is preserved if the filter file is ever lost.
 
 ### How it works
 
 1. Raw observations go to `~/knowledge/raw/claude-session/` via `remember`
 2. The librarian pipeline (`athenaeum run`) compiles raw files into wiki entities
 3. Future sessions search the wiki via `recall` or the SessionStart hook
+4. User feedback about what to capture reshapes `observation-filter.md`, which
+   future sessions read as the authority

--- a/src/athenaeum/schema/observation-filter.md
+++ b/src/athenaeum/schema/observation-filter.md
@@ -2,7 +2,9 @@
 
 Meta-memory: guides what the system notices and saves. This file is both
 configuration and a living document — the librarian updates it during
-consolidation when patterns emerge in incoming data.
+consolidation when patterns emerge in incoming data, and Claude updates it
+directly when the user gives feedback about what should or shouldn't be
+captured (see **Tuning** below).
 
 ## Always Capture
 
@@ -23,6 +25,37 @@ asking to remember, or when three or more related observations accumulate):
 - **Travel**: frequent destinations, airline/hotel preferences
 - **Health**: relevant context for scheduling or energy management
 - **Hobbies & interests**: non-work topics the user engages with
+
+## Never Capture
+
+Exclusions added here take precedence over the sections above. Populate with
+user feedback like "stop saving X" or "you're being too noisy about Y".
+
+<!-- Example:
+- **Error message snippets**: dumps of stack traces and command output — these
+  are ephemeral and belong in retros, not the wiki (added 2026-04-17 per user).
+-->
+
+## Tuning
+
+This filter is user-tunable. When the user gives feedback about what should
+or shouldn't be captured, update this file directly (Claude's Edit tool is
+fine; `athenaeum run` will pick up the change on the next consolidation pass).
+Log the change with a date and a one-line rationale so future readers can
+trace why an entry exists.
+
+Signals to watch for and how to respond:
+
+| User signal                        | Where to put it            |
+| ---------------------------------- | -------------------------- |
+| "stop saving X" / "too noisy on Y" | **Never Capture**          |
+| "you should have remembered Z"     | **Always Capture**         |
+| "remember more about <topic>"      | **Capture When Reinforced**|
+| "Z matters a lot" (after reinforce)| promote to **Always Capture** |
+
+After editing this file, save a brief meta-observation via the `remember` tool
+(e.g., "Updated observation-filter: added 'Never Capture: stack traces' per
+user feedback") so the tuning is audit-trailed in raw/.
 
 ## Decay Rules
 

--- a/tests/test_observation_filter.py
+++ b/tests/test_observation_filter.py
@@ -1,0 +1,59 @@
+"""Tests for the observation-filter tuning mechanism.
+
+Issue #29: the filter file is the user-tunable authority for what gets
+captured. These tests pin the contract between the filter schema file
+(copied to wiki/_schema/observation-filter.md on init) and the
+CLAUDE.md.example that instructs Claude to read and update it.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+
+from athenaeum.init import init_knowledge_dir
+
+CLAUDE_MD_EXAMPLE = (
+    Path(__file__).parent.parent / "examples" / "claude-code" / "CLAUDE.md.example"
+)
+
+
+def test_filter_has_tuning_sections(tmp_path: Path) -> None:
+    """The scaffolded filter includes the sections Claude needs to tune it."""
+    target = tmp_path / "knowledge"
+    init_knowledge_dir(target)
+
+    filter_text = (target / "wiki" / "_schema" / "observation-filter.md").read_text(
+        encoding="utf-8"
+    )
+    assert "## Always Capture" in filter_text
+    assert "## Capture When Reinforced" in filter_text
+    assert "## Never Capture" in filter_text
+    assert "## Tuning" in filter_text
+
+
+def test_claude_md_example_references_filter_path() -> None:
+    """CLAUDE.md.example points Claude at the filter file as the authority."""
+    text = CLAUDE_MD_EXAMPLE.read_text(encoding="utf-8")
+    assert "~/knowledge/wiki/_schema/observation-filter.md" in text
+
+
+def test_claude_md_example_has_tuning_instructions() -> None:
+    """CLAUDE.md.example tells Claude how to update the filter on feedback."""
+    text = CLAUDE_MD_EXAMPLE.read_text(encoding="utf-8")
+    assert "Tuning the observation filter" in text
+    assert "Stop saving X" in text or "stop saving" in text.lower()
+    assert "Never Capture" in text
+
+
+def test_bundled_filter_matches_init_output(tmp_path: Path) -> None:
+    """The bundled schema is what gets copied (no divergence)."""
+    target = tmp_path / "knowledge"
+    init_knowledge_dir(target)
+
+    schema_pkg = importlib.resources.files("athenaeum.schema")
+    bundled = (schema_pkg / "observation-filter.md").read_text(encoding="utf-8")
+    copied = (target / "wiki" / "_schema" / "observation-filter.md").read_text(
+        encoding="utf-8"
+    )
+    assert copied == bundled


### PR DESCRIPTION
## Summary

Closes #29. Wires the existing `observation-filter.md` schema file into Claude's behavior so user feedback actually reshapes what gets captured.

Before: the filter file was scaffolded on every `athenaeum init`, but nothing read it. `CLAUDE.md.example` had a static "What to remember / What NOT to remember" list that duplicated (and effectively overrode) the filter. No feedback loop.

After: `CLAUDE.md.example` points Claude at `~/knowledge/wiki/_schema/observation-filter.md` as the authority, and includes a new "Tuning the observation filter" section that tells Claude to edit the file directly when the user gives feedback.

## Changes

- `examples/claude-code/CLAUDE.md.example`:
  - Static capture rules replaced by a reference to the filter file + brief fallback
  - New "Tuning the observation filter" section with signal → action examples ("stop saving X" → Never Capture, "you should have remembered Z" → Always Capture, etc.)
  - Instruction to log a meta-observation via `remember` after editing the filter so tuning is audit-trailed in `raw/`

- `src/athenaeum/schema/observation-filter.md`:
  - Adds **Never Capture** section for user-driven exclusions (overrides the positive rules)
  - Adds **Tuning** section with a signal → section lookup table and a note that both Claude and the librarian update it
  - Preamble clarifies dual ownership (librarian pattern detection + direct Claude edits)

- `tests/test_observation_filter.py` — pins the CLAUDE.md.example ↔ filter.md contract

## Why no CLI subcommand

Issue #29 listed "`athenaeum configure` command for interactive filter setup" as one option. I skipped it — the file path is stable and users can `$EDITOR ~/knowledge/wiki/_schema/observation-filter.md` or let Claude edit it. Keeps the CLI surface small and means the filter is editable by humans without any tooling dependency.

## Test plan

- [x] `pytest tests/test_observation_filter.py -v` — 4/4 pass
- [x] `pytest tests/` — 200 pass
- [x] `ruff check src/ tests/` clean
- [ ] CI green across 3.11/3.12/3.13

Generated with Claude Code
