### PR TITLE
fix(cli): serve forwards search_backend + cache_dir to MCP

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -148,6 +148,7 @@ def _cmd_status(args: argparse.Namespace) -> int:
 
 
 def _cmd_serve(args: argparse.Namespace) -> int:
+    from athenaeum.config import load_config
     from athenaeum.mcp_server import create_server
 
     target = args.path.expanduser().resolve()
@@ -159,7 +160,16 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         print("Run 'athenaeum init --path {args.path}' first, then retry.")
         return 1
 
-    server = create_server(raw_root=raw_root, wiki_root=wiki_root)
+    cfg = load_config(target)
+    backend = cfg.get("search_backend", "keyword")
+    cache_dir = Path("~/.cache/athenaeum").expanduser()
+
+    server = create_server(
+        raw_root=raw_root,
+        wiki_root=wiki_root,
+        search_backend=backend,
+        cache_dir=cache_dir,
+    )
     try:
         server.run()
     except KeyboardInterrupt:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,6 +106,60 @@ class TestRebuildIndex:
         assert "Unknown search backend" in capsys.readouterr().err
 
 
+class TestServe:
+    """`athenaeum serve` must forward the configured search_backend + cache_dir
+    to create_server so the MCP `recall` tool uses the vector index when the
+    user has configured `search_backend: vector`. Regression guard against the
+    bug where serve hard-coded defaults (keyword) and silently ignored
+    athenaeum.yaml."""
+
+    def test_serve_reads_vector_backend_from_config(
+        self, knowledge_with_wiki: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (knowledge_with_wiki / "athenaeum.yaml").write_text(
+            "auto_recall: true\nsearch_backend: vector\n"
+        )
+        captured: dict[str, object] = {}
+
+        class _FakeServer:
+            def run(self) -> None:
+                raise KeyboardInterrupt
+
+        def _fake_create_server(**kwargs: object) -> _FakeServer:
+            captured.update(kwargs)
+            return _FakeServer()
+
+        import athenaeum.mcp_server as mcp_mod
+        monkeypatch.setattr(mcp_mod, "create_server", _fake_create_server)
+
+        rc = main(["serve", "--path", str(knowledge_with_wiki)])
+        assert rc == 0
+        assert captured["search_backend"] == "vector"
+        assert captured["wiki_root"] == knowledge_with_wiki / "wiki"
+        assert captured["raw_root"] == knowledge_with_wiki / "raw"
+        assert captured["cache_dir"] is not None
+
+    def test_serve_defaults_to_fts5_from_config_defaults(
+        self, knowledge_with_wiki: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        class _FakeServer:
+            def run(self) -> None:
+                raise KeyboardInterrupt
+
+        def _fake_create_server(**kwargs: object) -> _FakeServer:
+            captured.update(kwargs)
+            return _FakeServer()
+
+        import athenaeum.mcp_server as mcp_mod
+        monkeypatch.setattr(mcp_mod, "create_server", _fake_create_server)
+
+        rc = main(["serve", "--path", str(knowledge_with_wiki)])
+        assert rc == 0
+        assert captured["search_backend"] == "fts5"
+
+
 class TestTestMcp:
     def test_all_steps_pass_with_fastmcp_available(
         self, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary

`athenaeum serve` was silently ignoring the configured search backend.
`_cmd_serve` called `create_server(raw_root=..., wiki_root=...)` without
forwarding `search_backend` or `cache_dir`, so the live MCP `recall` tool
defaulted to keyword even when `athenaeum.yaml` had `search_backend: vector`.

Caught while verifying vector sync end-to-end — live `mcp__athenaeum__recall`
returned keyword scores (8.0) instead of vector distances, despite
`rebuild-index` correctly producing a chromadb collection.

## Changes

- `_cmd_serve` now calls `load_config()`, reads `search_backend`, and passes
  it through with `cache_dir=~/.cache/athenaeum` (same default as
  `rebuild-index`).
- Two regression tests in `TestServe` monkeypatch `create_server` and assert
  the kwargs flow through from config (vector override + fts5 default).

## Test plan

- [x] `pytest tests/test_cli.py::TestServe -v` — 2 passed
- [x] `pytest tests/ -q` — 202 passed
- [x] `ruff check src/ tests/` — clean
- [ ] After merge + MCP restart: live `mcp__athenaeum__recall` returns vector
      distances, not keyword scores

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
