### PR TITLE
fix(hooks): UserPromptSubmit emits hookSpecificOutput wrapper (#39)

### DIFF
--- a/examples/claude-code/user-prompt-recall.sh
+++ b/examples/claude-code/user-prompt-recall.sh
@@ -79,4 +79,4 @@ while IFS=$'\t' read -r fname name score; do
   echo "$fname" >> "$SEEN_FILE"
 done <<< "$RESULTS"
 
-printf '{"additionalContext":"[Knowledge context] Wiki pages relevant to this message (use `recall` MCP tool for full details):\\n%s"}' "$MATCHES"
+printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"[Knowledge context] Wiki pages relevant to this message (use `recall` MCP tool for full details):\\n%s"}}' "$MATCHES"

--- a/src/athenaeum/mcp_server.py
+++ b/src/athenaeum/mcp_server.py
@@ -292,11 +292,18 @@ def create_server(
     def recall(query: str, top_k: int = 5) -> str:
         """Search the knowledge wiki for pages relevant to a query.
 
-        Uses keyword matching against frontmatter (name, aliases, tags) and
-        body text. Frontmatter matches are weighted higher for relevance.
+        Dispatches to the configured search backend:
+
+        - ``keyword`` (default fallback): in-memory scoring over frontmatter
+          and body; integer-ish relevance scores, higher is better.
+        - ``fts5``: SQLite FTS5 over a pre-built index; BM25 scores,
+          higher is better.
+        - ``vector``: chromadb embeddings over a pre-built index; distance
+          scores, lower is better.
 
         Args:
-            query: Search query string (keywords, names, topics).
+            query: Search query string (keywords, names, topics — or natural
+                language for semantic recall under the vector backend).
             top_k: Maximum number of results to return (default 5).
 
         Returns:

--- a/tests/test_shell_hooks.py
+++ b/tests/test_shell_hooks.py
@@ -135,11 +135,17 @@ class TestUserPromptRecall:
             capture_output=True, text=True, timeout=10,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        assert result.stdout, "expected additionalContext JSON on stdout"
+        assert result.stdout, "expected hookSpecificOutput JSON on stdout"
 
         payload = json.loads(result.stdout)
-        assert "additionalContext" in payload
-        assert "Customer Development" in payload["additionalContext"]
+        assert "hookSpecificOutput" in payload, (
+            "Claude Code requires additionalContext to be nested under "
+            "hookSpecificOutput with hookEventName; flat {'additionalContext': ...} "
+            "is silently ignored. See issue #39."
+        )
+        hook_output = payload["hookSpecificOutput"]
+        assert hook_output.get("hookEventName") == "UserPromptSubmit"
+        assert "Customer Development" in hook_output["additionalContext"]
 
     def test_silent_on_short_prompt(self, hook_env: dict[str, str]) -> None:
         _require("bash")


### PR DESCRIPTION
## Summary

- Fix `examples/claude-code/user-prompt-recall.sh` to emit the current
  Claude Code hook-output schema. The old flat
  `{"additionalContext": "..."}` form is silently ignored; output must be
  nested under `hookSpecificOutput` with `hookEventName: "UserPromptSubmit"`.
- Update `tests/test_shell_hooks.py` to assert the nested shape so the
  next schema drift fails CI, not end users.
- Refresh the `recall` MCP tool docstring — it claimed "Uses keyword
  matching" but has dispatched to the configured backend (keyword /
  FTS5 / vector) since the search abstraction landed.

Closes #39.

## Why this matters

Caught while verifying end-to-end vector recall after merging #38. The
MCP `recall` tool works correctly with the vector backend, but the
UserPromptSubmit hook appeared broken — it ran successfully, produced
stdout, exited 0, and Claude saw nothing. Root cause: schema drift on
Claude Code's side; our example (and the hook wrapper used in live
cwc config) still emitted the deprecated shape.

## Test plan

- [x] `pytest tests/ -q` — 202 passed
- [x] `ruff check src/ tests/` — clean
- [x] Manual hook invocation emits the new shape (verified with
      `python3 -m json.tool` on stdout)
- [ ] After merge: fresh session "quote the `[Knowledge context]` block
      about Vandelay Industries" returns the injected page names without tool
      calls

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
