### PR TITLE
feat(hooks): LLM query-topic extraction for recall quality

### DIFF
--- a/examples/claude-code/user-prompt-recall.sh
+++ b/examples/claude-code/user-prompt-recall.sh
@@ -3,10 +3,16 @@
 # the user's message.
 #
 # Queries a precomputed SQLite FTS5 index (built by session-start-recall.sh
-# at SessionStart). No Python needed at query time — uses sqlite3 + jq.
+# at SessionStart). Typical runtime: <50ms for FTS5 alone, ~500-1500ms
+# when the optional LLM topic extractor is active.
 #
-# Tracks which pages were already surfaced this session to avoid repeating.
-# Typical runtime: <50ms.
+# Query rewriting (optional): if `athenaeum query-topics` is available and
+# ANTHROPIC_API_KEY is set, the raw prompt is first run through Haiku to
+# extract substantive topics (entity names, proper nouns) while ignoring
+# meta-instructions like "quote verbatim" or "don't call tools". This
+# rescues named-entity recall on instruction-heavy prompts. When unset or
+# the extractor returns empty, the hook falls back to a regex+stopword
+# keyword extractor.
 #
 # Configure in ~/.claude/settings.json:
 #   "hooks": {
@@ -24,6 +30,7 @@
 set -euo pipefail
 
 DB_FILE="${HOME}/.cache/athenaeum/wiki-index.db"
+ATHENAEUM_CLI="${ATHENAEUM_CLI:-athenaeum}"
 
 if [ ! -f "$DB_FILE" ]; then
   exit 0
@@ -39,15 +46,28 @@ if [ -z "$PROMPT" ] || [ ${#PROMPT} -lt 8 ]; then
 fi
 
 # ── Extract search terms ────────────────────────────────────────────────
-STOPWORDS="the and for are but not you all can had her was one our out has his how its let may new now old see way who did get got him she too use with from have this that they will been call come each find give help here just know like long look make many more most much must next only over said same some such take tell than them then very want well went were what when which while work also back been being both came does done down even goes going good keep last left life line made need never part place point right show small still think those turn used using where would about after again could every great might often other shall should since start state still there these thing think three through under until which while world would years your into just like made over said some than them then time very want what when will with year does really right going being looking trying running check please sure okay yeah thanks"
+# First try the LLM topic extractor (rescues named entities on
+# instruction-heavy prompts). Falls back to the regex extractor when the
+# CLI isn't installed, ANTHROPIC_API_KEY isn't set, or the extractor
+# times out / errors.
+TERMS=""
+if command -v "$ATHENAEUM_CLI" >/dev/null 2>&1 && [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  TERMS=$("$ATHENAEUM_CLI" query-topics "$PROMPT" --timeout 3 2>/dev/null || echo "")
+fi
 
-TERMS=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '\n' | grep -vE "^(${STOPWORDS})$" | grep -E '.{3,}' | sort -u | head -8)
+if [ -z "$TERMS" ]; then
+  STOPWORDS="the and for are but not you all can had her was one our out has his how its let may new now old see way who did get got him she too use with from have this that they will been call come each find give help here just know like long look make many more most much must next only over said same some such take tell than them then very want well went were what when which while work also back been being both came does done down even goes going good keep last left life line made need never part place point right show small still think those turn used using where would about after again could every great might often other shall should since start state still there these thing think three through under until which while world would years your into just like made over said some than them then time very want what when will with year does really right going being looking trying running check please sure okay yeah thanks"
+  TERMS=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '\n' | grep -vE "^(${STOPWORDS})$" | grep -E '.{3,}' | sort -u | head -8)
+fi
 
 if [ -z "$TERMS" ]; then
   exit 0
 fi
 
-FTS_QUERY=$(echo "$TERMS" | sed 's/.*/"&"/' | tr '\n' ' ' | sed 's/ *$//' | sed 's/" "/\" OR \"/g')
+# Build FTS5 query: "phrase one" OR "phrase two" ...
+# Lowercase each line (FTS5 indexes lowercased tokens) and wrap in quotes
+# for phrase matching — phrases like "Return Path" stay intact.
+FTS_QUERY=$(echo "$TERMS" | tr '[:upper:]' '[:lower:]' | sed 's/.*/"&"/' | tr '\n' ' ' | sed 's/ *$//' | sed 's/" "/\" OR \"/g')
 
 # ── Session dedup ───────────────────────────────────────────────────────
 SEEN_FILE="/tmp/knowledge-seen-${SESSION_ID}"

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -82,6 +82,23 @@ def main(argv: list[str] | None = None) -> int:
         help="Don't delete the temp knowledge dir on exit (for debugging)",
     )
 
+    # query-topics command — LLM-based topic extraction for hook query rewriting
+    query_topics_parser = subparsers.add_parser(
+        "query-topics",
+        help="Extract substantive search topics from a prompt (Haiku). "
+             "Used by the UserPromptSubmit hook to rewrite queries before "
+             "FTS5/vector search. Prints one topic per line to stdout; "
+             "empty output means fall back to the caller's built-in extractor.",
+    )
+    query_topics_parser.add_argument(
+        "prompt", type=str,
+        help="The user's raw message.",
+    )
+    query_topics_parser.add_argument(
+        "--timeout", type=float, default=3.0,
+        help="Seconds to wait for the LLM before giving up (default: 3.0)",
+    )
+
     # rebuild-index command — rebuild the search index out-of-band
     rebuild_parser = subparsers.add_parser(
         "rebuild-index",
@@ -120,6 +137,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "rebuild-index":
         return _cmd_rebuild_index(args)
+
+    if args.command == "query-topics":
+        return _cmd_query_topics(args)
 
     if args.command == "test-mcp":
         return _cmd_test_mcp(args)
@@ -237,6 +257,15 @@ def _cmd_rebuild_index(args: argparse.Namespace) -> int:
 
     print(f"Unknown search backend: {backend}", file=sys.stderr)
     return 1
+
+
+def _cmd_query_topics(args: argparse.Namespace) -> int:
+    """Print extracted topics, one per line. Empty output = fall back."""
+    from athenaeum.query_topics import extract_topics
+
+    for topic in extract_topics(args.prompt, timeout=args.timeout):
+        print(topic)
+    return 0
 
 
 def _cmd_test_mcp(args: argparse.Namespace) -> int:

--- a/src/athenaeum/query_topics.py
+++ b/src/athenaeum/query_topics.py
@@ -1,0 +1,102 @@
+"""LLM-based topic extraction for query rewriting.
+
+The UserPromptSubmit hook's recall quality degrades on instruction-heavy
+prompts where the actual topic is buried in meta-instructions (e.g.
+"quote the block about Return Path verbatim"). A keyword-by-alphabetical-
+sort extractor drops proper nouns; embedding the whole prompt drifts the
+semantic center away from the buried topic.
+
+This module runs a cheap LLM over the prompt with a system message that
+asks it to extract substantive topics while ignoring meta-commentary.
+The extracted topics are then used to drive FTS5 or vector search in
+the hook.
+
+If the API is unavailable, the function returns an empty list and the
+caller is expected to fall back to its existing extractor. No exception
+escapes — every failure mode collapses to the empty-list fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+
+log = logging.getLogger("athenaeum")
+
+DEFAULT_TOPIC_MODEL = "claude-haiku-4-5-20251001"
+
+_SYSTEM_PROMPT = (
+    "You extract substantive search topics from a user's message for a "
+    "librarian to use against a wiki. Return ONLY a JSON array of short "
+    "topic strings — proper nouns, entity names, company names, project "
+    "names, concrete concepts. Ignore meta-instructions (\"don't call "
+    "tools\", \"quote verbatim\", \"say so\"), generic verbs, and filler. "
+    "Prefer the exact casing the user used. Return at most 8 topics. "
+    "If the message has no substantive topic, return []."
+)
+
+_USER_TEMPLATE = (
+    "User message:\n---\n{prompt}\n---\n\n"
+    "Respond with JSON only, no prose. Example: [\"Return Path\", \"lean startup\"]"
+)
+
+
+def _get_topic_model() -> str:
+    return os.environ.get("ATHENAEUM_TOPIC_MODEL", DEFAULT_TOPIC_MODEL)
+
+
+def extract_topics(prompt: str, timeout: float = 3.0) -> list[str]:
+    """Extract substantive search topics from a user prompt.
+
+    Returns an empty list (never raises) on any failure: missing API key,
+    missing anthropic SDK, network/timeout, malformed response. The hook
+    treats an empty result as "fall back to the built-in extractor".
+
+    Args:
+        prompt: The raw user message.
+        timeout: Seconds to wait for the API call before giving up.
+    """
+    if not prompt or len(prompt.strip()) < 4:
+        return []
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        return []
+
+    try:
+        import anthropic
+    except ImportError:
+        return []
+
+    try:
+        client = anthropic.Anthropic(api_key=api_key, timeout=timeout, max_retries=0)
+        response = client.messages.create(
+            model=_get_topic_model(),
+            max_tokens=256,
+            system=_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": _USER_TEMPLATE.format(prompt=prompt)}],
+        )
+    except Exception as exc:
+        log.debug("query_topics: API call failed: %s", exc)
+        return []
+
+    try:
+        text = response.content[0].text.strip()
+    except (AttributeError, IndexError, TypeError):
+        return []
+
+    match = re.search(r"\[.*\]", text, re.DOTALL)
+    if not match:
+        return []
+
+    try:
+        items = json.loads(match.group())
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(items, list):
+        return []
+
+    return [str(item).strip() for item in items if isinstance(item, str) and item.strip()][:8]

--- a/tests/test_query_topics.py
+++ b/tests/test_query_topics.py
@@ -1,0 +1,148 @@
+"""Tests for athenaeum.query_topics — LLM-based topic extraction.
+
+The module must collapse every failure mode (missing key, SDK missing,
+timeout, bad JSON, non-string items) to an empty list so the hook can
+cleanly fall back to its built-in extractor. These tests pin that
+contract.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from athenaeum import query_topics
+
+
+def _mock_response(text: str) -> Any:
+    return SimpleNamespace(content=[SimpleNamespace(text=text)])
+
+
+def test_returns_empty_when_api_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert query_topics.extract_topics("Tell me about Return Path") == []
+
+
+def test_returns_empty_on_short_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    assert query_topics.extract_topics("hi") == []
+    assert query_topics.extract_topics("") == []
+    assert query_topics.extract_topics("   ") == []
+
+
+def test_extracts_topics_from_instruction_heavy_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    captured: dict[str, Any] = {}
+
+    class _FakeMessages:
+        def create(self, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return _mock_response('["Return Path", "consulting engagement"]')
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["__client_kwargs__"] = kwargs
+            self.messages = _FakeMessages()
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "Anthropic", _FakeClient)
+
+    topics = query_topics.extract_topics(
+        "Without calling any tools, quote the block about Return Path verbatim."
+    )
+    assert topics == ["Return Path", "consulting engagement"]
+    assert captured["model"] == query_topics.DEFAULT_TOPIC_MODEL
+    assert captured["__client_kwargs__"]["api_key"] == "sk-test"
+    assert captured["__client_kwargs__"]["max_retries"] == 0
+
+
+def test_returns_empty_when_api_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    class _FakeClient:
+        def __init__(self, **_: Any) -> None:
+            self.messages = self
+
+        def create(self, **_: Any) -> Any:
+            raise RuntimeError("network fell over")
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "Anthropic", _FakeClient)
+
+    assert query_topics.extract_topics("Tell me about Return Path") == []
+
+
+def test_returns_empty_on_malformed_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    class _FakeClient:
+        def __init__(self, **_: Any) -> None:
+            self.messages = self
+
+        def create(self, **_: Any) -> Any:
+            return _mock_response("sorry, I can't help with that")
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "Anthropic", _FakeClient)
+
+    assert query_topics.extract_topics("Tell me about Return Path") == []
+
+
+def test_filters_non_string_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    class _FakeClient:
+        def __init__(self, **_: Any) -> None:
+            self.messages = self
+
+        def create(self, **_: Any) -> Any:
+            return _mock_response('["Return Path", 42, null, "", "  ", "Kalshi"]')
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "Anthropic", _FakeClient)
+
+    assert query_topics.extract_topics("anything goes") == ["Return Path", "Kalshi"]
+
+
+def test_caps_at_eight_topics(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    class _FakeClient:
+        def __init__(self, **_: Any) -> None:
+            self.messages = self
+
+        def create(self, **_: Any) -> Any:
+            many = [f"topic{i}" for i in range(20)]
+            import json as _json
+            return _mock_response(_json.dumps(many))
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "Anthropic", _FakeClient)
+
+    topics = query_topics.extract_topics("some prompt with topics")
+    assert len(topics) == 8
+    assert topics[0] == "topic0"
+
+
+def test_respects_topic_model_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("ATHENAEUM_TOPIC_MODEL", "claude-haiku-3-5")
+    captured: dict[str, Any] = {}
+
+    class _FakeClient:
+        def __init__(self, **_: Any) -> None:
+            self.messages = self
+
+        def create(self, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return _mock_response("[]")
+
+    import anthropic
+    monkeypatch.setattr(anthropic, "Anthropic", _FakeClient)
+
+    query_topics.extract_topics("some prompt")
+    assert captured["model"] == "claude-haiku-3-5"


### PR DESCRIPTION
## Summary

- Adds `athenaeum.query_topics`: a cheap Haiku 4.5 preprocessor that extracts substantive search topics (entity names, proper nouns, concrete concepts) from a user prompt while ignoring meta-instructions.
- Exposes `athenaeum query-topics <prompt>` for shell-hook consumption (line-delimited stdout, empty = caller falls back).
- Wires the example UserPromptSubmit hook to call the CLI when available and feed topics into the FTS5 `MATCH` query.

Fixes recall quality on instruction-heavy prompts like:

> *Without calling any tools, quote the `[Knowledge context]` block about Vandelay Industries verbatim.*

Previously:
- **FTS5** `sort -u | head -8` drops `return` (10th alphabetically) → miss.
- **Vector** embedding averages over "without tools", "quote", "block", "verbatim" → semantic drift away from the buried proper noun.

With Haiku preprocessing the hook sees `["Vandelay Industries"]` and both backends surface the right page.

## Failure-mode contract

Every error path in `query_topics` returns `[]` (never raises):

- Missing `ANTHROPIC_API_KEY`
- Missing `anthropic` SDK
- Network / timeout
- Non-JSON response text
- Non-string or empty items in the list

The hook treats empty output as "fall back to the regex extractor" — so turning this on is strictly additive and cannot regress turns where the API is unavailable.

## Cost / latency

- ~300–1500ms per turn (inside the hook's 5s outer timeout).
- ~$0.0001 per turn at Haiku 4.5 pricing — negligible.
- Override model via `ATHENAEUM_TOPIC_MODEL`.

## Test plan

- [x] 8 new unit tests (`tests/test_query_topics.py`) pin the contract: missing key, short prompt, JSON parsing, API error, malformed JSON, non-string filtering, 8-item cap, env override.
- [x] Full suite: `210 passed`.
- [x] `ruff check src/ tests/` clean.
- [x] Live API check with real key: extracts `Vandelay Industries` from the failing prompt.
- [ ] Live verification in a fresh Claude Code session under `SEARCH_BACKEND=vector` against `~/knowledge/` — covered by the companion cwc hook edit.

Closes #41.
