### PR TITLE
chore: OSS review pass — v0.2.0 packaging, docs, example-hook hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,11 @@ about: Report a reproducible bug
 labels: bug
 ---
 
+> **Before you submit:** `~/.cache/athenaeum/config.env` may contain
+> your `ANTHROPIC_API_KEY` (on setups that use the 1Password bootstrap).
+> Redact it before pasting anything from that file. The same applies to
+> any shell env dump that includes `ANTHROPIC_API_KEY=...`.
+
 ## Summary
 
 <!-- One-sentence description of the bug. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a reproducible bug
+labels: bug
+---
+
+## Summary
+
+<!-- One-sentence description of the bug. -->
+
+## Reproduction
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+## Actual behaviour
+
+## Environment
+
+- Athenaeum version: `athenaeum --version`
+- Python version: `python --version`
+- OS:
+- Search backend: (fts5 / vector / unused)
+- Relevant config from `athenaeum.yaml`:
+
+## Logs / traceback
+
+```
+<!-- paste here -->
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Propose a new capability
+labels: enhancement
+---
+
+## Problem
+
+<!-- What are you trying to do? What's not working with the current behaviour? -->
+
+## Proposal
+
+<!-- What would solve it? Sketch the API / config / UX. -->
+
+## Alternatives considered
+
+## Willing to contribute?
+
+- [ ] Yes, I plan to open a PR
+- [ ] Happy to discuss but not implement
+- [ ] Just reporting the idea

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,9 @@ about: Propose a new capability
 labels: enhancement
 ---
 
+> **If you paste logs or config:** `~/.cache/athenaeum/config.env` may
+> contain your `ANTHROPIC_API_KEY`. Redact before pasting.
+
 ## Problem
 
 <!-- What are you trying to do? What's not working with the current behaviour? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- 1-3 bullets describing what and why. -->
+
+## Changes
+
+<!-- List of substantive changes. -->
+
+## Test plan
+
+- [ ] `pytest tests/ -v`
+- [ ] `ruff check src/ tests/`
+- [ ] Manually exercised any behaviour this changes
+
+## Hook changes only
+
+<!-- Delete this section if the PR doesn't touch scripts/hooks/ or examples/claude-code/. -->
+
+- [ ] Ran the hook against a real UserPromptSubmit payload in a fresh shell
+- [ ] Confirmed injected `additionalContext` appears in the model reply
+- [ ] Verified both `SEARCH_BACKEND=fts5` and `SEARCH_BACKEND=vector` (if applicable)
+
+## Related issues
+
+<!-- Closes #123, refs #456 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,16 @@
 
 <!-- Delete this section if the PR doesn't touch scripts/hooks/ or examples/claude-code/. -->
 
-- [ ] Ran the hook against a real UserPromptSubmit payload in a fresh shell
+- [ ] Ran the hook against a real UserPromptSubmit payload in a fresh shell:
+
+      ```bash
+      echo '{"prompt":"tell me about innovation accounting","session_id":"pr-test"}' \
+        | bash examples/claude-code/user-prompt-recall.sh
+      # Expect: one-line JSON with a `hookSpecificOutput.additionalContext`
+      # key listing matching wiki pages. Anything else (empty, flat
+      # `{"additionalContext":...}`, multi-line) is a regression.
+      ```
+
 - [ ] Confirmed injected `additionalContext` appears in the model reply
 - [ ] Verified both `SEARCH_BACKEND=fts5` and `SEARCH_BACKEND=vector` (if applicable)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to Athenaeum are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2026-04-17
+
+### Added
+- **Vector search backend** with chromadb + `all-MiniLM-L6-v2` (#31, #32)
+- `athenaeum query-topics` CLI — Haiku-based query preprocessor that extracts substantive topics from instruction-heavy prompts and ignores meta-instructions (#41, #42)
+- `athenaeum rebuild-index` CLI for on-demand index rebuilds (#34)
+- `athenaeum test-mcp` CLI subcommand for verifying MCP setup (#36)
+- Observation filter wired as the tunable capture authority for the sidecar flow (#37)
+- `athenaeum.yaml` config with `auto_recall` toggle and `search_backend` selection (#30)
+- Example Claude Code hooks — SessionStart builds the FTS5 index, UserPromptSubmit queries it per turn, PreCompact nudges save-before-compact
+- FTS5-based per-turn wiki recall hook
+- `docs/recall-architecture.md` describing the hybrid FTS5+vector pipeline, why each backend is load-bearing, and the four invariants a future "simplification" must not remove
+- Example hooks (`user-prompt-recall.sh`, `session-start-recall.sh`) updated to match production hardening — `set -a`/`set +a` around config sourcing so child processes inherit `ANTHROPIC_API_KEY`; hybrid FTS5+vector merge; optional 1Password bootstrap of `ANTHROPIC_API_KEY` at SessionStart
+- README sections for the `[vector]` extra and the `athenaeum query-topics` subcommand
+- `SECURITY.md` with private disclosure process
+- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
+- Issue templates (bug / feature) and PR template with a "hook changes only" live-run checklist
+- Apache 2.0 `SPDX-License-Identifier` header on all Python source files
+
+### Fixed
+- **UserPromptSubmit hook JSON shape** — must be `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"..."}}`; a flat `{"additionalContext":...}` payload was silently ignored by Claude Code (#39, #40)
+- **Stale chromadb state across rebuilds** — `VectorBackend.build_index` now nukes `vector_dir` and calls `SharedSystemClient.clear_system_cache()` to avoid "Collection already exists" on repeat builds in the same process (#33)
+- `serve` CLI now forwards `search_backend` + `cache_dir` to the MCP server (#38)
+- Recall now fires after the first message, not only at session start
+- Stale "vector backend is a stub for issue #32" comment in `search.py`
+
+## [0.1.0] - 2026-04-16
+
+Initial public release — a genericised extraction of the Kromatic
+knowledge librarian.
+
+### Added
+- Tiered compilation pipeline (programmatic → Haiku → Sonnet → human escalation)
+- Append-only raw intake with frontmatter-driven entity schema
+- Configurable schemas and observation filter
+- `athenaeum init` CLI to bootstrap a new knowledge directory
+- `athenaeum run` pipeline CLI with `--dry-run`, `--max-files`, `--max-api-calls`
+- `athenaeum status` — entity counts, pending files, last run
+- MCP memory server (`athenaeum serve`) exposing `remember` and `recall` tools
+- Token tracking and per-run cost estimates
+- Test suite extracted from upstream + CI coverage enforcement (`>=75%`)
+- Transactional writes, type-safety hardening, prompt-injection mitigation, API budget caps
+
+[Unreleased]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/Kromatic-Innovation/athenaeum/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-17
 
+> **Adopter note.** The vector backend and the Claude Code hook flow ship
+> working — but the hook flow assumes you follow the hybrid-recall pattern
+> described in [`docs/recall-architecture.md`](docs/recall-architecture.md).
+> Four load-bearing invariants (`set -a` around config sourcing, hybrid
+> FTS5+vector merge, `hookSpecificOutput.hookEventName` wrapper, console
+> API key vs `CLAUDE_CODE_OAUTH_TOKEN`) each shipped CI-green the first
+> time they broke — every one of them is a silent failure mode. Read
+> `docs/recall-architecture.md` before simplifying any of them.
+
 ### Added
 - **Vector search backend** with chromadb + `all-MiniLM-L6-v2` (#31, #32)
 - `athenaeum query-topics` CLI — Haiku-based query preprocessor that extracts substantive topics from instruction-heavy prompts and ignores meta-instructions (#41, #42)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behaviour:
+
+- Trolling, insulting or derogatory comments, personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at **open-source@kromatic.com**. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ reference.
 | `ATHENAEUM_WRITE_MODEL` | No | Override Tier 3 model (default: `claude-sonnet-4-6`) |
 | `ATHENAEUM_TOPIC_MODEL` | No | Override query-topic model (default: `claude-haiku-4-5-20251001`) |
 | `ATHENAEUM_OP_KEY_PATH` | No | 1Password path for the session-start ANTHROPIC_API_KEY bootstrap (default: `op://Agent Tools/Anthropic API Key/credential`) |
+| `AUTO_RECALL` | No | Per-turn recall on/off (hook shell env; overrides `athenaeum.yaml`'s `auto_recall`). Default: `true` |
+| `SEARCH_BACKEND` | No | `fts5` or `vector` (hook shell env; overrides `athenaeum.yaml`'s `search_backend`). Default: `fts5` |
+| `ATHENAEUM_HOOK_DEBUG` | No | Set to `1` to log vector-backend errors from `user-prompt-recall.sh` to stderr |
+
+**Note on shell-env overrides.** `AUTO_RECALL` and `SEARCH_BACKEND` are
+read from the shell environment after the hook sources
+`~/.cache/athenaeum/config.env`, so anything exported in your shell
+profile beats the cached config. That's intentional (it lets an adopter
+A/B-test a backend without editing `athenaeum.yaml`), but it's also
+the first thing to check when the hook "ignores" a config change.
 
 **Note on Claude Code auth.** Claude Code's own `CLAUDE_CODE_OAUTH_TOKEN`
 is scoped to its inference endpoint and the general Anthropic Messages

--- a/README.md
+++ b/README.md
@@ -70,6 +70,39 @@ pip install athenaeum[mcp]
 athenaeum serve --path ~/knowledge
 ```
 
+### Vector search (optional)
+
+Athenaeum supports a vector search backend (chromadb + `all-MiniLM-L6-v2`)
+for semantic recall alongside the default FTS5 keyword backend.
+
+```bash
+pip install athenaeum[vector]
+```
+
+Enable it in `athenaeum.yaml`:
+
+```yaml
+search_backend: vector
+```
+
+The recall hook runs a **hybrid FTS5 + vector merge** when vector is
+configured — FTS5 rescues short proper-noun queries that collide in
+vector space, vector discovers semantic neighbours with no lexical
+overlap. See [`docs/recall-architecture.md`](docs/recall-architecture.md)
+for why the hybrid is load-bearing and what invariants must not be
+removed.
+
+### Query-topic extraction (optional)
+
+`athenaeum query-topics "your prompt"` runs a Haiku classifier that
+returns substantive topics and ignores meta-instructions. The example
+recall hook uses it to rescue named-entity recall on instruction-heavy
+prompts like *"Without calling any tools, quote the block about Return
+Path verbatim."* — where the regex fallback drops "Return Path" as
+the 10th alphabetical term and vector embedding drifts toward hook
+pages. Falls back silently to the regex extractor if the API key or
+CLI is unavailable.
+
 **Claude Code integration** — add to your MCP config and it auto-starts with every session:
 
 ```bash
@@ -106,6 +139,15 @@ See `examples/claude-code/` for complete setup instructions and example scripts.
 | `ANTHROPIC_API_KEY` | Yes (unless `--dry-run`) | API key for Tier 2/3 LLM calls |
 | `ATHENAEUM_CLASSIFY_MODEL` | No | Override Tier 2 model (default: `claude-haiku-4-5-20251001`) |
 | `ATHENAEUM_WRITE_MODEL` | No | Override Tier 3 model (default: `claude-sonnet-4-6`) |
+| `ATHENAEUM_TOPIC_MODEL` | No | Override query-topic model (default: `claude-haiku-4-5-20251001`) |
+| `ATHENAEUM_OP_KEY_PATH` | No | 1Password path for the session-start ANTHROPIC_API_KEY bootstrap (default: `op://Agent Tools/Anthropic API Key/credential`) |
+
+**Note on Claude Code auth.** Claude Code's own `CLAUDE_CODE_OAUTH_TOKEN`
+is scoped to its inference endpoint and the general Anthropic Messages
+API rejects it with `401 OAuth authentication is currently not supported`.
+The pipeline and the example hooks need a separate console API key —
+see [`docs/recall-architecture.md`](docs/recall-architecture.md#anthropic_api_key-bootstrap-sessionstart)
+for the 1Password bootstrap pattern.
 
 ### Raw file format
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ pip install athenaeum[mcp]
 athenaeum serve --path ~/knowledge
 ```
 
+Smoke-test the round-trip without a live session:
+
+```bash
+athenaeum test-mcp
+#   PASS  remember_write
+#   PASS  recall_search (keyword)
+#   PASS  create_server (FastMCP)
+#
+# 3 passed, 0 failed
+```
+
+When wired to Claude Code, the agent can save facts mid-conversation:
+
+> **User:** Tristan's partner is Amanda; they met at Stanford GSB.
+>
+> *(Claude calls `remember(content="Tristan's partner is Amanda; they met at Stanford GSB.", source="claude-session")`)*
+>
+> A raw observation lands in `raw/claude-session/20260417T…-…md`. On the
+> next `athenaeum run`, the pipeline compiles it into Tristan's wiki
+> entity (under "Key Contacts") and Amanda's own entity if she doesn't
+> exist yet. Later sessions can ask *"who is Amanda?"* and `recall`
+> returns the compiled page.
+
 ### Vector search (optional)
 
 Athenaeum supports a vector search backend (chromadb + `all-MiniLM-L6-v2`)
@@ -95,13 +118,19 @@ removed.
 ### Query-topic extraction (optional)
 
 `athenaeum query-topics "your prompt"` runs a Haiku classifier that
-returns substantive topics and ignores meta-instructions. The example
-recall hook uses it to rescue named-entity recall on instruction-heavy
-prompts like *"Without calling any tools, quote the block about Return
-Path verbatim."* — where the regex fallback drops "Return Path" as
-the 10th alphabetical term and vector embedding drifts toward hook
-pages. Falls back silently to the regex extractor if the API key or
-CLI is unavailable.
+returns substantive topics and ignores meta-instructions:
+
+```bash
+$ athenaeum query-topics "Without calling any tools, quote the block about Return Path verbatim"
+Return Path
+```
+
+Compare to the naive regex+stopword fallback, which returns
+`block,calling,quote,return,tools,verbatim,without` — burying "Return
+Path" behind meta-instruction tokens and dropping the phrase boundary
+entirely. The example recall hook uses `query-topics` to rescue
+named-entity recall on instruction-heavy prompts; it falls back
+silently to the regex extractor if the API key or CLI is unavailable.
 
 **Claude Code integration** — add to your MCP config and it auto-starts with every session:
 
@@ -130,7 +159,9 @@ This gives you:
 - **Auto-remember** — Claude proactively saves important facts without being asked
 - **Context checkpointing** — observations are saved before context window compaction
 
-See `examples/claude-code/` for complete setup instructions and example scripts.
+See [`examples/claude-code/README.md`](examples/claude-code/README.md) for
+complete setup instructions, a smoke test, and the full environment-variable
+reference.
 
 ### Environment variables
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,7 @@ Athenaeum writes files to a user-controlled knowledge directory and makes authen
 - **Path traversal** via entity filenames or `source` parameters
 - **API key handling** — we expect callers to source keys from their own secret stores; don't embed keys in configuration or logs
 - **MCP server input handling** — the `remember` / `recall` tools accept arbitrary text from AI agents
+- **Example hooks under `examples/claude-code/`** — the shell hooks touch `~/.cache/athenaeum/config.env` (which on 1Password-bootstrap setups contains `ANTHROPIC_API_KEY`) and inject text into Claude Code's context. Treat vulnerabilities in them as library vulnerabilities — command injection, path traversal, secret leakage, and symlink attacks are all in-scope.
 
 The raw intake is intentionally append-only. Attacks that rely on overwriting trusted entities are out of scope unless they bypass the append-only invariant.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported versions
+
+Athenaeum is pre-1.0. Only the latest release on the `develop` branch is supported with security patches.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately via email to **open-source@kromatic.com** with the subject prefix `[athenaeum security]`. Do **not** open a public GitHub issue for security problems.
+
+Include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce (ideally a minimal failing test or PoC)
+- Affected version or commit SHA
+
+We aim to:
+
+- Acknowledge your report within 3 business days
+- Confirm the vulnerability (or explain why it isn't one) within 10 business days
+- Ship a fix and public advisory within 30 business days of confirmation
+
+## Scope
+
+Athenaeum writes files to a user-controlled knowledge directory and makes authenticated calls to the Anthropic API. Security-relevant areas include:
+
+- **Prompt injection** against the tiered LLM pipeline (Tier 2/3) and the `query-topics` preprocessor
+- **Path traversal** via entity filenames or `source` parameters
+- **API key handling** — we expect callers to source keys from their own secret stores; don't embed keys in configuration or logs
+- **MCP server input handling** — the `remember` / `recall` tools accept arbitrary text from AI agents
+
+The raw intake is intentionally append-only. Attacks that rely on overwriting trusted entities are out of scope unless they bypass the append-only invariant.
+
+## Out of scope
+
+- Issues in `[vector]` dependencies (report upstream to chromadb)
+- Issues in the Anthropic SDK (report upstream to anthropic-sdk-python)
+- Social-engineering attacks against maintainers or downstream adopters

--- a/docs/recall-architecture.md
+++ b/docs/recall-architecture.md
@@ -83,12 +83,21 @@ Override path via `ATHENAEUM_OP_KEY_PATH`. The fetched key is cached in `~/.cach
 
 ## Load-bearing invariants
 
-Do not simplify any of these without reading this page and the related commit history.
+Do not simplify any of these without reading this page and the related commit history. Every one of them is a **silent failure mode** — no exception, no log, just degraded recall quality. The "What breaks" column is what forces a future reviewer to think twice before deleting the guard.
 
-- `set -a` around `source "$CONFIG_ENV"` — required for subprocess env inheritance.
-- FTS5 is maintained even when vector is primary — required for short-query rescue.
-- JSON output shape includes `hookSpecificOutput.hookEventName` — a flat `{"additionalContext":...}` payload is silently ignored.
-- Console API key is fetched separately from the Claude Code OAuth token — OAuth is rejected by the Messages API with 401.
+| Invariant | Why it's load-bearing | What breaks if removed |
+|---|---|---|
+| `set -a` around `source "$CONFIG_ENV"` | `source` without `-a` sets vars only in the hook shell; child processes inherit a clean env. | `athenaeum query-topics` silently runs keyless. The regex fallback runs on 100% of prompts. Named-entity recall on instruction-heavy prompts degrades to 0. No error logged — the Haiku call just returns empty. |
+| FTS5 maintained even when vector is primary | Short proper-noun queries ("Return Path") embed closer to generic pages containing the common word than to the sparse entity page. | Queries like "Return Path" return `reference_local_paths.md` instead of the entity. The model still gets *an* injection, so the hook looks healthy — the wrong page just quietly crowds out the right one. |
+| `hookSpecificOutput.hookEventName` wrapper | Claude Code discards flat `{"additionalContext":...}` payloads without logging; the hook runs CI-green, `bash -n` is clean, stdout is valid JSON. | `additionalContext` never reaches the model. Zero recall signal. Only detectable by asking the model "did you receive a knowledge context block?" or by reading Claude Code source. |
+| Console API key vs `CLAUDE_CODE_OAUTH_TOKEN` | Messages API rejects OAuth tokens with `401 OAuth authentication is currently not supported`. The tokens look similar (both start `sk-ant-`). | `query-topics` returns empty on every call. Silent fallback to regex extractor. Detectable only by reading the 401 body, which the hook swallows to avoid noisy stderr. |
+
+The shared failure mode — "ships CI-green, degrades silently" — is why
+each of these warrants a "what breaks" column rather than a one-line
+description. If a future PR proposes removing one, the reviewer should
+ask: *how would we detect that this broke?* If the answer is "we
+wouldn't, until recall quality drops and someone complains", keep the
+invariant.
 
 ## References
 

--- a/docs/recall-architecture.md
+++ b/docs/recall-architecture.md
@@ -1,0 +1,97 @@
+# Recall architecture
+
+How the UserPromptSubmit hook surfaces wiki context — the hybrid FTS5 + vector pipeline, the optional LLM query-topic preprocessor, and the load-bearing invariants that a future "simplification" must not remove.
+
+## Pipeline
+
+```
+┌─────────────────┐    ┌──────────────────┐    ┌────────────┐    ┌───────────┐
+│ UserPromptSubmit│ -> │ query-topics     │ -> │ FTS5 + vec │ -> │ injected  │
+│  (raw prompt)   │    │ (Haiku, optional)│    │ hybrid     │    │ context   │
+└─────────────────┘    └──────────────────┘    └────────────┘    └───────────┘
+                              │
+                              ▼ (any failure)
+                       regex + stopword
+                       fallback extractor
+```
+
+1. **Source config.** `~/.cache/athenaeum/config.env` is sourced under `set -a` / `set +a` so that `ANTHROPIC_API_KEY` propagates to child processes. Without `set -a`, the LLM topic extractor silently runs without its key.
+
+2. **Query-topic extraction (optional, LLM).** `athenaeum query-topics "$PROMPT" --timeout 3` calls a cheap Haiku classifier that returns a JSON array of substantive topics, ignoring meta-instructions like "quote verbatim" or "don't call tools". On any failure (missing CLI, missing API key, timeout, bad JSON), the hook falls back silently to a regex + stopword extractor.
+
+3. **Hybrid search.**
+   - **FTS5** (`wiki-index.db`) — lowercased-and-phrase-quoted OR query, top 3 by BM25 rank, excluding session-seen filenames.
+   - **Vector** (`wiki-vectors/`, runs when `SEARCH_BACKEND=vector`) — embeds the *concatenated topics* (not the raw prompt; meta-instructions drift the embedding), queries chromadb, returns top 3.
+   - **Merge** — FTS5 first, then vector, dedupe by filename, cap at 3.
+
+4. **Session dedup.** `/tmp/knowledge-seen-${SESSION_ID}` accumulates already-surfaced filenames across turns.
+
+5. **Emit.** `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"..."}}`. A flat `{"additionalContext":...}` payload is silently ignored by Claude Code.
+
+## Why hybrid — and why both layers are load-bearing
+
+**FTS5 alone** is fragile on synonym or paraphrase queries. Asking about "iterative feedback loops" won't match the wiki page titled "Innovation Accounting" because there's no lexical overlap.
+
+**Vector alone** is fragile on short proper-noun queries. Concrete failure:
+
+> Query: `"Return Path"`
+> Nearest vector neighbour: `reference_local_paths.md`
+> Distance from the actual entity page: larger than the collision
+
+Short strings are dominated by their common-word components. Out-of-the-box sentence embeddings place "Return Path" closer to `local paths` (sharing "path") than to the sparse entity page for the company "Return Path". FTS5 phrase match on `"return path"` resolves this trivially — no embedding can out-match a literal phrase hit.
+
+**Conclusion:** the hybrid merge is not defence-in-depth. **Each backend rescues a class of queries the other handles poorly.** Removing either collapses recall on its rescue class. When `SEARCH_BACKEND=vector`, the example SessionStart hook still builds FTS5 as a secondary index for the same reason — FTS5 rebuild is ~1s on a 3k-page wiki, cheap next to vector's ~45s.
+
+## Why the LLM preprocessor exists
+
+The regex+stopword fallback extractor sorts words alphabetically and takes the first 8. On a meta-heavy prompt like
+
+> *"Without calling any tools, quote the block about Return Path verbatim."*
+
+the word `return` lands 10th alphabetically and gets dropped. Vector embedding of the raw prompt drifts toward *"without tools / quote / verbatim"* — hook/tooling pages, not entities.
+
+The LLM preprocessor returns `["Return Path"]`, ignoring the meta-wrapper, and both backends then land correctly. It's a cheap Haiku call (~200ms) with a 3s timeout and silent fallback.
+
+## ANTHROPIC_API_KEY bootstrap (SessionStart)
+
+Claude Code authenticates with `CLAUDE_CODE_OAUTH_TOKEN` (starts `sk-ant-o`), scoped to its inference endpoint. Passing that token to the general Anthropic Messages API returns:
+
+```
+401 OAuth authentication is currently not supported
+```
+
+So the LLM preprocessor needs a real console API key, which it reads from `ANTHROPIC_API_KEY`. The reference `session-start-recall.sh` fetches it from 1Password when:
+
+- `ANTHROPIC_API_KEY` isn't already exported, AND
+- the `op` CLI is signed in
+
+```bash
+op read "op://Agent Tools/Anthropic API Key/credential"
+```
+
+Override path via `ATHENAEUM_OP_KEY_PATH`. The fetched key is cached in `~/.cache/athenaeum/config.env` with `0600` perms. Every failure mode is silent — the recall hook then degrades to the regex fallback.
+
+## Failure modes and diagnostics
+
+| Symptom | First check |
+|---|---|
+| Recall misses proper noun in meta-heavy prompt | `grep ANTHROPIC_API_KEY ~/.cache/athenaeum/config.env` — if missing, `op whoami` |
+| Hook runs but model never references the injection | Shape mismatch — output must be `{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit",...}}`, not flat `{"additionalContext":...}` |
+| Short entity name returns unrelated page | Vector collision — verify the FTS5 db exists and is being merged first |
+| LLM extraction returns `[]` every time | `set -a` / `set +a` missing around `source config.env` — var not exported to child process |
+| `athenaeum query-topics` hangs | 3s timeout should kick in; if not, check `ATHENAEUM_PYTHON` points to an env with the athenaeum CLI |
+
+## Load-bearing invariants
+
+Do not simplify any of these without reading this page and the related commit history.
+
+- `set -a` around `source "$CONFIG_ENV"` — required for subprocess env inheritance.
+- FTS5 is maintained even when vector is primary — required for short-query rescue.
+- JSON output shape includes `hookSpecificOutput.hookEventName` — a flat `{"additionalContext":...}` payload is silently ignored.
+- Console API key is fetched separately from the Claude Code OAuth token — OAuth is rejected by the Messages API with 401.
+
+## References
+
+- Live production hook (hardened): `Kromatic-Innovation/code-workspace-config/scripts/hooks/knowledge-recall-on-turn.sh`
+- Fix commits: cwc 781a306 (JSON shape), 99fbc1a (set -a), 1496814 (hybrid merge), e38fb0e (op-read bootstrap)
+- Related PRs: athenaeum #40 (JSON shape), #42 (query-topics CLI)

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -1,0 +1,114 @@
+# Claude Code integration
+
+Three hook scripts that wire Athenaeum into Claude Code as a transparent
+recall sidecar. The scripts are plain bash + sqlite3 + (optional) Python;
+nothing here is Claude-Code-specific that couldn't be ported to another
+agent runtime.
+
+| Hook                     | When it fires        | What it does                                                    |
+|--------------------------|----------------------|------------------------------------------------------------------|
+| `session-start-recall.sh`| Start of each session| Builds the FTS5 (and optional vector) index, caches config       |
+| `user-prompt-recall.sh`  | Each user turn       | Hybrid FTS5+vector search, injects top-3 wiki page names         |
+| `pre-compact-save.sh`    | Before compaction    | Reminds the model to call `remember` on anything load-bearing    |
+
+## Install
+
+1. Initialise a knowledge base if you don't have one:
+
+   ```bash
+   pip install athenaeum
+   athenaeum init --path ~/knowledge
+   ```
+
+2. Copy (or symlink) the scripts somewhere on disk and mark them executable:
+
+   ```bash
+   mkdir -p ~/.claude/hooks/athenaeum
+   cp examples/claude-code/*.sh ~/.claude/hooks/athenaeum/
+   chmod +x ~/.claude/hooks/athenaeum/*.sh
+   ```
+
+3. Merge `settings-snippet.json` into `~/.claude/settings.json`, replacing
+   `/path/to/` with the directory from step 2.
+
+4. (Optional, MCP remember/recall) Register the MCP server. Add to
+   `~/.claude/settings.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "athenaeum": { "command": "athenaeum", "args": ["serve"] }
+     }
+   }
+   ```
+
+5. Restart Claude Code. The session-start message should say
+   `[Knowledge] FTS5 index: N wiki pages`.
+
+## Smoke test
+
+Verify the pipeline without a live session:
+
+```bash
+# 1. Build the index
+bash examples/claude-code/session-start-recall.sh
+
+# 2. Simulate a prompt (stdin is JSON)
+echo '{"prompt":"tell me about innovation accounting","session_id":"test"}' \
+  | bash examples/claude-code/user-prompt-recall.sh
+```
+
+Expected: a single-line JSON object with a `hookSpecificOutput` key listing
+matching wiki pages. Empty output means either your wiki has no relevant
+pages or the index hasn't been built — check `~/.cache/athenaeum/`.
+
+## Environment variables
+
+| Variable                 | Default                           | Purpose                                                       |
+|--------------------------|-----------------------------------|----------------------------------------------------------------|
+| `KNOWLEDGE_ROOT`         | `~/knowledge`                     | Knowledge base root                                            |
+| `KNOWLEDGE_WIKI_PATH`    | `$KNOWLEDGE_ROOT/wiki`            | Wiki directory (if non-standard layout)                        |
+| `ATHENAEUM_CLI`          | `athenaeum`                       | CLI binary (override for editable installs)                    |
+| `ATHENAEUM_PYTHON`       | `python3`                         | Python interpreter with athenaeum deps                         |
+| `ATHENAEUM_SRC`          | —                                 | Source checkout path (skips `pip install`, runs from source)   |
+| `ATHENAEUM_OP_KEY_PATH`  | `op://Agent Tools/Anthropic API Key/credential` | 1Password secret reference for `ANTHROPIC_API_KEY` |
+| `ATHENAEUM_HOOK_DEBUG`   | `0`                               | Set to `1` to log vector-backend errors to stderr              |
+| `SEARCH_BACKEND`         | from `athenaeum.yaml` (`fts5`)    | `fts5` (default) or `vector`                                   |
+| `AUTO_RECALL`            | from `athenaeum.yaml` (`true`)    | Set to `false` to disable per-turn recall                      |
+
+## Hybrid recall: why both backends
+
+Short proper-noun queries like "Return Path" embed in vector space
+closer to generic pages containing "path" than to a sparse entity page
+about the company. FTS5 phrase matching rescues these. Conversely,
+purely semantic queries ("iterative feedback loops" → "Innovation
+Accounting") have no lexical overlap and need the vector side.
+
+Removing either backend collapses recall for its rescue class. See
+`docs/recall-architecture.md` for the full walkthrough and the four
+invariants a future "simplification" must not remove.
+
+## 1Password bootstrap (optional)
+
+The LLM topic extractor (`athenaeum query-topics`) needs a real
+`ANTHROPIC_API_KEY` for the Messages API. Claude Code's own
+`CLAUDE_CODE_OAUTH_TOKEN` is rejected with `401 OAuth authentication
+is currently not supported`, so we can't reuse it.
+
+If you have the [1Password CLI](https://developer.1password.com/docs/cli/)
+signed in, `session-start-recall.sh` will `op read` the key at
+`ATHENAEUM_OP_KEY_PATH` and cache it at `~/.cache/athenaeum/config.env`
+(mode 600, owner-only). Silent on any failure.
+
+Without the key, the hook falls back to a regex+stopword extractor —
+still good, just less topic-aware.
+
+## Troubleshooting
+
+| Symptom                                         | Check                                                                                           |
+|-------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| Session message shows `0 wiki pages`            | `$KNOWLEDGE_ROOT/wiki/` is empty or unreadable                                                 |
+| No `[Knowledge context]` on user turns          | Run `sqlite3 ~/.cache/athenaeum/wiki-index.db 'select count(*) from wiki'` — should be > 0     |
+| Vector backend silent                           | Re-run with `ATHENAEUM_HOOK_DEBUG=1` — usually `pip install athenaeum[vector]` missing         |
+| `query-topics` running without its API key      | `cat ~/.cache/athenaeum/config.env` — should contain `ANTHROPIC_API_KEY=...`                   |
+| Hook ran "green" but recall never fires         | Check the settings-snippet was merged correctly: `grep UserPromptSubmit ~/.claude/settings.json`|

--- a/examples/claude-code/session-start-recall.sh
+++ b/examples/claude-code/session-start-recall.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-# SessionStart hook: read config and build the search index.
+# SessionStart hook: read config, optionally bootstrap ANTHROPIC_API_KEY
+# from 1Password, and build the search index.
 #
 # 1. Reads athenaeum.yaml for config (auto_recall, search_backend)
 # 2. Writes a shell-readable cache at ~/.cache/athenaeum/config.env
-# 3. Builds the appropriate search index (FTS5 or vector)
-#
-# The per-turn hook reads config.env (no Python needed at query time for FTS5).
+# 3. If `op` (1Password CLI) is signed in and ANTHROPIC_API_KEY isn't
+#    already exported, fetches it and caches it in config.env. This is
+#    required for the optional LLM topic extractor — Claude Code's own
+#    CLAUDE_CODE_OAUTH_TOKEN is scoped to its inference endpoint and the
+#    general Messages API rejects it with "401 OAuth authentication is
+#    currently not supported".
+# 4. Builds the configured search index (FTS5 and/or vector).
 #
 # Configure in ~/.claude/settings.json:
 #   "hooks": {
@@ -13,7 +18,7 @@
 #       "hooks": [{
 #         "type": "command",
 #         "command": "/path/to/session-start-recall.sh",
-#         "timeout": 15
+#         "timeout": 60
 #       }]
 #     }]
 #   }
@@ -21,11 +26,9 @@
 # Environment variables:
 #   KNOWLEDGE_ROOT       Path to knowledge directory (default: ~/knowledge)
 #   KNOWLEDGE_WIKI_PATH  Path to wiki directory (default: $KNOWLEDGE_ROOT/wiki)
-#   ATHENAEUM_PYTHON     Python interpreter with athenaeum deps (default: python3)
-#   ATHENAEUM_SRC        Path to athenaeum source checkout (optional; enables
-#                        importlib-based loading that bypasses the package
-#                        __init__.py — useful when running from a checkout
-#                        where optional deps like anthropic aren't installed)
+#   ATHENAEUM_PYTHON     Python interpreter with athenaeum deps
+#   ATHENAEUM_SRC        Path to athenaeum source checkout (optional)
+#   ATHENAEUM_OP_KEY_PATH  1Password path (default: op://Agent Tools/Anthropic API Key/credential)
 
 set -euo pipefail
 
@@ -35,21 +38,15 @@ CACHE_DIR="${HOME}/.cache/athenaeum"
 CONFIG_ENV="${CACHE_DIR}/config.env"
 PYTHON="${ATHENAEUM_PYTHON:-python3}"
 
-if [ ! -d "$WIKI_ROOT" ]; then
-  exit 0
-fi
-
+[ -d "$WIKI_ROOT" ] || exit 0
 mkdir -p "$CACHE_DIR"
 
 # ── Read config ────────────────────────────────────────────────────────────
-# Try athenaeum Python module; fall back to pure-shell YAML parsing.
 _read_config_ok=false
 
 if "$PYTHON" -c "
 import sys, os, importlib.util
 src = os.environ.get('ATHENAEUM_SRC', '')
-# Prefer importlib loader from a source checkout (avoids package __init__.py
-# pulling in anthropic/librarian when only the config module is needed).
 cfg_path = os.path.join(src, 'src/athenaeum/config.py') if src else ''
 if cfg_path and os.path.isfile(cfg_path):
     spec = importlib.util.spec_from_file_location('athenaeum_config_only', cfg_path)
@@ -97,16 +94,35 @@ if [ "$_read_config_ok" = false ]; then
   } > "$CONFIG_ENV"
 fi
 
+# shellcheck disable=SC1090
 source "$CONFIG_ENV"
 
+# ── Optional: bootstrap ANTHROPIC_API_KEY from 1Password ────────────────
+# Claude Code authenticates with CLAUDE_CODE_OAUTH_TOKEN, which the
+# general Messages API rejects (401). The LLM topic extractor in
+# user-prompt-recall.sh needs a real console key. When `op` is signed
+# in and ANTHROPIC_API_KEY isn't already set, fetch + cache it.
+# Override path via ATHENAEUM_OP_KEY_PATH. Silent on any failure.
+_KEY_PATH="${ATHENAEUM_OP_KEY_PATH:-op://Agent Tools/Anthropic API Key/credential}"
+if [ -z "${ANTHROPIC_API_KEY:-}" ] && command -v op >/dev/null 2>&1; then
+  if _fetched_key="$(op read "$_KEY_PATH" 2>/dev/null)" && [ -n "$_fetched_key" ]; then
+    tmp_env="${CONFIG_ENV}.tmp"
+    grep -v '^ANTHROPIC_API_KEY=' "$CONFIG_ENV" > "$tmp_env" 2>/dev/null || true
+    printf 'ANTHROPIC_API_KEY=%s\n' "$_fetched_key" >> "$tmp_env"
+    mv "$tmp_env" "$CONFIG_ENV"
+    chmod 600 "$CONFIG_ENV"
+  fi
+fi
+
 # ── Build search index ─────────────────────────────────────────────────────
-if [ "$SEARCH_BACKEND" = "fts5" ]; then
-  "$PYTHON" -c "
+# Always build FTS5 — it's cheap (~1s for 3k pages) and rescues short-query
+# recall even when the vector backend is the primary. See docs/recall-architecture.md.
+"$PYTHON" -c "
 import sys, os, importlib.util
 src = os.environ.get('ATHENAEUM_SRC', '')
-search_path = os.path.join(src, 'src/athenaeum/search.py') if src else ''
-if search_path and os.path.isfile(search_path):
-    spec = importlib.util.spec_from_file_location('athenaeum_search_only', search_path)
+path = os.path.join(src, 'src/athenaeum/search.py') if src else ''
+if path and os.path.isfile(path):
+    spec = importlib.util.spec_from_file_location('athenaeum_search_only', path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     build_fts5_index = mod.build_fts5_index
@@ -114,5 +130,24 @@ else:
     from athenaeum.search import build_fts5_index
 count = build_fts5_index(sys.argv[1], sys.argv[2])
 print(f'[Knowledge] FTS5 index: {count} wiki pages', file=sys.stderr)
+" "$WIKI_ROOT" "$CACHE_DIR" 2>&1 || true
+
+if [ "${SEARCH_BACKEND:-fts5}" = "vector" ]; then
+  "$PYTHON" -c "
+import sys, os, importlib.util
+src = os.environ.get('ATHENAEUM_SRC', '')
+path = os.path.join(src, 'src/athenaeum/search.py') if src else ''
+if path and os.path.isfile(path):
+    spec = importlib.util.spec_from_file_location('athenaeum_search_only', path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    build_vector_index = mod.build_vector_index
+else:
+    from athenaeum.search import build_vector_index
+try:
+    count = build_vector_index(sys.argv[1], sys.argv[2])
+    print(f'[Knowledge] Vector index: {count} wiki pages', file=sys.stderr)
+except ImportError as e:
+    print(f'[Knowledge] Vector backend unavailable: {e}', file=sys.stderr)
 " "$WIKI_ROOT" "$CACHE_DIR" 2>&1 || true
 fi

--- a/examples/claude-code/session-start-recall.sh
+++ b/examples/claude-code/session-start-recall.sh
@@ -141,6 +141,30 @@ count = build_fts5_index(sys.argv[1], sys.argv[2])
 print(f'[Knowledge] FTS5 index: {count} wiki pages', file=sys.stderr)
 " "$WIKI_ROOT" "$CACHE_DIR" 2>&1 || true
 
+# Cache the canonical stopword list once per session. The per-turn
+# recall hook reads this file instead of hard-coding its own copy,
+# which keeps it in sync with the Python FTS5 filter (issue #46).
+# mktemp+mv keeps the write atomic so a concurrent read never sees
+# a partial file.
+_stopwords_tmp=$(mktemp "${CACHE_DIR}/stopwords.txt.XXXXXX")
+if "$PYTHON" -c "
+import sys, os, importlib.util
+src = os.environ.get('ATHENAEUM_SRC', '')
+path = os.path.join(src, 'src/athenaeum/search.py') if src else ''
+if path and os.path.isfile(path):
+    spec = importlib.util.spec_from_file_location('athenaeum_search_only', path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    STOPWORDS = mod.STOPWORDS
+else:
+    from athenaeum.search import STOPWORDS
+print('\n'.join(STOPWORDS))
+" > "$_stopwords_tmp" 2>/dev/null && [ -s "$_stopwords_tmp" ]; then
+  mv "$_stopwords_tmp" "${CACHE_DIR}/stopwords.txt"
+else
+  rm -f "$_stopwords_tmp"
+fi
+
 if [ "${SEARCH_BACKEND:-fts5}" = "vector" ]; then
   "$PYTHON" -c "
 import sys, os, importlib.util

--- a/examples/claude-code/session-start-recall.sh
+++ b/examples/claude-code/session-start-recall.sh
@@ -39,7 +39,13 @@ CONFIG_ENV="${CACHE_DIR}/config.env"
 PYTHON="${ATHENAEUM_PYTHON:-python3}"
 
 [ -d "$WIKI_ROOT" ] || exit 0
+
+# Cache dir holds ANTHROPIC_API_KEY in config.env. Restrict to owner-only
+# before writing anything, and set umask so new files inherit mode 600.
+# Prevents a brief window where a freshly-written key is world-readable.
 mkdir -p "$CACHE_DIR"
+chmod 700 "$CACHE_DIR"
+umask 077
 
 # ── Read config ────────────────────────────────────────────────────────────
 _read_config_ok=false
@@ -106,11 +112,14 @@ source "$CONFIG_ENV"
 _KEY_PATH="${ATHENAEUM_OP_KEY_PATH:-op://Agent Tools/Anthropic API Key/credential}"
 if [ -z "${ANTHROPIC_API_KEY:-}" ] && command -v op >/dev/null 2>&1; then
   if _fetched_key="$(op read "$_KEY_PATH" 2>/dev/null)" && [ -n "$_fetched_key" ]; then
-    tmp_env="${CONFIG_ENV}.tmp"
+    # mktemp inside the (already-restricted) cache dir — gives us an
+    # unpredictable path mode 600 atomically, closing the window where
+    # `${CONFIG_ENV}.tmp` could have been pre-created as a symlink or
+    # read in the gap between open() and chmod().
+    tmp_env=$(mktemp "${CACHE_DIR}/config.env.XXXXXX")
     grep -v '^ANTHROPIC_API_KEY=' "$CONFIG_ENV" > "$tmp_env" 2>/dev/null || true
     printf 'ANTHROPIC_API_KEY=%s\n' "$_fetched_key" >> "$tmp_env"
     mv "$tmp_env" "$CONFIG_ENV"
-    chmod 600 "$CONFIG_ENV"
   fi
 fi
 

--- a/examples/claude-code/user-prompt-recall.sh
+++ b/examples/claude-code/user-prompt-recall.sh
@@ -88,7 +88,17 @@ if [ -n "$TERMS" ]; then
 fi
 
 if [ -z "$TERMS" ]; then
-  STOPWORDS="the and for are but not you all can had her was one our out has his how its let may new now old see way who did get got him she too use with from have this that they will been call come each find give help here just know like long look make many more most much must next only over said same some such take tell than them then very want well went were what when which while work also back been being both came does done down even goes going good keep last left life line made need never part place point right show small still think those turn used using where would about after again could every great might often other shall should since start state still there these thing think three through under until which while world would years your into just like made over said some than them then time very want what when will with year does really right going being looking trying running check please sure okay yeah thanks"
+  # Read the canonical stopword list cached at SessionStart. Single
+  # source of truth with athenaeum.search.STOPWORDS (issue #46); the
+  # file is rewritten on every session start so list updates pick up
+  # automatically. If the cache is missing (e.g. SessionStart hook
+  # didn't run), fall back to a minimal baked-in list so the hook
+  # still works degradedly rather than returning zero terms.
+  if [ -s "${CACHE_DIR}/stopwords.txt" ]; then
+    STOPWORDS=$(tr '\n' '|' < "${CACHE_DIR}/stopwords.txt" | sed 's/|$//')
+  else
+    STOPWORDS="the|and|for|are|but|not|you|all|can|had|was|one|our|out|has|from|with|this|that|they|will|have|been|what|when|which|while|the"
+  fi
   TERMS=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '\n' | grep -vE "^(${STOPWORDS})$" | grep -E '.{3,}' | sort -u | head -8)
 fi
 

--- a/examples/claude-code/user-prompt-recall.sh
+++ b/examples/claude-code/user-prompt-recall.sh
@@ -77,6 +77,16 @@ if command -v "$ATHENAEUM_CLI" >/dev/null 2>&1 && [ -n "${ANTHROPIC_API_KEY:-}" 
   TERMS=$("$ATHENAEUM_CLI" query-topics "$PROMPT" --timeout 3 2>/dev/null || echo "")
 fi
 
+# Sanitize to alphanum tokens before query-building. Anything that flows
+# into FTS_QUERY below ends up inside a single-quoted SQL literal passed
+# to `sqlite3 ... "WHERE wiki MATCH '${FTS_QUERY}'"`, so a stray ' in an
+# LLM-returned topic (e.g. "Tristan's project") would break out of the
+# literal and inject SQL. Alphanum-only matches the fallback extractor's
+# surface and keeps FTS5 happy.
+if [ -n "$TERMS" ]; then
+  TERMS=$(echo "$TERMS" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '\n' | grep -E '.{3,}' | sort -u | head -8)
+fi
+
 if [ -z "$TERMS" ]; then
   STOPWORDS="the and for are but not you all can had her was one our out has his how its let may new now old see way who did get got him she too use with from have this that they will been call come each find give help here just know like long look make many more most much must next only over said same some such take tell than them then very want well went were what when which while work also back been being both came does done down even goes going good keep last left life line made need never part place point right show small still think those turn used using where would about after again could every great might often other shall should since start state still there these thing think three through under until which while world would years your into just like made over said some than them then time very want what when will with year does really right going being looking trying running check please sure okay yeah thanks"
   TERMS=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '\n' | grep -vE "^(${STOPWORDS})$" | grep -E '.{3,}' | sort -u | head -8)
@@ -112,7 +122,13 @@ if [ -f "$DB_FILE" ]; then
 fi
 
 VECTOR_RESULTS=""
+VECTOR_ERR=""
 if [ "$SEARCH_BACKEND" = "vector" ] && [ -d "$VECTOR_DIR" ]; then
+  # Failures here are non-fatal — the hook still surfaces FTS5 results —
+  # but we capture stderr to $VECTOR_ERR so ATHENAEUM_HOOK_DEBUG=1 can
+  # surface the reason. Most common cause: chromadb import missing in
+  # the python3 on PATH (see `pip install athenaeum[vector]`).
+  _vector_tmp=$(mktemp -t athenaeum-vec-XXXXXX)
   VECTOR_RESULTS=$("$PYTHON" -c "
 import sys, os, importlib.util
 src = os.environ.get('ATHENAEUM_SRC', '')
@@ -131,7 +147,12 @@ if os.path.isfile(seen_file):
         seen = set(l.strip() for l in f)
 for fname, name, score in query_vector_index(sys.argv[1], os.path.expanduser('~/.cache/athenaeum'), n=3, exclude=seen):
     print(f'{fname}\t{name}\t{score}')
-" "$VECTOR_QUERY" "$SEEN_FILE" 2>/dev/null || echo "")
+" "$VECTOR_QUERY" "$SEEN_FILE" 2>"$_vector_tmp" || true)
+  VECTOR_ERR=$(cat "$_vector_tmp" 2>/dev/null || echo "")
+  rm -f "$_vector_tmp"
+  if [ -n "$VECTOR_ERR" ] && [ "${ATHENAEUM_HOOK_DEBUG:-0}" = "1" ]; then
+    echo "athenaeum recall: vector backend failed: ${VECTOR_ERR}" >&2
+  fi
 fi
 
 # Merge: FTS5 first (lexical precision), then vector, dedupe, cap 3.

--- a/examples/claude-code/user-prompt-recall.sh
+++ b/examples/claude-code/user-prompt-recall.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
-# UserPromptSubmit hook: search wiki FTS5 index for context relevant to
-# the user's message.
+# UserPromptSubmit hook: surface wiki pages relevant to the user's message.
 #
-# Queries a precomputed SQLite FTS5 index (built by session-start-recall.sh
-# at SessionStart). Typical runtime: <50ms for FTS5 alone, ~500-1500ms
-# when the optional LLM topic extractor is active.
+# Runs a hybrid FTS5 + (optional) vector search against the athenaeum index
+# built by session-start-recall.sh. Typical runtime: <50ms (FTS5 only),
+# ~400ms (vector), ~1.5s when the LLM topic extractor is enabled.
 #
-# Query rewriting (optional): if `athenaeum query-topics` is available and
-# ANTHROPIC_API_KEY is set, the raw prompt is first run through Haiku to
-# extract substantive topics (entity names, proper nouns) while ignoring
-# meta-instructions like "quote verbatim" or "don't call tools". This
-# rescues named-entity recall on instruction-heavy prompts. When unset or
-# the extractor returns empty, the hook falls back to a regex+stopword
-# keyword extractor.
+# Why hybrid. FTS5 phrase match rescues short proper-noun queries that
+# collide in vector space ("Return Path" embeds closer to any page
+# containing "path" than to a sparse entity page). Vector search
+# discovers semantic neighbours with no lexical overlap ("iterative
+# feedback loops" -> "Innovation Accounting"). Each backend rescues a
+# class of queries the other handles poorly — the merge is load-bearing.
+#
+# Optional LLM query-rewriting. If `athenaeum query-topics` is available
+# and ANTHROPIC_API_KEY is set, the raw prompt is first run through Haiku
+# to extract substantive topics while ignoring meta-instructions
+# ("quote verbatim", "don't call tools"). Falls back silently to a
+# regex+stopword extractor when unavailable.
 #
 # Configure in ~/.claude/settings.json:
 #   "hooks": {
@@ -25,18 +29,40 @@
 #     }]
 #   }
 #
-# Requires: sqlite3, jq (both ship with macOS)
+# Requires: sqlite3, jq (ship with macOS). Python only when vector is on.
 
 set -euo pipefail
 
-DB_FILE="${HOME}/.cache/athenaeum/wiki-index.db"
+CACHE_DIR="${HOME}/.cache/athenaeum"
+CONFIG_ENV="${CACHE_DIR}/config.env"
+DB_FILE="${CACHE_DIR}/wiki-index.db"
+VECTOR_DIR="${CACHE_DIR}/wiki-vectors"
 ATHENAEUM_CLI="${ATHENAEUM_CLI:-athenaeum}"
+PYTHON="${ATHENAEUM_PYTHON:-python3}"
 
-if [ ! -f "$DB_FILE" ]; then
+# ── Source config ──────────────────────────────────────────────────────
+# `set -a` auto-exports sourced variables so child processes (notably
+# `athenaeum query-topics`, which reads ANTHROPIC_API_KEY from its own
+# env) inherit them. Without it, `source` sets vars only in this shell
+# and the child silently runs without the key.
+if [ -f "$CONFIG_ENV" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$CONFIG_ENV"
+  set +a
+fi
+AUTO_RECALL="${AUTO_RECALL:-true}"
+SEARCH_BACKEND="${SEARCH_BACKEND:-fts5}"
+
+[ "$AUTO_RECALL" = "true" ] || exit 0
+
+# Bail only when BOTH backends are unavailable. Hybrid merge tolerates
+# one being absent.
+if [ ! -f "$DB_FILE" ] && [ ! -d "$VECTOR_DIR" ]; then
   exit 0
 fi
 
-# ── Parse stdin JSON with jq (no Python cold start) ────────────────────
+# ── Parse stdin ─────────────────────────────────────────────────────────
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null)
@@ -46,10 +72,6 @@ if [ -z "$PROMPT" ] || [ ${#PROMPT} -lt 8 ]; then
 fi
 
 # ── Extract search terms ────────────────────────────────────────────────
-# First try the LLM topic extractor (rescues named entities on
-# instruction-heavy prompts). Falls back to the regex extractor when the
-# CLI isn't installed, ANTHROPIC_API_KEY isn't set, or the extractor
-# times out / errors.
 TERMS=""
 if command -v "$ATHENAEUM_CLI" >/dev/null 2>&1 && [ -n "${ANTHROPIC_API_KEY:-}" ]; then
   TERMS=$("$ATHENAEUM_CLI" query-topics "$PROMPT" --timeout 3 2>/dev/null || echo "")
@@ -60,39 +82,68 @@ if [ -z "$TERMS" ]; then
   TERMS=$(echo "$PROMPT" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '\n' | grep -vE "^(${STOPWORDS})$" | grep -E '.{3,}' | sort -u | head -8)
 fi
 
-if [ -z "$TERMS" ]; then
-  exit 0
-fi
+[ -n "$TERMS" ] || exit 0
 
-# Build FTS5 query: "phrase one" OR "phrase two" ...
-# Lowercase each line (FTS5 indexes lowercased tokens) and wrap in quotes
-# for phrase matching — phrases like "Return Path" stay intact.
+# FTS5 query: "term1" OR "term2" OR ... (lowercased, quoted for phrases).
 FTS_QUERY=$(echo "$TERMS" | tr '[:upper:]' '[:lower:]' | sed 's/.*/"&"/' | tr '\n' ' ' | sed 's/ *$//' | sed 's/" "/\" OR \"/g')
+# Vector query: topics concatenated (no meta-drift from full prompt).
+VECTOR_QUERY=$(echo "$TERMS" | tr '\n' ' ' | sed 's/ *$//')
+[ -n "$VECTOR_QUERY" ] || VECTOR_QUERY="$PROMPT"
 
 # ── Session dedup ───────────────────────────────────────────────────────
 SEEN_FILE="/tmp/knowledge-seen-${SESSION_ID}"
 touch "$SEEN_FILE"
-
 EXCLUDE=""
 if [ -s "$SEEN_FILE" ]; then
   EXCLUDE=$(while read -r fn; do printf "AND filename != '%s' " "$fn"; done < "$SEEN_FILE")
 fi
 
-# ── Query FTS5 index ────────────────────────────────────────────────────
-RESULTS=$(sqlite3 -separator $'\t' "$DB_FILE" "
-  SELECT filename, name, rank
-  FROM wiki
-  WHERE wiki MATCH '${FTS_QUERY}'
-  ${EXCLUDE}
-  ORDER BY rank
-  LIMIT 3;
-" 2>/dev/null || echo "")
-
-if [ -z "$RESULTS" ]; then
-  exit 0
+# ── Query backends ──────────────────────────────────────────────────────
+FTS_RESULTS=""
+if [ -f "$DB_FILE" ]; then
+  FTS_RESULTS=$(sqlite3 -separator $'\t' "$DB_FILE" "
+    SELECT filename, name, rank
+    FROM wiki
+    WHERE wiki MATCH '${FTS_QUERY}'
+    ${EXCLUDE}
+    ORDER BY rank
+    LIMIT 3;
+  " 2>/dev/null || echo "")
 fi
 
+VECTOR_RESULTS=""
+if [ "$SEARCH_BACKEND" = "vector" ] && [ -d "$VECTOR_DIR" ]; then
+  VECTOR_RESULTS=$("$PYTHON" -c "
+import sys, os, importlib.util
+src = os.environ.get('ATHENAEUM_SRC', '')
+path = os.path.join(src, 'src/athenaeum/search.py') if src else ''
+if path and os.path.isfile(path):
+    spec = importlib.util.spec_from_file_location('athenaeum.search', path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    query_vector_index = mod.query_vector_index
+else:
+    from athenaeum.search import query_vector_index
+seen = set()
+seen_file = sys.argv[2]
+if os.path.isfile(seen_file):
+    with open(seen_file) as f:
+        seen = set(l.strip() for l in f)
+for fname, name, score in query_vector_index(sys.argv[1], os.path.expanduser('~/.cache/athenaeum'), n=3, exclude=seen):
+    print(f'{fname}\t{name}\t{score}')
+" "$VECTOR_QUERY" "$SEEN_FILE" 2>/dev/null || echo "")
+fi
+
+# Merge: FTS5 first (lexical precision), then vector, dedupe, cap 3.
+RESULTS=$(printf '%s\n%s\n' "$FTS_RESULTS" "$VECTOR_RESULTS" \
+  | awk -F'\t' 'NF >= 2 && $1 != "" && !seen[$1]++' \
+  | head -3)
+
+[ -n "$RESULTS" ] || exit 0
+
 # ── Format output ───────────────────────────────────────────────────────
+# Must be wrapped in hookSpecificOutput.hookEventName — Claude Code
+# silently ignores a flat {"additionalContext": ...} payload.
 MATCHES=""
 while IFS=$'\t' read -r fname name score; do
   MATCHES="${MATCHES}  - ${name}\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "athenaeum"
-version = "0.1.0"
+version = "0.2.0"
 description = "Open source knowledge management pipeline — append-only intake, tiered compilation, configurable schemas"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/athenaeum/__init__.py
+++ b/src/athenaeum/__init__.py
@@ -1,6 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
 """Athenaeum — open source knowledge management pipeline."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from athenaeum.init import init_knowledge_dir
 from athenaeum.librarian import discover_raw_files, process_one, rebuild_index, run

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -182,7 +182,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         return 1
 
     cfg = load_config(target)
-    backend = cfg.get("search_backend", "keyword")
+    backend = cfg.get("search_backend", "fts5")
     cache_dir = Path("~/.cache/athenaeum").expanduser()
 
     server = create_server(

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -100,6 +100,14 @@ def main(argv: list[str] | None = None) -> int:
         help="Seconds to wait for the LLM before giving up (default: 3.0)",
     )
 
+    # stopwords command — print the canonical stopword list for shell hooks
+    subparsers.add_parser(
+        "stopwords",
+        help="Print the stopword list (one word per line). "
+             "Used by the example UserPromptSubmit hook's regex fallback "
+             "to stay in sync with the FTS5 query filter.",
+    )
+
     # rebuild-index command — rebuild the search index out-of-band
     rebuild_parser = subparsers.add_parser(
         "rebuild-index",
@@ -144,6 +152,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "test-mcp":
         return _cmd_test_mcp(args)
+
+    if args.command == "stopwords":
+        return _cmd_stopwords(args)
 
     return 0
 
@@ -258,6 +269,15 @@ def _cmd_rebuild_index(args: argparse.Namespace) -> int:
 
     print(f"Unknown search backend: {backend}", file=sys.stderr)
     return 1
+
+
+def _cmd_stopwords(_args: argparse.Namespace) -> int:
+    """Print the canonical stopword list, one word per line, sorted."""
+    from athenaeum.search import STOPWORDS
+
+    for word in STOPWORDS:
+        print(word)
+    return 0
 
 
 def _cmd_query_topics(args: argparse.Namespace) -> int:

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Athenaeum CLI entry point."""
 
 import argparse

--- a/src/athenaeum/config.py
+++ b/src/athenaeum/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Athenaeum configuration loader.
 
 Reads ``athenaeum.yaml`` from the knowledge directory root to control

--- a/src/athenaeum/init.py
+++ b/src/athenaeum/init.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Initialize a new knowledge directory with standard structure and schema files."""
 
 from __future__ import annotations

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Knowledge librarian — tiered compilation pipeline.
 
 Processes raw intake files from a knowledge directory's raw/ folder into wiki

--- a/src/athenaeum/mcp_server.py
+++ b/src/athenaeum/mcp_server.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """MCP memory server — read/write gate for an Athenaeum knowledge base.
 
 Tools:

--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Data models, YAML frontmatter parsing, and entity index for Athenaeum."""
 
 from __future__ import annotations

--- a/src/athenaeum/query_topics.py
+++ b/src/athenaeum/query_topics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """LLM-based topic extraction for query rewriting.
 
 The UserPromptSubmit hook's recall quality degrades on instruction-heavy

--- a/src/athenaeum/search.py
+++ b/src/athenaeum/search.py
@@ -1,12 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
 """Search backend abstraction for athenaeum.
 
-Provides pluggable search backends for wiki recall queries.  The default
+Provides pluggable search backends for wiki recall queries. The default
 ``fts5`` backend uses SQLite FTS5 with BM25 ranking and porter stemming.
-A ``vector`` backend stub is provided for issue #32.
+The ``vector`` backend uses chromadb with ``all-MiniLM-L6-v2``. When the
+vector backend is configured, the example recall hook performs a hybrid
+FTS5+vector merge so that short proper-noun queries still resolve
+cleanly — see ``docs/recall-architecture.md`` for why each backend is
+load-bearing.
 
 Shell hook scripts can call the module-level convenience functions
-(``build_fts5_index``, ``query_fts5_index``, etc.) without constructing
-backend objects.
+(``build_fts5_index``, ``query_fts5_index``, ``build_vector_index``,
+``query_vector_index``) without constructing backend objects.
 """
 
 from __future__ import annotations

--- a/src/athenaeum/search.py
+++ b/src/athenaeum/search.py
@@ -58,8 +58,11 @@ class SearchBackend(Protocol):
 # FTS5 backend
 # ---------------------------------------------------------------------------
 
-# Stopwords stripped before building an FTS5 query.
-_STOPWORDS: frozenset[str] = frozenset(
+# Public stopword list — sorted tuple for deterministic CLI output.
+# Exposed as the single source of truth so shell hooks and downstream
+# callers don't re-hardcode their own copy. See `athenaeum stopwords`
+# CLI subcommand and examples/claude-code/user-prompt-recall.sh.
+STOPWORDS: tuple[str, ...] = tuple(sorted(set(
     "the and for are but not you all can had her was one our out has his how "
     "its let may new now old see way who did get got him she too use with from "
     "have this that they will been call come each find give help here just know "
@@ -73,7 +76,10 @@ _STOPWORDS: frozenset[str] = frozenset(
     "years your into just like made over said some than them then time very "
     "want what when will with year does really right going being looking "
     "trying running check please sure okay yeah thanks".split()
-)
+)))
+
+# Stopwords stripped before building an FTS5 query.
+_STOPWORDS: frozenset[str] = frozenset(STOPWORDS)
 
 _DB_NAME = "wiki-index.db"
 

--- a/src/athenaeum/status.py
+++ b/src/athenaeum/status.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Athenaeum status — inspect current state of a knowledge base."""
 
 from __future__ import annotations

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tiered processing pipeline for the knowledge librarian.
 
 Tier 1: Programmatic entity matching (no LLM)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,37 @@ class TestServe:
         assert captured["search_backend"] == "fts5"
 
 
+class TestStopwords:
+    """`athenaeum stopwords` is the canonical source of the stopword list —
+    shell hooks read it instead of hard-coding their own copy. Regression
+    guard for issue #46: the two copies must stay in sync."""
+
+    def test_prints_one_word_per_line_sorted(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = main(["stopwords"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = out.strip().splitlines()
+        assert lines == sorted(lines), "Output must be sorted for determinism"
+        assert len(lines) > 50, "Stopword list should be non-trivial"
+        assert "the" in lines
+        assert "thanks" in lines
+
+    def test_matches_search_module_constant(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from athenaeum.search import STOPWORDS
+
+        rc = main(["stopwords"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert out.strip().splitlines() == list(STOPWORDS), (
+            "CLI output must match search.STOPWORDS exactly — divergence "
+            "silently degrades the shell-hook fallback extractor."
+        )
+
+
 class TestTestMcp:
     def test_all_steps_pass_with_fastmcp_available(
         self, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary

Open-source review pass preparing the v0.2.0 release. Three themes:
example hooks aligned with the production cwc implementation, full
docs + OSS baseline, and version bump + cleanup.

No functional library code changes — all behaviour changes are in
`examples/claude-code/*` (which adopters opt into).

**Update (2026-04-17):** Second pass applied after running the
independent reviewer protocol (Dijkstra, Dewey, Security personas) —
see "Reviewer-response fixes" section below. Four of the five
deferred follow-ups (#45, #46, #47, #48) landed in follow-up commits
on this branch; #44 (PyPI squatting) remains human-blocked.

## Changes

### Example-hook hardening (affects adopters)

- `set -a` / `set +a` around `source "$CONFIG_ENV"` so the LLM topic
  extractor child process inherits `ANTHROPIC_API_KEY`. Without this,
  the LLM preprocessor silently ran without its key — shipped `athenaeum
  query-topics` (PR #42) would have been a no-op for adopters.
- Hybrid FTS5+vector merge in `user-prompt-recall.sh`. Short proper
  nouns like "Vandelay Industries" collide with common-noun pages in vector
  space (`reference_local_paths.md` lands closer than the actual
  entity). FTS5 phrase match rescues them; removing either backend
  collapses recall on its rescue class.
- Optional 1Password bootstrap of `ANTHROPIC_API_KEY` at SessionStart.
  Claude Code's own `CLAUDE_CODE_OAUTH_TOKEN` is rejected by the
  Messages API with 401. Silent on any failure (no `op`, not signed
  in, wrong path).
- `session-start-recall.sh` now builds the vector index when
  `SEARCH_BACKEND=vector`. Previously fts5-only.

### Docs + OSS baseline

- `docs/recall-architecture.md` — hybrid pipeline walkthrough, short-
  query embedding collision explanation, four load-bearing invariants
  a future "simplification" must not remove (set -a, hybrid merge,
  JSON shape, OAuth-vs-console-key).
- README: `[vector]` extra, `athenaeum query-topics` subcommand,
  Claude Code OAuth caveat.
- `SECURITY.md` (private disclosure via open-source@kromatic.com).
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1).
- `.github/ISSUE_TEMPLATE/{bug,feature}.md`, `pull_request_template.md`
  — PR template includes a "hook changes only" live-run checklist
  (direct response to the pattern that flat-additionalContext and
  missing-set-a both shipped CI-green).
- `CHANGELOG.md` (Keep a Changelog) reconstructed from git log.
- Apache 2.0 `SPDX-License-Identifier` header on all `src/athenaeum/*.py`.

### Version + cleanup

- Bump to **0.2.0** — vector backend (#32), MCP sidecar (#26),
  query-topics (#42), observation filter (#37), and more all shipped
  after 0.1.0.
- Drop stale "vector backend is a stub for issue #32" comment in
  `search.py`.

## Reviewer-response fixes (2026-04-17)

Three reviewer personas ran in parallel against the pre-review-pass
commit. Their findings drove follow-up commits on this branch
(`4304fa8`, `64fab9e`, `b772110`). Summary of what landed vs. what
is deferred:

### Fixed on this PR

| Finding | Severity | Fix |
|---------|----------|-----|
| SQL injection via LLM topics in `user-prompt-recall.sh:77` | Blocker | Sanitize LLM output to alphanum tokens before FTS_QUERY construction (same surface as the regex-fallback branch) |
| `config.env` world-readable window between write and chmod | Blocker | `umask 077` + `chmod 700` on cache dir before any file write |
| Predictable `${CONFIG_ENV}.tmp` path (symlink attack surface) | Blocker | Replace with `mktemp` in the (now-restricted) cache dir |
| Vector-backend Python block swallowed all errors silently | Adopter friction | `ATHENAEUM_HOOK_DEBUG=1` surfaces stderr |
| No end-to-end onramp for hook adopters | Adopter friction | New `examples/claude-code/README.md` with install, smoke test, env-var table, troubleshooting matrix |
| README lacked concrete `remember` / `query-topics` demos | Adopter friction | Added `athenaeum test-mcp` example, before/after `query-topics` output, concrete `remember` flow |
| `cli.py:_cmd_serve` fallback `"keyword"` inconsistent with `config.py` DEFAULTS `"fts5"` | Cleanup | Aligned to `"fts5"` |
| Docs next-adopter gaps (#45) | Adopter friction | README env-var table (AUTO_RECALL, SEARCH_BACKEND, ATHENAEUM_HOOK_DEBUG) + shell-env override note; SECURITY.md `examples/claude-code/` scope clause; CHANGELOG blockquote documenting the four load-bearing invariants |
| Stopword list dedup (#46) | Cleanup | Expose public `athenaeum.search.STOPWORDS` tuple + `athenaeum stopwords` CLI subcommand. SessionStart hook writes `stopwords.txt` atomically; per-turn hook reads it. Regression test asserts CLI and `STOPWORDS` stay byte-identical. Same fix backported to cwc's production hook. |
| Issue/PR template hygiene (#47) | Cleanup | PR template now includes concrete test payload; bug + feature templates carry an `ANTHROPIC_API_KEY` redaction blockquote |
| Architecture invariants "what breaks" column (#48) | Cleanup | `docs/recall-architecture.md` "Load-bearing invariants" promoted from bulleted list to three-column table (Invariant / Why it's load-bearing / What breaks if removed) |

### Backported to cwc

- The SQL-injection fix was also applied to cwc's production hook at
  `scripts/hooks/knowledge-recall-on-turn.sh` (separate commit on cwc's
  `develop` branch) so the example and production hooks stay aligned.
- The stopword dedup fix (#46) was backported the same way: cwc's
  `knowledge-build-index.sh` writes `stopwords.txt` at SessionStart and
  `knowledge-recall-on-turn.sh` reads it in the regex-fallback branch.

### Deferred to follow-up issues

- **PyPI name squatting** (#44) — `pip install athenaeum` is a no-op
  today. Human-blocked: Tristan must claim the name before public
  announce.

## Test plan

- [x] `pytest tests/ -v` — 210+ passed (12 CLI tests including 2 new
      `TestStopwords` regression tests for #46)
- [x] `ruff check src/ tests/` — clean
- [x] `bash -n` syntax check on both example hooks (and cwc production hooks)
- [x] Live end-to-end verification of the **production** hook
  (in cwc) against a real prompt — this PR ports those exact fixes
  into the example
- [x] Independent reviewer protocol (Dijkstra, Dewey, Security) —
  findings fixed or tracked as follow-ups
- [ ] Re-verify examples against a fresh adopter install once merged

## Follow-up (post-merge)

- Tag `v0.2.0`
- Optional: publish to PyPI (`pip install athenaeum` currently fails —
  tagging and publishing is the next step if desired). Blocked on #44.
