### PR TITLE
ci: PyPI trusted-publishing release workflow (#44)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          proj=$(python -c "import tomllib,sys; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag" != "$proj" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME ($tag) does not match pyproject.toml version ($proj)"
+            exit 1
+          fi
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/athenaeum
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI via Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Adds a tag-triggered release workflow that builds `athenaeum` and
publishes it to PyPI via Trusted Publishing (OIDC). Part of #44 —
the remaining human step is claiming the name on PyPI.

- Trigger: `v*` tag pushes only (no branch triggers — releases are
  intentionally explicit).
- Build job: `python -m build` (sdist + wheel), with a version-match
  guard that fails the workflow if `pyproject.toml` version and the
  tag disagree. Prevents the classic "tagged `v0.2.1` but the artifact
  says `0.2.0`" footgun.
- Publish job: uses `pypa/gh-action-pypi-publish@release/v1` with
  `id-token: write` + `environment: pypi`. No long-lived token — PyPI
  verifies the GitHub OIDC claim against its configured Trusted
  Publisher and issues a short-lived upload token per run.

## Prerequisites (human-only, one-time)

Before the first tag push, the repo owner needs to:

1. Register a pending publisher on PyPI:
   https://pypi.org/manage/account/publishing/ with
   - project name: `athenaeum`
   - owner: `Kromatic-Innovation`
   - repo: `athenaeum`
   - workflow: `release.yml`
   - environment: `pypi`
2. Create a GitHub environment named `pypi` on this repo
   (Settings → Environments → New environment). Can start empty;
   optionally add required reviewers for a publish-approval gate.

Once both exist, `git tag v0.2.0 && git push origin v0.2.0` publishes.

## Test plan

- [x] YAML syntax validated locally
- [ ] Post-merge, verify workflow shows up under Actions
- [ ] After PyPI pending-publisher setup, push a throwaway tag like
      `v0.2.0-rc1` (version must match a pyproject bump) or publish
      a real `v0.2.0` to exercise the happy path
- [ ] Confirm `pip install athenaeum` returns our package

🤖 Generated with [Claude Code](https://claude.com/claude-code)
