### PR TITLE
ci: revert pypa/gh-action-pypi-publish to tag-ref pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,18 @@ jobs:
           name: dist
           path: dist/
 
+      # pypa/gh-action-pypi-publish is a Docker container action. The
+      # container image at `ghcr.io/pypa/gh-action-pypi-publish:<tag>` is
+      # keyed by semver tag, not commit SHA — pinning the action at a SHA
+      # (as we do for the JS-based actions above) causes the Docker pull
+      # to 404 with "manifest unknown". We therefore pin by a specific
+      # semver tag. That tag is still a mutable ref, but the tradeoff is
+      # acceptable here: pypa is a first-party trusted publisher, and
+      # the OIDC exchange with PyPI verifies both the repo and the
+      # workflow ref at publish time. See v0.2.1 release attempt (run
+      # 24582826878) for the failure mode this comment documents.
       - name: Publish to PyPI via Trusted Publishing
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d  # v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           # PEP 740 attestations — publisher mints a sigstore bundle,
           # PyPI stores it, downstream consumers can


### PR DESCRIPTION
## Summary

- The v0.2.1 release workflow (run [24582826878](https://github.com/Kromatic-Innovation/athenaeum/actions/runs/24582826878)) failed at publish with `docker: Error response from daemon: manifest unknown`
- Root cause: `pypa/gh-action-pypi-publish` is a Docker container action whose image at `ghcr.io/pypa/gh-action-pypi-publish:<ref>` is keyed by **semver tag**, not commit SHA. SHA-pinning (as we do for the JS-based actions) breaks the Docker pull because pypa doesn't publish per-commit images
- Reverted that one action to `@v1.14.0`, with an inline comment documenting the constraint so nobody re-SHA-pins it and rediscovers the failure. Other actions stay SHA-pinned
- v0.2.1 was never published to PyPI (publish step failed before upload), so after merge we'll move the existing tag to include this fix

## Test plan

- [x] Only `.github/workflows/release.yml` changed — no code, no tests
- [ ] Merge → delete `v0.2.1` tag → retag at new develop HEAD → push → verify PyPI publish succeeds this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
