### PR TITLE
docs(readme): add PyPI / python-versions / license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Athenaeum
 
+[![PyPI version](https://img.shields.io/pypi/v/athenaeum.svg)](https://pypi.org/project/athenaeum/)
+[![Python versions](https://img.shields.io/pypi/pyversions/athenaeum.svg)](https://pypi.org/project/athenaeum/)
+[![License](https://img.shields.io/pypi/l/athenaeum.svg)](https://github.com/Kromatic-Innovation/athenaeum/blob/main/LICENSE)
+
 Open source knowledge management pipeline for AI agents — append-only intake, tiered compilation, configurable schemas.
 
 > **Using Claude Code?** Athenaeum ships a transparent memory sidecar — a


### PR DESCRIPTION
## Summary

- Adds PyPI version, supported-python-versions, and license badges at the top of the README
- Now that v0.2.1 is on PyPI, these SVGs render live from shields.io and don't need regeneration per release
- Purely cosmetic — no functional changes

## Test plan

- [x] README.md is the only file touched
- [ ] After merge: hard-reload the GitHub README page and confirm the badges render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
