### PR TITLE
release: v0.2.3 (docs + ops, no library changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-04-21
+
+Documentation and ops release accompanying the launch of
+["What We Learned Running Our Own Operations on Agentic Memory"](https://kromatic.com/blog/agentic-memory-in-production/).
+No library code changes — every existing install keeps working without
+modification.
+
+### Added
+- **`docs/why-athenaeum.md`** — evergreen design-rationale doc. Covers the
+  three problems that motivated Athenaeum, the four questions a production
+  memory system has to answer, and a full comparison against Claude's
+  built-in memory, Anthropic's memory tool, RAG, Karpathy's wiki gist, and
+  the mem0/Letta/Zep/Cognee category. The four design choices (sources as
+  first-class objects, the tiered librarian, passive recall, the editable
+  observation filter) are mapped to which failure mode each one fixes.
+- **`.github/workflows/promote-main.yml`** — fast-forward `develop → main`
+  promotion workflow (workflow_dispatch) matching the rest of the Kromatic
+  deploy-pipeline repos. Validates that `main` is a strict ancestor of
+  `develop` and that required CI checks passed on the `develop` SHA before
+  touching `main`. No merge commits are introduced on `main`, so history
+  stays linear.
+
+### Changed
+- **`README.md` restructured** around the four design choices. Leads with
+  "who this is for" and one-line pointers into `docs/why-athenaeum.md`;
+  preserves install / quickstart / MCP / hooks / vector / env vars / data
+  formats / known limitations below. The standalone Architecture bullet
+  list is gone (now covered in `docs/why-athenaeum.md`).
+- **`docs/assets/athena.png`** — replaced with the Athena illustration from
+  the launch blog post.
+- **`CONTRIBUTING.md`** — documents the develop-first branch flow
+  explicitly: feature → `develop`, `develop → main` via the promotion
+  workflow, no direct PRs to `main`. Explains why there is no staging
+  branch (library repo; releases via PyPI/`release.yml`).
+
+### Fixed
+- **`SECURITY.md`** supported-branch statement. The supported release lives
+  on `main`; fixes land on `develop` first and are promoted. The prior
+  wording had these inverted.
+
 ## [0.2.2] - 2026-04-17
 
 Pre-blog-post review pass. Non-breaking fixes surfaced by a final

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "athenaeum"
-version = "0.2.2"
+version = "0.2.3"
 description = "Open source knowledge management pipeline — append-only intake, tiered compilation, configurable schemas"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Version bump to 0.2.3 accompanying the launch blog post. Docs + ops release, no library code changes.

- `pyproject.toml` — version 0.2.2 → 0.2.3
- `CHANGELOG.md` — new [0.2.3] section detailing the four changes since 0.2.2 (why-athenaeum.md, README restructure, illustration swap, promote-main workflow + develop-first docs, SECURITY.md fix)

After this merges to develop, the Promote Main workflow will fast-forward `main` to this SHA for the first real end-to-end use of the new workflow. The `v0.2.3` tag will be cut on that `main` SHA to fire `release.yml` and publish to PyPI.

## Test plan

- [ ] CI passes on this PR.
- [ ] `Promote Main` workflow succeeds (fast-forward precondition met; CI green on source SHA).
- [ ] `release.yml` triggered by the `v0.2.3` tag publishes successfully to PyPI via Trusted Publishing.
- [ ] `pip install athenaeum==0.2.3` works after publish; README and the new `docs/why-athenaeum.md` render on PyPI.

Generated with [Claude Code](https://claude.com/claude-code)
