### PR TITLE
ops(promote-main): use PROMOTION_BOT_TOKEN for refs-API PATCH

### DIFF
--- a/.github/workflows/promote-main.yml
+++ b/.github/workflows/promote-main.yml
@@ -101,9 +101,18 @@ jobs:
 
       - name: Push fast-forward promotion via refs API
         env:
-          GH_TOKEN: ${{ github.token }}
+          # PROMOTION_BOT_TOKEN is required because main's branch protection
+          # (required_pull_request_reviews) rejects direct ref writes by the
+          # default GITHUB_TOKEN with HTTP 422. The bot token has the App
+          # bypass for promotion refs.
+          GH_TOKEN: ${{ secrets.PROMOTION_BOT_TOKEN }}
         run: |
           set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::PROMOTION_BOT_TOKEN secret is not available to this workflow. Configure it at the org level or the repo secrets."
+            exit 1
+          fi
 
           update_payload=$(jq -nc --arg sha "$source_sha" '{sha:$sha,force:false}')
           update_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/git/refs/heads/${TARGET_BRANCH}"


### PR DESCRIPTION
## Summary

Wires `PROMOTION_BOT_TOKEN` into the refs-API PATCH step of `promote-main.yml` so the workflow can actually promote autonomously.

**Why:** `main`'s branch protection has `required_pull_request_reviews` set (0 approvals), which rejects direct ref writes by the default `GITHUB_TOKEN` with HTTP 422. That's what forced the manual admin fast-forward during the 0.2.3 release. The org-level `PROMOTION_BOT_TOKEN` (GitHub App) has the bypass for promotion refs.

**Scope:** only the PATCH step swaps tokens. Checkout and CI-check steps still use `github.token` (read-only).

**Security note:** the workflow triggers on `workflow_dispatch` only — no `pull_request`, no `pull_request_target`, no `push`. Fork PRs therefore cannot access this secret. The token is also guarded with an explicit empty-check so a missing secret fails fast with a clear error instead of silently retrying the old 422.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge + promote to main, the next `Promote Main` run completes without HTTP 422 (i.e., no manual admin fast-forward needed next time).

Generated with [Claude Code](https://claude.com/claude-code)
