### PR TITLE
feat: pending-question ingest loop (closes #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-20
+
+Headline feature: **the Tier 4 escalation path is no longer write-only.**
+`_pending_questions.md` now supports a full answer loop — humans (or
+containerized agents via MCP) can resolve a pending question, and the
+librarian ingests the answer as raw intake on the next run. This closes
+the human-in-the-loop gap that shipped as a known limitation in 0.2.x.
+
+### Added
+- **`athenaeum ingest-answers` CLI** — scans `wiki/_pending_questions.md`,
+  converts each `[x]`-checked block into a raw intake file under
+  `raw/answers/{ISO-TS}-{entity-slug}.md` (with frontmatter linking back
+  to the original source), then moves the block into
+  `wiki/_pending_questions_archive.md`. Idempotent — re-running with no
+  new `[x]` blocks is a no-op. Malformed blocks are preserved in place
+  and logged to stderr, so a single corrupt entry cannot poison the
+  rest of the file.
+- **`athenaeum.answers` module** — new public surface exposing
+  `ingest_answers`, `parse_pending_questions`, `list_unanswered`, and
+  `resolve_by_id`. The parser tolerates both schema variants (blocks
+  split on `## ` headers or `---` dividers) and emits structured
+  `PendingQuestion` dataclasses.
+- **Two new MCP tools** — `list_pending_questions()` returns unanswered
+  blocks as JSON (id, entity, source, question, conflict_type,
+  description, created_at), and `resolve_question(id, answer)` flips
+  `- [ ]` -> `- [x]` and writes the answer body below the checkbox.
+  Archival is intentionally NOT done at resolve-time — it runs on the
+  next `ingest-answers` pass so the write path stays small and the
+  archive step is atomic.
+- **Checkbox render in `tier4_escalate`** — every new escalation now
+  renders a leading `- [ ] {question}` line directly under the header.
+  The question is derived from the first line of the LLM's description;
+  an empty description falls back to
+  `"Resolve {conflict_type} conflict for {entity}"`.
+- **`tests/test_answers.py`** — new file covering round-trip,
+  idempotency, mixed state, malformed-block tolerance, archive
+  newest-first ordering, and MCP-helper happy + error paths.
+
+### Changed
+- **`src/athenaeum/__init__.py`** `__version__` bumped `0.2.2 -> 0.3.0`
+  (was stale; pyproject was 0.2.3 on the prior release).
+- **`tier4_escalate` schema** gained the checkbox line. Existing consumers
+  that `.count("## [")` on the file for a pending-question total still
+  work unchanged (the header format is preserved verbatim).
+
 ## [0.2.3] - 2026-04-21
 
 Documentation and ops release accompanying the launch of
@@ -195,7 +240,10 @@ knowledge librarian.
 - Test suite extracted from upstream + CI coverage enforcement (`>=75%`)
 - Transactional writes, type-safety hardening, prompt-injection mitigation, API budget caps
 
-[Unreleased]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.3...v0.3.0
+[0.2.3]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.2...v0.2.3
+[0.2.2]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Kromatic-Innovation/athenaeum/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -102,6 +102,69 @@ Example round-trip:
 > exist yet. Later sessions can ask _"who is Amanda?"_ and `recall`
 > returns the compiled page.
 
+## Answering pending questions
+
+When Tier 3 can't resolve an ambiguity or a principled contradiction, the
+librarian escalates to `wiki/_pending_questions.md`. Each escalation lands
+as a block like:
+
+```markdown
+## [2026-04-20] Entity: "Acme Corp" (from sessions/20240406T120000Z-aabb0011.md)
+- [ ] Is Acme still Series A after the 2026 recapitalisation?
+**Conflict type**: principled
+**Description**: Prior wiki says Series A; the 2026-04 raw file implies Series B.
+```
+
+You resolve a question one of two ways — pick whichever fits your workflow:
+
+### Option 1 — Edit the file directly
+
+Flip `[ ]` to `[x]` on the checkbox line and type your answer below the
+checkbox (above or below the conflict-type / description lines — either
+works; the parser strips those metadata lines when extracting the answer):
+
+```markdown
+## [2026-04-20] Entity: "Acme Corp" (from sessions/20240406T120000Z-aabb0011.md)
+- [x] Is Acme still Series A after the 2026 recapitalisation?
+
+They closed Series B on 2026-03-12, led by Acme Growth Partners.
+The 2026-04 raw file is correct; the prior wiki entry is stale.
+
+**Conflict type**: principled
+**Description**: Prior wiki says Series A; the 2026-04 raw file implies Series B.
+```
+
+### Option 2 — Use the MCP tool
+
+For containerized agents that can't touch the filesystem, `athenaeum serve`
+exposes two tools:
+
+- `list_pending_questions()` returns unanswered blocks as JSON — each item
+  carries a stable `id` derived from the header + question text.
+- `resolve_question(id, answer)` flips the checkbox and writes the answer
+  body under it. It does **not** archive on its own — archival runs on the
+  next `ingest-answers` pass.
+
+### Step 2 — ingest the answers
+
+Either way, run:
+
+```bash
+athenaeum ingest-answers --path ~/knowledge
+```
+
+Each `[x]` block is rewritten as a raw intake file under
+`raw/answers/{timestamp}-{entity-slug}.md` with frontmatter linking back
+to the original source, then moved into
+`wiki/_pending_questions_archive.md` (newest-first, append-only — answered
+blocks are never deleted, only moved). The next `athenaeum run` picks the
+raw file up like any other intake and folds the answer into the wiki
+entity.
+
+Re-running with no new `[x]` blocks is a no-op. Malformed blocks are
+preserved in place and logged to stderr, so a corrupt single entry cannot
+poison the rest of the file.
+
 ## Transparent sidecar (Claude Code hooks)
 
 For a fully passive experience where Claude auto-recalls relevant context on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "athenaeum"
-version = "0.2.3"
+version = "0.3.0"
 description = "Open source knowledge management pipeline — append-only intake, tiered compilation, configurable schemas"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/athenaeum/__init__.py
+++ b/src/athenaeum/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Athenaeum — open source knowledge management pipeline."""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 from athenaeum.init import init_knowledge_dir
 from athenaeum.librarian import discover_raw_files, process_one, rebuild_index, run

--- a/src/athenaeum/answers.py
+++ b/src/athenaeum/answers.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pending-question answer ingestion.
+
+``_pending_questions.md`` is populated by ``tier4_escalate`` whenever Tier 3
+surfaces an ambiguity or a principled contradiction. Each block starts with
+a header like::
+
+    ## [2026-04-20] Entity: "Acme Corp" (from sessions/20240406T120000Z-aabb.md)
+    - [ ] Is Acme still Series A after the 2026 recapitalisation?
+    **Conflict type**: principled
+    **Description**: Prior wiki says Series A; new raw file implies Series B.
+
+The user resolves a question by either:
+
+1. Editing the file and flipping ``- [ ]`` to ``- [x]`` (typing answer text
+   below the checkbox on subsequent lines).
+2. Calling the MCP tool :func:`resolve_question` which does the same edit.
+
+Running ``athenaeum ingest-answers`` then:
+
+- Writes each ``[x]`` block as a raw intake file under
+  ``raw/answers/{ISO-TS}-{entity-slug}.md`` with frontmatter naming the
+  original source.
+- Appends the processed block to ``_pending_questions_archive.md``
+  (newest-first, append-only, never deleted).
+- Leaves unanswered ``[ ]`` blocks in place.
+
+Re-running with no new ``[x]`` blocks is a no-op. Malformed blocks are
+skipped with a warning on stderr and a log entry; the rest of the file is
+still processed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# Header grammar — matches `## [ISO-DATE] Entity: "{name}" (from {ref})`.
+# ISO-DATE is intentionally a loose match (``[^\]]+``) so a future shift to
+# datetime-with-time doesn't break the parser. The entity name is captured
+# between straight quotes; the raw ref is everything up to the closing paren.
+_HEADER_RE = re.compile(
+    r"^## \[(?P<date>[^\]]+)\] Entity: \"(?P<entity>[^\"]+)\" \(from (?P<ref>[^)]+)\)$"
+)
+# Checkbox grammar — ``- [ ]`` or ``- [x]`` (case-insensitive on ``x``).
+_CHECKBOX_RE = re.compile(r"^- \[(?P<state>[ xX])\]\s*(?P<question>.*)$")
+# Lines we strip when extracting the user's answer body.
+_META_PREFIXES = ("**Conflict type**:", "**Description**:")
+
+
+@dataclass
+class PendingQuestion:
+    """Parsed view of one block in ``_pending_questions.md``.
+
+    Returned by :func:`parse_pending_questions` and consumed by the MCP
+    ``list_pending_questions`` / ``resolve_question`` tools. ``raw_block``
+    preserves the exact source text of the block so callers can rewrite the
+    file without losing formatting.
+    """
+
+    id: str
+    entity: str
+    source: str
+    question: str
+    conflict_type: str
+    description: str
+    created_at: str
+    answered: bool
+    answer_lines: list[str]
+    raw_block: str
+
+
+def _make_id(header_line: str, question_text: str) -> str:
+    """Stable id derived from the header line + question text.
+
+    Idempotent across runs as long as the block text hasn't been edited —
+    which is also when the id should change, because the block's identity
+    has changed.
+    """
+    payload = f"{header_line.strip()}\n{question_text.strip()}".encode("utf-8")
+    return hashlib.sha1(payload).hexdigest()[:12]
+
+
+def _split_blocks(text: str) -> list[str]:
+    """Split ``_pending_questions.md`` text into per-question blocks.
+
+    Blocks are separated by ``## `` headers or ``---`` dividers; the file
+    leader (``# Pending Questions``, blank lines, or a stray preamble)
+    is discarded. Each returned block starts with its ``## `` header.
+    """
+    blocks: list[str] = []
+    current: list[str] = []
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if line.startswith("## "):
+            if current:
+                blocks.append("\n".join(current).rstrip())
+            current = [line]
+        elif stripped == "---":
+            if current:
+                blocks.append("\n".join(current).rstrip())
+                current = []
+        else:
+            if current:
+                current.append(line)
+    if current:
+        blocks.append("\n".join(current).rstrip())
+
+    return [b for b in blocks if b.startswith("## ")]
+
+
+def _parse_block(block_text: str) -> PendingQuestion | None:
+    """Parse one block. Returns ``None`` on malformed input."""
+    lines = block_text.splitlines()
+    if not lines:
+        return None
+
+    header_match = _HEADER_RE.match(lines[0])
+    if not header_match:
+        log.warning("Skipping block with malformed header: %r", lines[0][:80])
+        print(
+            f"[warn] skipping pending-question block with malformed header: "
+            f"{lines[0][:80]!r}",
+            file=sys.stderr,
+        )
+        return None
+
+    # Find the checkbox line — first non-blank line after the header.
+    checkbox_idx: int | None = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "":
+            continue
+        if _CHECKBOX_RE.match(lines[idx]):
+            checkbox_idx = idx
+        break
+
+    if checkbox_idx is None:
+        log.warning(
+            "Skipping block without checkbox line: %r", lines[0][:80]
+        )
+        print(
+            f"[warn] skipping pending-question block without `- [ ]` line: "
+            f"{lines[0][:80]!r}",
+            file=sys.stderr,
+        )
+        return None
+
+    cb_match = _CHECKBOX_RE.match(lines[checkbox_idx])
+    assert cb_match is not None  # guarded above
+    answered = cb_match.group("state").lower() == "x"
+    question = cb_match.group("question").strip()
+
+    conflict_type = ""
+    description = ""
+    answer_lines: list[str] = []
+
+    for raw_line in lines[checkbox_idx + 1 :]:
+        stripped = raw_line.strip()
+        if stripped.startswith("**Conflict type**:"):
+            conflict_type = stripped.removeprefix("**Conflict type**:").strip()
+            continue
+        if stripped.startswith("**Description**:"):
+            description = stripped.removeprefix("**Description**:").strip()
+            continue
+        # Otherwise: treat as part of the user's answer body.
+        answer_lines.append(raw_line)
+
+    # Trim leading/trailing blank lines from the answer body.
+    while answer_lines and not answer_lines[0].strip():
+        answer_lines.pop(0)
+    while answer_lines and not answer_lines[-1].strip():
+        answer_lines.pop()
+
+    return PendingQuestion(
+        id=_make_id(lines[0], question),
+        entity=header_match.group("entity"),
+        source=header_match.group("ref"),
+        question=question,
+        conflict_type=conflict_type,
+        description=description,
+        created_at=header_match.group("date"),
+        answered=answered,
+        answer_lines=answer_lines,
+        raw_block=block_text,
+    )
+
+
+def parse_pending_questions(pending_path: Path) -> list[PendingQuestion]:
+    """Parse ``_pending_questions.md`` into :class:`PendingQuestion` objects.
+
+    Malformed blocks are logged and skipped — a corrupt single block cannot
+    poison the rest of the file.
+    """
+    if not pending_path.exists():
+        return []
+    text = pending_path.read_text(encoding="utf-8")
+    return [pq for b in _split_blocks(text) if (pq := _parse_block(b)) is not None]
+
+
+# ---------------------------------------------------------------------------
+# Ingest pipeline
+# ---------------------------------------------------------------------------
+
+
+def _slugify(name: str) -> str:
+    """Turn an entity name into a filesystem-safe slug."""
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", name.strip().lower()).strip("-")
+    return slug or "entity"
+
+
+def _render_archive_block(pq: PendingQuestion, archived_at: str) -> str:
+    """Render an archive entry for an answered block.
+
+    Includes the original raw block verbatim plus a trailer noting when the
+    answer was ingested. Newest-first is handled by the caller.
+    """
+    return (
+        f"{pq.raw_block}\n\n"
+        f"**Archived**: {archived_at}\n"
+    )
+
+
+def _render_answer_raw_file(pq: PendingQuestion, resolved_at: str) -> str:
+    """Render the raw intake markdown for a resolved question."""
+    body = "\n".join(pq.answer_lines).strip()
+    if not body:
+        body = "(no answer body provided)"
+
+    return (
+        "---\n"
+        "source: pending_question_answer\n"
+        f"original_source: raw/{pq.source}\n"
+        f"entity: {pq.entity}\n"
+        f"resolved_at: {resolved_at}\n"
+        f"question: {pq.question}\n"
+        "---\n\n"
+        f"{body}\n"
+    )
+
+
+def ingest_answers(pending_path: Path, raw_root: Path) -> int:
+    """Parse resolved items from ``pending_path``, write raw intake, archive.
+
+    Walks ``_pending_questions.md``; for each ``[x]`` block writes a file
+    under ``raw/answers/`` with frontmatter linking back to the original
+    source, then moves the block to ``_pending_questions_archive.md``
+    (newest-first, append-only). ``[ ]`` blocks are left in place.
+
+    Idempotent: calling again with no new ``[x]`` blocks is a no-op.
+    Malformed blocks emit a warning and are skipped.
+
+    Args:
+        pending_path: Path to ``_pending_questions.md``.
+        raw_root: Raw intake root (answers land in ``raw_root/answers/``).
+
+    Returns:
+        Count of answers ingested on this run.
+    """
+    if not pending_path.exists():
+        return 0
+
+    text = pending_path.read_text(encoding="utf-8")
+    blocks = _split_blocks(text)
+    if not blocks:
+        return 0
+
+    answers_dir = raw_root / "answers"
+
+    unanswered: list[PendingQuestion] = []
+    archived_new: list[str] = []
+    ingested = 0
+
+    now = datetime.now(timezone.utc)
+    iso_ts = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    filename_ts = now.strftime("%Y%m%dT%H%M%SZ")
+
+    for block_text in blocks:
+        pq = _parse_block(block_text)
+        if pq is None:
+            # Malformed — preserve as-is in the primary file so the human
+            # can see + fix it. Do not archive.
+            log.warning("Preserving malformed block verbatim in primary file.")
+            unanswered.append(
+                PendingQuestion(
+                    id="malformed",
+                    entity="",
+                    source="",
+                    question="",
+                    conflict_type="",
+                    description="",
+                    created_at="",
+                    answered=False,
+                    answer_lines=[],
+                    raw_block=block_text,
+                )
+            )
+            continue
+
+        if not pq.answered:
+            unanswered.append(pq)
+            continue
+
+        # Write raw intake file — retry with a counter if the slug collides
+        # within the same second (two answers resolved in the same run).
+        answers_dir.mkdir(parents=True, exist_ok=True)
+        slug = _slugify(pq.entity)
+        candidate = answers_dir / f"{filename_ts}-{slug}.md"
+        counter = 1
+        while candidate.exists():
+            candidate = answers_dir / f"{filename_ts}-{slug}-{counter}.md"
+            counter += 1
+        candidate.write_text(_render_answer_raw_file(pq, iso_ts), encoding="utf-8")
+        archived_new.append(_render_archive_block(pq, iso_ts))
+        ingested += 1
+
+    if ingested == 0:
+        return 0
+
+    # Rewrite the primary file — keep the header, keep unanswered blocks.
+    primary_parts = ["# Pending Questions"]
+    for pq in unanswered:
+        primary_parts.append(pq.raw_block)
+    primary_body = "\n\n---\n\n".join(primary_parts) + "\n"
+    pending_path.write_text(primary_body, encoding="utf-8")
+
+    # Append to archive, newest-first.
+    archive_path = pending_path.parent / "_pending_questions_archive.md"
+    existing_archive = ""
+    if archive_path.exists():
+        existing_archive = archive_path.read_text(encoding="utf-8")
+
+    new_section = "\n\n---\n\n".join(archived_new)
+    if existing_archive.strip():
+        # newest-first: new answers go at the top, under the header.
+        if existing_archive.startswith("# Answered Questions"):
+            # Split off the header so we can prepend under it.
+            _, _, rest = existing_archive.partition("\n")
+            combined = (
+                "# Answered Questions\n\n"
+                + new_section
+                + "\n\n---\n\n"
+                + rest.lstrip()
+            )
+        else:
+            combined = (
+                "# Answered Questions\n\n"
+                + new_section
+                + "\n\n---\n\n"
+                + existing_archive.lstrip()
+            )
+    else:
+        combined = "# Answered Questions\n\n" + new_section + "\n"
+
+    archive_path.write_text(combined, encoding="utf-8")
+
+    log.info(
+        "Ingested %d pending-question answer(s) from %s", ingested, pending_path
+    )
+    return ingested
+
+
+# ---------------------------------------------------------------------------
+# MCP-facing helpers
+# ---------------------------------------------------------------------------
+
+
+def list_unanswered(pending_path: Path) -> list[dict]:
+    """Return unanswered pending questions as dicts suitable for MCP output.
+
+    Each dict has: ``id``, ``entity``, ``source``, ``question``,
+    ``conflict_type``, ``description``, ``created_at``.
+    """
+    return [
+        {
+            "id": pq.id,
+            "entity": pq.entity,
+            "source": pq.source,
+            "question": pq.question,
+            "conflict_type": pq.conflict_type,
+            "description": pq.description,
+            "created_at": pq.created_at,
+        }
+        for pq in parse_pending_questions(pending_path)
+        if not pq.answered
+    ]
+
+
+def resolve_by_id(pending_path: Path, question_id: str, answer: str) -> dict:
+    """Locate a block by id, flip ``[ ]`` -> ``[x]``, append the answer body.
+
+    Does NOT archive — archival happens on the next ``ingest_answers`` run
+    so the write path stays small. Returns a dict with ``ok`` and either
+    ``block`` (the rewritten block text) or ``error``.
+    """
+    if not pending_path.exists():
+        return {"ok": False, "error": f"pending questions file not found: {pending_path}"}
+
+    text = pending_path.read_text(encoding="utf-8")
+    blocks = _split_blocks(text)
+    if not blocks:
+        return {"ok": False, "error": "no pending question blocks in file"}
+
+    new_block_text: str | None = None
+    rewritten_blocks: list[str] = []
+
+    for block_text in blocks:
+        pq = _parse_block(block_text)
+        if pq is None:
+            rewritten_blocks.append(block_text)
+            continue
+        if pq.id != question_id:
+            rewritten_blocks.append(block_text)
+            continue
+        if pq.answered:
+            return {
+                "ok": False,
+                "error": f"question {question_id} already answered",
+            }
+
+        updated = _rewrite_block_as_answered(block_text, answer)
+        new_block_text = updated
+        rewritten_blocks.append(updated)
+
+    if new_block_text is None:
+        return {"ok": False, "error": f"question id not found: {question_id}"}
+
+    primary_parts = ["# Pending Questions", *rewritten_blocks]
+    primary_body = "\n\n---\n\n".join(primary_parts) + "\n"
+    pending_path.write_text(primary_body, encoding="utf-8")
+
+    return {"ok": True, "block": new_block_text}
+
+
+def _rewrite_block_as_answered(block_text: str, answer: str) -> str:
+    """Flip the checkbox on ``block_text`` and insert ``answer`` beneath it.
+
+    Preserves all other lines (header, conflict type, description) so the
+    archive trail keeps full context.
+    """
+    lines = block_text.splitlines()
+    new_lines: list[str] = []
+    answer_inserted = False
+
+    for line in lines:
+        match = _CHECKBOX_RE.match(line)
+        if match and not answer_inserted:
+            new_lines.append(f"- [x] {match.group('question').strip()}")
+            new_lines.append("")
+            for answer_line in answer.rstrip().splitlines():
+                new_lines.append(answer_line)
+            new_lines.append("")
+            answer_inserted = True
+            continue
+        new_lines.append(line)
+
+    return "\n".join(new_lines).rstrip() + "\n"

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -108,6 +108,18 @@ def main(argv: list[str] | None = None) -> int:
              "to stay in sync with the FTS5 query filter.",
     )
 
+    # ingest-answers command — convert resolved `[x]` blocks in
+    # _pending_questions.md into raw intake files and archive the answered
+    # blocks. Idempotent — safe to run from a scheduler.
+    ingest_answers_parser = subparsers.add_parser(
+        "ingest-answers",
+        help="Ingest answered pending questions from _pending_questions.md",
+    )
+    ingest_answers_parser.add_argument(
+        "--path", type=Path, default=Path("~/knowledge"),
+        help="Knowledge directory (default: ~/knowledge)",
+    )
+
     # rebuild-index command — rebuild the search index out-of-band
     rebuild_parser = subparsers.add_parser(
         "rebuild-index",
@@ -143,6 +155,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "run":
         return _cmd_run(args)
+
+    if args.command == "ingest-answers":
+        return _cmd_ingest_answers(args)
 
     if args.command == "rebuild-index":
         return _cmd_rebuild_index(args)
@@ -275,6 +290,35 @@ def _cmd_run(args: argparse.Namespace) -> int:
         max_files=args.max_files,
         max_api_calls=args.max_api_calls,
     )
+
+
+def _cmd_ingest_answers(args: argparse.Namespace) -> int:
+    """Ingest answered blocks from `_pending_questions.md` as raw intake.
+
+    See :func:`athenaeum.answers.ingest_answers` for the semantics.
+    """
+    from athenaeum.answers import ingest_answers
+
+    target = args.path.expanduser().resolve()
+    if not target.exists():
+        print(f"Knowledge directory not found: {target}", file=sys.stderr)
+        print(
+            f"Run 'athenaeum init --path {args.path}' first, then retry.",
+            file=sys.stderr,
+        )
+        return 1
+
+    pending_path = target / "wiki" / "_pending_questions.md"
+    raw_root = target / "raw"
+
+    try:
+        count = ingest_answers(pending_path, raw_root)
+    except Exception as exc:  # noqa: BLE001 — surface a clean CLI error
+        print(f"Fatal error ingesting answers: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Ingested {count} answered question(s).")
+    return 0
 
 
 def _cmd_rebuild_index(args: argparse.Namespace) -> int:

--- a/src/athenaeum/mcp_server.py
+++ b/src/athenaeum/mcp_server.py
@@ -276,4 +276,49 @@ def create_server(
         """
         return remember_write(raw_root, content, source, wiki_root=wiki_root)
 
+    @mcp.tool()
+    def list_pending_questions() -> list[dict]:
+        """List unanswered pending questions.
+
+        Returns the unanswered blocks from ``wiki/_pending_questions.md`` in
+        a shape any agent can render — including containerized agents that
+        cannot touch the filesystem directly. Each item has ``id``,
+        ``entity``, ``source`` (the originating raw file), ``question``,
+        ``conflict_type``, ``description``, and ``created_at``.
+
+        The ``id`` is stable across runs as long as the block's header +
+        question text are unchanged, so an agent can call this tool,
+        present the list, and then call ``resolve_question`` with the id
+        of the chosen item.
+        """
+        from athenaeum.answers import list_unanswered
+
+        pending_path = wiki_root / "_pending_questions.md"
+        return list_unanswered(pending_path)
+
+    @mcp.tool()
+    def resolve_question(id: str, answer: str) -> dict:
+        """Flip a pending question to answered and write the answer body.
+
+        Locates the block by id, flips ``- [ ]`` -> ``- [x]``, and inserts
+        the answer text beneath the checkbox. This is a write to the
+        primary file only — archival to ``_pending_questions_archive.md``
+        and conversion to a raw intake file both happen on the next
+        ``athenaeum ingest-answers`` run (keeping this tool's write path
+        small and auditable).
+
+        Args:
+            id: The id returned by ``list_pending_questions``.
+            answer: The answer body (markdown; may be multi-line).
+
+        Returns:
+            ``{"ok": true, "block": "..."}`` on success, or
+            ``{"ok": false, "error": "..."}`` if the id is not found,
+            already answered, or the file is missing.
+        """
+        from athenaeum.answers import resolve_by_id
+
+        pending_path = wiki_root / "_pending_questions.md"
+        return resolve_by_id(pending_path, id, answer)
+
     return mcp

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -461,16 +461,40 @@ def tier3_write(
 # Tier 4 — Human escalation
 # ---------------------------------------------------------------------------
 
+def _question_from_description(description: str, entity_name: str, conflict_type: str) -> str:
+    """Derive a one-line question for the checkbox row.
+
+    Uses the first non-empty line of the description, trimmed to a single
+    line (no newlines, no leading markdown bullets). Falls back to a canned
+    prompt if the description is empty.
+    """
+    for raw_line in description.splitlines():
+        line = raw_line.strip().lstrip("-*").strip()
+        if line:
+            return line
+    return f"Resolve {conflict_type} conflict for {entity_name}"
+
+
 def tier4_escalate(items: list[EscalationItem], pending_path: Path) -> None:
-    """Append escalation items to _pending_questions.md."""
+    """Append escalation items to ``_pending_questions.md``.
+
+    Each block is rendered with a leading checkbox line directly under the
+    header so the user (or the ``resolve_question`` MCP tool) can flip
+    ``[ ]`` -> ``[x]`` to mark an answer; ``athenaeum ingest-answers`` then
+    converts the block to a raw intake file. See ``athenaeum.answers``.
+    """
     if not items:
         return
 
     today = date.today().isoformat()
     sections: list[str] = []
     for item in items:
+        question = _question_from_description(
+            item.description, item.entity_name, item.conflict_type
+        )
         sections.append(
-            f"## [{today}] Entity: \"{item.entity_name}\" (from {item.raw_ref})\n\n"
+            f"## [{today}] Entity: \"{item.entity_name}\" (from {item.raw_ref})\n"
+            f"- [ ] {question}\n\n"
             f"**Conflict type**: {item.conflict_type}\n"
             f"**Description**: {item.description}\n"
         )

--- a/tests/test_answers.py
+++ b/tests/test_answers.py
@@ -1,0 +1,420 @@
+"""Tests for athenaeum.answers — pending-question answer ingestion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athenaeum.answers import (
+    PendingQuestion,
+    ingest_answers,
+    list_unanswered,
+    parse_pending_questions,
+    resolve_by_id,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _block(
+    *,
+    date: str = "2026-04-20",
+    entity: str = "Acme Corp",
+    source: str = "sessions/20240406T120000Z-aabb0011.md",
+    checkbox: str = "[ ]",
+    question: str = "Is Acme still Series A after the 2026 recap?",
+    conflict_type: str = "principled",
+    description: str = "Wiki says Series A; new raw implies Series B.",
+    answer: str = "",
+) -> str:
+    block = (
+        f"## [{date}] Entity: \"{entity}\" (from {source})\n"
+        f"- {checkbox} {question}\n"
+        f"**Conflict type**: {conflict_type}\n"
+        f"**Description**: {description}\n"
+    )
+    if answer:
+        block += f"\n{answer}\n"
+    return block
+
+
+@pytest.fixture
+def pending_path(tmp_path: Path) -> Path:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    return wiki / "_pending_questions.md"
+
+
+@pytest.fixture
+def raw_root(tmp_path: Path) -> Path:
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# parse_pending_questions
+# ---------------------------------------------------------------------------
+
+
+class TestParsePendingQuestions:
+    def test_returns_empty_when_file_missing(self, pending_path: Path) -> None:
+        assert parse_pending_questions(pending_path) == []
+
+    def test_parses_single_unanswered_block(self, pending_path: Path) -> None:
+        pending_path.write_text("# Pending Questions\n\n" + _block())
+        parsed = parse_pending_questions(pending_path)
+        assert len(parsed) == 1
+        pq = parsed[0]
+        assert pq.entity == "Acme Corp"
+        assert pq.source == "sessions/20240406T120000Z-aabb0011.md"
+        assert pq.question.startswith("Is Acme still")
+        assert pq.conflict_type == "principled"
+        assert "Series B" in pq.description
+        assert pq.created_at == "2026-04-20"
+        assert pq.answered is False
+        assert pq.answer_lines == []
+        assert len(pq.id) == 12
+
+    def test_parses_answered_block_with_body(self, pending_path: Path) -> None:
+        block = _block(
+            checkbox="[x]",
+            answer="They closed Series B in March 2026. Prior wiki is stale.",
+        )
+        pending_path.write_text("# Pending Questions\n\n" + block)
+        parsed = parse_pending_questions(pending_path)
+        assert len(parsed) == 1
+        pq = parsed[0]
+        assert pq.answered is True
+        assert any("Series B in March" in line for line in pq.answer_lines)
+
+    def test_id_stable_across_runs(self, pending_path: Path) -> None:
+        pending_path.write_text("# Pending Questions\n\n" + _block())
+        first = parse_pending_questions(pending_path)[0].id
+        second = parse_pending_questions(pending_path)[0].id
+        assert first == second
+
+    def test_id_differs_between_blocks(self, pending_path: Path) -> None:
+        content = (
+            "# Pending Questions\n\n"
+            + _block(entity="Acme Corp")
+            + "\n---\n\n"
+            + _block(entity="Globex")
+        )
+        pending_path.write_text(content)
+        parsed = parse_pending_questions(pending_path)
+        assert len({pq.id for pq in parsed}) == 2
+
+    def test_skips_malformed_header(
+        self, pending_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        content = (
+            "# Pending Questions\n\n"
+            "## Not a real header\n"
+            "- [ ] some question\n"
+            "**Conflict type**: ambiguous\n"
+            "**Description**: desc\n"
+        )
+        pending_path.write_text(content)
+        parsed = parse_pending_questions(pending_path)
+        assert parsed == []
+        err = capsys.readouterr().err
+        assert "malformed header" in err
+
+    def test_skips_block_without_checkbox(
+        self, pending_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        content = (
+            "# Pending Questions\n\n"
+            "## [2026-04-20] Entity: \"Acme\" (from sessions/x.md)\n"
+            "**Conflict type**: principled\n"
+            "**Description**: desc\n"
+        )
+        pending_path.write_text(content)
+        parsed = parse_pending_questions(pending_path)
+        assert parsed == []
+        err = capsys.readouterr().err
+        assert "without `- [ ]` line" in err
+
+
+# ---------------------------------------------------------------------------
+# ingest_answers — round-trip + idempotency + mixed state
+# ---------------------------------------------------------------------------
+
+
+class TestIngestAnswers:
+    def test_noop_when_file_missing(self, pending_path: Path, raw_root: Path) -> None:
+        assert ingest_answers(pending_path, raw_root) == 0
+
+    def test_noop_when_no_answered_blocks(
+        self, pending_path: Path, raw_root: Path
+    ) -> None:
+        pending_path.write_text("# Pending Questions\n\n" + _block())
+        original = pending_path.read_text()
+        assert ingest_answers(pending_path, raw_root) == 0
+        # File untouched, no archive created.
+        assert pending_path.read_text() == original
+        assert not (pending_path.parent / "_pending_questions_archive.md").exists()
+
+    def test_round_trip_single_answer(
+        self, pending_path: Path, raw_root: Path
+    ) -> None:
+        answered = _block(
+            checkbox="[x]",
+            answer="They closed Series B in March 2026.",
+        )
+        pending_path.write_text("# Pending Questions\n\n" + answered)
+
+        count = ingest_answers(pending_path, raw_root)
+        assert count == 1
+
+        # Raw intake file exists with correct frontmatter.
+        answer_files = list((raw_root / "answers").glob("*.md"))
+        assert len(answer_files) == 1
+        text = answer_files[0].read_text()
+        assert "source: pending_question_answer" in text
+        assert "original_source: raw/sessions/20240406T120000Z-aabb0011.md" in text
+        assert "entity: Acme Corp" in text
+        assert "resolved_at:" in text
+        assert "Series B in March 2026" in text
+
+        # Archive file contains the block.
+        archive = pending_path.parent / "_pending_questions_archive.md"
+        assert archive.exists()
+        archive_text = archive.read_text()
+        assert "Acme Corp" in archive_text
+        assert "**Archived**:" in archive_text
+
+        # Primary file no longer contains the answered block.
+        primary_text = pending_path.read_text()
+        assert "Acme Corp" not in primary_text
+        assert "# Pending Questions" in primary_text
+
+    def test_mixed_state_leaves_unanswered_blocks(
+        self, pending_path: Path, raw_root: Path
+    ) -> None:
+        answered = _block(
+            entity="Answered Co",
+            checkbox="[x]",
+            answer="Confirmed Series B.",
+        )
+        unanswered = _block(entity="Unanswered Co")
+        pending_path.write_text(
+            "# Pending Questions\n\n" + answered + "\n---\n\n" + unanswered
+        )
+
+        count = ingest_answers(pending_path, raw_root)
+        assert count == 1
+
+        primary_text = pending_path.read_text()
+        assert "Unanswered Co" in primary_text
+        assert "Answered Co" not in primary_text
+        # Checkbox for unanswered preserved.
+        assert "- [ ]" in primary_text
+
+        archive_text = (pending_path.parent / "_pending_questions_archive.md").read_text()
+        assert "Answered Co" in archive_text
+        assert "Unanswered Co" not in archive_text
+
+    def test_idempotent_rerun_is_noop(
+        self, pending_path: Path, raw_root: Path
+    ) -> None:
+        answered = _block(checkbox="[x]", answer="Confirmed.")
+        pending_path.write_text("# Pending Questions\n\n" + answered)
+
+        assert ingest_answers(pending_path, raw_root) == 1
+        # Second run — nothing answered remains.
+        assert ingest_answers(pending_path, raw_root) == 0
+        # Still exactly one raw answer file.
+        assert len(list((raw_root / "answers").glob("*.md"))) == 1
+
+    def test_archive_newest_first(
+        self, pending_path: Path, raw_root: Path
+    ) -> None:
+        # First run: archive "First" block.
+        first = _block(entity="First Co", checkbox="[x]", answer="answer one")
+        pending_path.write_text("# Pending Questions\n\n" + first)
+        ingest_answers(pending_path, raw_root)
+
+        # Second run: add + archive "Second" block.
+        second = _block(entity="Second Co", checkbox="[x]", answer="answer two")
+        pending_path.write_text("# Pending Questions\n\n" + second)
+        ingest_answers(pending_path, raw_root)
+
+        archive_text = (pending_path.parent / "_pending_questions_archive.md").read_text()
+        second_pos = archive_text.find("Second Co")
+        first_pos = archive_text.find("First Co")
+        assert second_pos != -1 and first_pos != -1
+        assert second_pos < first_pos  # newest-first
+
+    def test_malformed_block_preserved_verbatim(
+        self, pending_path: Path, raw_root: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        answered = _block(checkbox="[x]", answer="ok")
+        malformed = (
+            "## Not a real header\n"
+            "- [x] garbled\n"
+            "**Conflict type**: ???\n"
+        )
+        pending_path.write_text(
+            "# Pending Questions\n\n" + answered + "\n---\n\n" + malformed
+        )
+
+        count = ingest_answers(pending_path, raw_root)
+        assert count == 1
+
+        # Malformed block survived in the primary file so the human can fix it.
+        primary_text = pending_path.read_text()
+        assert "Not a real header" in primary_text
+
+    def test_collision_safe_filenames(
+        self, pending_path: Path, raw_root: Path
+    ) -> None:
+        # Two answered blocks for the same entity resolved in one run should
+        # not clobber each other's raw files.
+        a = _block(entity="Acme Co", checkbox="[x]", answer="first answer")
+        b = _block(
+            entity="Acme Co",
+            source="sessions/other.md",
+            checkbox="[x]",
+            answer="second answer",
+            question="Second distinct question?",
+        )
+        pending_path.write_text(
+            "# Pending Questions\n\n" + a + "\n---\n\n" + b
+        )
+        count = ingest_answers(pending_path, raw_root)
+        assert count == 2
+        assert len(list((raw_root / "answers").glob("*.md"))) == 2
+
+
+# ---------------------------------------------------------------------------
+# MCP helper surface
+# ---------------------------------------------------------------------------
+
+
+class TestListUnanswered:
+    def test_returns_unanswered_only(self, pending_path: Path) -> None:
+        content = (
+            "# Pending Questions\n\n"
+            + _block(entity="Open One")
+            + "\n---\n\n"
+            + _block(entity="Closed One", checkbox="[x]", answer="answer")
+        )
+        pending_path.write_text(content)
+        items = list_unanswered(pending_path)
+        assert len(items) == 1
+        assert items[0]["entity"] == "Open One"
+        assert "id" in items[0]
+        assert "question" in items[0]
+
+    def test_empty_when_file_missing(self, pending_path: Path) -> None:
+        assert list_unanswered(pending_path) == []
+
+
+class TestResolveById:
+    def test_happy_path_flips_checkbox_and_inserts_answer(
+        self, pending_path: Path
+    ) -> None:
+        pending_path.write_text("# Pending Questions\n\n" + _block())
+        items = list_unanswered(pending_path)
+        assert len(items) == 1
+        qid = items[0]["id"]
+
+        result = resolve_by_id(
+            pending_path, qid, "They closed Series B in March 2026."
+        )
+        assert result["ok"] is True
+        assert "[x]" in result["block"]
+        assert "Series B" in result["block"]
+
+        # File on disk now has the flipped checkbox + answer.
+        text = pending_path.read_text()
+        assert "- [x]" in text
+        assert "Series B in March 2026" in text
+        # Block is still in the primary file — archival happens on ingest.
+        assert "Acme Corp" in text
+
+    def test_not_found_returns_error(self, pending_path: Path) -> None:
+        pending_path.write_text("# Pending Questions\n\n" + _block())
+        result = resolve_by_id(pending_path, "doesnotexist", "answer")
+        assert result["ok"] is False
+        assert "not found" in result["error"]
+
+    def test_missing_file_returns_error(self, pending_path: Path) -> None:
+        result = resolve_by_id(pending_path, "anyid", "answer")
+        assert result["ok"] is False
+        assert "not found" in result["error"]
+
+    def test_already_answered_returns_error(
+        self, pending_path: Path
+    ) -> None:
+        pending_path.write_text("# Pending Questions\n\n" + _block())
+        items = list_unanswered(pending_path)
+        qid = items[0]["id"]
+        assert resolve_by_id(pending_path, qid, "first")["ok"] is True
+        # Second call on the same id: checkbox already [x].
+        result = resolve_by_id(pending_path, qid, "second")
+        assert result["ok"] is False
+        # Either "already answered" or "not found" (id may shift when
+        # checkbox line changes depending on hash inputs). We only hash
+        # header + question (not checkbox state), so the id is stable and
+        # the error path we want is "already answered".
+        assert "already answered" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Smoke: PendingQuestion dataclass round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_tier4_render_round_trips_through_parser(tmp_path: Path) -> None:
+    """End-to-end: tier4_escalate output is parseable by parse_pending_questions.
+
+    Highest-risk regression in issue #61 — mismatched regex between the
+    renderer in `tiers.py` and the parser here. This test fails loudly
+    the moment either side drifts.
+    """
+    from athenaeum.models import EscalationItem
+    from athenaeum.tiers import tier4_escalate
+
+    pending = tmp_path / "_pending_questions.md"
+    items = [
+        EscalationItem(
+            raw_ref="sessions/20240406T120000Z-aabb.md",
+            entity_name="Acme Corp",
+            conflict_type="principled",
+            description="Prior wiki says Series A; new raw implies Series B.",
+        ),
+    ]
+    tier4_escalate(items, pending)
+
+    parsed = parse_pending_questions(pending)
+    assert len(parsed) == 1
+    pq = parsed[0]
+    assert pq.entity == "Acme Corp"
+    assert pq.source == "sessions/20240406T120000Z-aabb.md"
+    assert pq.conflict_type == "principled"
+    assert pq.answered is False
+    assert pq.question  # non-empty
+
+
+def test_pending_question_is_dataclass() -> None:
+    pq = PendingQuestion(
+        id="abc",
+        entity="E",
+        source="s",
+        question="q",
+        conflict_type="ambiguous",
+        description="d",
+        created_at="2026-04-20",
+        answered=False,
+        answer_lines=[],
+        raw_block="",
+    )
+    assert pq.id == "abc"
+    assert pq.answered is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -329,3 +329,45 @@ class TestTestMcp:
         assert "FAIL  create_server" in captured.err
         assert "pip install athenaeum[mcp]" in captured.err
         assert "2 passed, 1 failed" in captured.out
+
+
+class TestIngestAnswers:
+    """`athenaeum ingest-answers` subcommand (issue #61)."""
+
+    def test_missing_knowledge_dir_returns_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = main(["ingest-answers", "--path", str(tmp_path / "nope")])
+        assert rc == 1
+        assert "Knowledge directory not found" in capsys.readouterr().err
+
+    def test_noop_on_empty_pending_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        (tmp_path / "wiki").mkdir()
+        (tmp_path / "raw").mkdir()
+        rc = main(["ingest-answers", "--path", str(tmp_path)])
+        assert rc == 0
+        assert "Ingested 0" in capsys.readouterr().out
+
+    def test_ingests_answered_block(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        wiki = tmp_path / "wiki"
+        raw = tmp_path / "raw"
+        wiki.mkdir()
+        raw.mkdir()
+        (wiki / "_pending_questions.md").write_text(
+            "# Pending Questions\n\n"
+            "## [2026-04-20] Entity: \"Acme Corp\" (from sessions/test.md)\n"
+            "- [x] Question about Acme?\n"
+            "**Conflict type**: principled\n"
+            "**Description**: Conflicting Series info.\n"
+            "\n"
+            "Series B, closed March 2026.\n"
+        )
+        rc = main(["ingest-answers", "--path", str(tmp_path)])
+        assert rc == 0
+        assert "Ingested 1" in capsys.readouterr().out
+        assert list((raw / "answers").glob("*.md"))
+        assert (wiki / "_pending_questions_archive.md").exists()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -292,6 +292,98 @@ class TestCreateServer:
 
 
 # ---------------------------------------------------------------------------
+# Pending-questions tools (issue #61)
+# ---------------------------------------------------------------------------
+
+
+def _seed_pending_wiki(tmp_path: Path, *, answered: bool = False) -> Path:
+    """Build a tmp knowledge dir with a seeded `_pending_questions.md`."""
+    raw = tmp_path / "raw"
+    wiki = tmp_path / "wiki"
+    raw.mkdir()
+    wiki.mkdir()
+    checkbox = "[x]" if answered else "[ ]"
+    pending = wiki / "_pending_questions.md"
+    pending.write_text(
+        "# Pending Questions\n\n"
+        "## [2026-04-20] Entity: \"Acme Corp\" (from sessions/test.md)\n"
+        f"- {checkbox} Is Acme Series A or Series B after 2026?\n"
+        "**Conflict type**: principled\n"
+        "**Description**: Prior wiki says Series A; new raw implies Series B.\n"
+    )
+    return tmp_path
+
+
+class TestPendingQuestionMCPTools:
+    """The two tools registered in `create_server` for issue #61.
+
+    We exercise the underlying module helpers (same semantics as the tools)
+    and verify the tools themselves are registered on the FastMCP server.
+    """
+
+    def test_list_and_resolve_happy_path(self, tmp_path: Path) -> None:
+        from athenaeum.answers import list_unanswered, resolve_by_id
+
+        root = _seed_pending_wiki(tmp_path)
+        pending_path = root / "wiki" / "_pending_questions.md"
+
+        items = list_unanswered(pending_path)
+        assert len(items) == 1
+        item = items[0]
+        assert set(item.keys()) >= {
+            "id", "entity", "source", "question",
+            "conflict_type", "description", "created_at",
+        }
+        assert item["entity"] == "Acme Corp"
+
+        result = resolve_by_id(pending_path, item["id"], "Series B, closed March 2026.")
+        assert result["ok"] is True
+
+        # After resolve, list_unanswered no longer returns this item.
+        assert list_unanswered(pending_path) == []
+
+    def test_resolve_not_found(self, tmp_path: Path) -> None:
+        from athenaeum.answers import resolve_by_id
+
+        root = _seed_pending_wiki(tmp_path)
+        pending_path = root / "wiki" / "_pending_questions.md"
+        result = resolve_by_id(pending_path, "nope", "answer")
+        assert result["ok"] is False
+        assert "not found" in result["error"]
+
+    def test_list_empty_when_file_missing(self, tmp_path: Path) -> None:
+        from athenaeum.answers import list_unanswered
+
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        assert list_unanswered(wiki / "_pending_questions.md") == []
+
+    def test_tools_registered_on_server(self, tmp_path: Path) -> None:
+        """Both `list_pending_questions` + `resolve_question` must be exposed."""
+        pytest.importorskip("fastmcp")
+        import asyncio
+
+        from athenaeum.mcp_server import create_server
+
+        raw = tmp_path / "raw"
+        wiki = tmp_path / "wiki"
+        raw.mkdir()
+        wiki.mkdir()
+        server = create_server(raw_root=raw, wiki_root=wiki)
+
+        # FastMCP exposes tools via `get_tool(name)` (async). We only care
+        # that both names resolve without raising.
+        async def _lookup() -> tuple[object, object]:
+            lpq = await server.get_tool("list_pending_questions")
+            rq = await server.get_tool("resolve_question")
+            return lpq, rq
+
+        lpq, rq = asyncio.run(_lookup())
+        assert lpq is not None
+        assert rq is not None
+
+
+# ---------------------------------------------------------------------------
 # CLI integration
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -816,3 +816,54 @@ class TestTier4:
         content = pending.read_text()
         assert "Entity Alpha" in content
         assert "Entity Beta" in content
+
+    def test_renders_checkbox_line_under_header(self, tmp_path: Path) -> None:
+        """New schema (issue #61): leading `- [ ]` line under each header.
+
+        The checkbox is the anchor for `ingest_answers` + the MCP
+        `resolve_question` tool. Without it, an answered block cannot
+        round-trip back into raw intake.
+        """
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            EscalationItem(
+                raw_ref="sessions/test.md",
+                entity_name="Acme Corp",
+                conflict_type="principled",
+                description="Conflicting info about Acme's Series status.",
+            ),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        lines = content.splitlines()
+
+        # Find the header line and assert the next non-blank line is a `- [ ]`.
+        header_idx = next(
+            i for i, line in enumerate(lines) if line.startswith("## [")
+        )
+        # Checkbox may follow directly with no blank line between (per issue
+        # schema: `directly under the header`).
+        assert lines[header_idx + 1].startswith("- [ ]"), (
+            f"expected checkbox line directly after header; got {lines[header_idx + 1]!r}"
+        )
+        # Question text should be present on the checkbox line (derived
+        # from the description).
+        assert "Conflicting info about Acme" in lines[header_idx + 1]
+        # Conflict-type and description lines preserved below.
+        assert "**Conflict type**: principled" in content
+        assert "**Description**: Conflicting info about Acme" in content
+
+    def test_checkbox_fallback_for_empty_description(self, tmp_path: Path) -> None:
+        """If description is empty, the checkbox line still renders a prompt."""
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            EscalationItem(
+                raw_ref="sessions/test.md",
+                entity_name="Silent Co",
+                conflict_type="ambiguous",
+                description="",
+            ),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert "- [ ] Resolve ambiguous conflict for Silent Co" in content


### PR DESCRIPTION
Closes #61.

## Summary

Closes the human-in-the-loop gap on Tier 4 escalations. `_pending_questions.md`
was write-only before this PR — the librarian appended blocks but there was
no supported way for an answer to flow back into the pipeline. After this PR,
humans (or containerized agents via MCP) can resolve a pending question and
`athenaeum ingest-answers` converts each `[x]` block into a raw intake file,
moves the block into a newest-first archive, and leaves unanswered blocks in
place. This is the headline feature for the 0.3.0 release.

## Changes

- **Schema update** — `tier4_escalate` now renders a leading `- [ ] {question}`
  line directly under each header. The question is derived from the first
  line of the LLM's description, with a canned fallback for empty descriptions.
- **New `athenaeum.answers` module** — `ingest_answers`, `parse_pending_questions`,
  `list_unanswered`, `resolve_by_id`. Idempotent, malformed-block tolerant,
  stable-id (sha1 of header + question).
- **New `athenaeum ingest-answers --path <knowledge>` CLI** — scans the file,
  writes `raw/answers/{ts}-{slug}.md` with frontmatter linking back to the
  original source, archives answered blocks to `_pending_questions_archive.md`
  (newest-first, append-only).
- **Two new MCP tools** — `list_pending_questions()` returns unanswered blocks
  as JSON; `resolve_question(id, answer)` flips `- [ ]` -> `- [x]` and writes
  the answer body. Archive step is intentionally deferred to the next
  `ingest-answers` pass so the write path is small and atomic.
- **Docs** — new README "Answering pending questions" section covering both
  workflows. CHANGELOG bumps to 0.3.0 with a full feature writeup.
  `__version__` in `src/athenaeum/__init__.py` was stale at 0.2.2 — now
  matches `pyproject.toml`.

## Commits

- `71db319` feat(tiers): render `- [ ]` checkbox under each tier4 escalation
- `f1b6816` feat(answers): add ingest-answers module + CLI subcommand
- `cc22e03` feat(mcp): add list_pending_questions + resolve_question tools
- `48f068c` docs: release 0.3.0 — pending-question ingest loop

Each commit is independently green (228 -> 254 -> 258 -> 258 tests passing
at each SHA).

## Test plan

- [x] `pytest tests/` — 258 passing (32 new)
- [x] `ruff check src/ tests/` — clean
- [x] Each commit in the chain passes the full suite at its SHA (bisect-safe)
- [x] `athenaeum ingest-answers --help` shows the new subcommand
- [x] `athenaeum --version` reports `0.3.0`
- [x] `test_tier4_render_round_trips_through_parser` pins the
      renderer/parser contract — the single highest-risk regression class
- [ ] CI green on `develop` base (waiting on GH Actions)

## Notes for reviewers

- `resolve_question` deliberately does NOT archive on resolve — that stays a
  concern of `ingest-answers` to keep the write path small. Re-resolving an
  already-answered block returns
  `{"ok": false, "error": "already answered"}` (the id is stable because it's
  hashed from header + question, not checkbox state).
- Malformed blocks in `_pending_questions.md` are preserved verbatim in the
  primary file with a stderr warning, so a corrupt single entry cannot
  poison the rest of the file. Test: `test_malformed_block_preserved_verbatim`.
- The archive format (`_pending_questions_archive.md`) is append-only and
  newest-first. Each archived block carries an `**Archived**: {iso-ts}`
  trailer so the audit trail records when the answer was ingested in
  addition to when the question was resolved.
