### PR TITLE
fix(answers): Quine QA follow-up to #62 — parser contract, descriptions, archive dedup, error codes (#61)

### DIFF
--- a/src/athenaeum/answers.py
+++ b/src/athenaeum/answers.py
@@ -44,11 +44,43 @@ log = logging.getLogger(__name__)
 
 # Header grammar — matches `## [ISO-DATE] Entity: "{name}" (from {ref})`.
 # ISO-DATE is intentionally a loose match (``[^\]]+``) so a future shift to
-# datetime-with-time doesn't break the parser. The entity name is captured
-# between straight quotes; the raw ref is everything up to the closing paren.
+# datetime-with-time doesn't break the parser.
+#
+# Entity: between straight quotes, but tolerates backslash-escaped quotes
+# (``\\"``) written by the renderer so names containing `"` round-trip.
+# Unescape with :func:`_unescape_entity` after capture.
+#
+# Ref: greedy to the final ``)`` anchored at end-of-line. This lets raw paths
+# that happen to contain parens (e.g. ``sessions/foo (v2).md``) round-trip
+# without special-casing the renderer.
+#
+# The trailing ``$`` anchor + the outer grammar prevents greedy-runaway if a
+# line somehow contains multiple ``)`` sequences.
 _HEADER_RE = re.compile(
-    r"^## \[(?P<date>[^\]]+)\] Entity: \"(?P<entity>[^\"]+)\" \(from (?P<ref>[^)]+)\)$"
+    r"^## \[(?P<date>[^\]]+)\] Entity: \""
+    r"(?P<entity>(?:[^\"\\]|\\.)*)"
+    r"\" \(from (?P<ref>.+)\)$"
 )
+
+
+def _unescape_entity(raw: str) -> str:
+    """Unescape ``\\"`` and ``\\\\`` in a captured entity name.
+
+    Paired with the renderer in :mod:`athenaeum.tiers` which escapes
+    backslashes and then double quotes.
+    """
+    # Walk the string so we don't over-unescape adjacent sequences.
+    out: list[str] = []
+    i = 0
+    while i < len(raw):
+        ch = raw[i]
+        if ch == "\\" and i + 1 < len(raw):
+            out.append(raw[i + 1])
+            i += 2
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
 # Checkbox grammar — ``- [ ]`` or ``- [x]`` (case-insensitive on ``x``).
 _CHECKBOX_RE = re.compile(r"^- \[(?P<state>[ xX])\]\s*(?P<question>.*)$")
 # Lines we strip when extracting the user's answer body.
@@ -181,7 +213,7 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
 
     return PendingQuestion(
         id=_make_id(lines[0], question),
-        entity=header_match.group("entity"),
+        entity=_unescape_entity(header_match.group("entity")),
         source=header_match.group("ref"),
         question=question,
         conflict_type=conflict_type,

--- a/src/athenaeum/answers.py
+++ b/src/athenaeum/answers.py
@@ -115,6 +115,20 @@ def _make_id(header_line: str, question_text: str) -> str:
     Idempotent across runs as long as the block text hasn't been edited —
     which is also when the id should change, because the block's identity
     has changed.
+
+    Stability contract (locked by ``test_id_stable_across_checkbox_flip``
+    and ``test_id_changes_when_question_edited``):
+
+    - The id is a 12-hex-char SHA-1 prefix over header + question text.
+    - It is **stable** across description edits and across checkbox state
+      flips (``[ ]`` ↔ ``[x]``). A handle obtained from
+      :func:`list_unanswered` therefore remains valid for
+      :func:`resolve_by_id` even after a description clarification edit.
+    - It **changes** when the question text itself is edited. Changing
+      the question is considered a new question — a new id is correct.
+
+    This means MCP consumers can cache ``id`` values across a session
+    without worrying about description-text churn invalidating them.
     """
     payload = f"{header_line.strip()}\n{question_text.strip()}".encode("utf-8")
     return hashlib.sha1(payload).hexdigest()[:12]
@@ -194,13 +208,46 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
     description = ""
     answer_lines: list[str] = []
 
-    for raw_line in lines[checkbox_idx + 1 :]:
+    # Tracks whether we're still accumulating continuation lines into the
+    # description field. A **Description**: line opens the window; the next
+    # blank line or the next ``**Key**:`` style line closes it. This lets
+    # multi-line descriptions (3+ lines) survive ingest instead of losing
+    # everything after the first line.
+    in_description = False
+
+    remaining = lines[checkbox_idx + 1 :]
+    for raw_line in remaining:
         stripped = raw_line.strip()
         if stripped.startswith("**Conflict type**:"):
+            in_description = False
             conflict_type = stripped.removeprefix("**Conflict type**:").strip()
             continue
         if stripped.startswith("**Description**:"):
+            in_description = True
             description = stripped.removeprefix("**Description**:").strip()
+            continue
+        if in_description:
+            # Continuation: consume into description until we hit a terminator.
+            # Blank line or another ``**Key**:`` tag closes the window.
+            if stripped == "" or stripped.startswith("**"):
+                in_description = False
+                # A blank line is a pure terminator — drop it and move on.
+                if stripped == "":
+                    continue
+                # A new **Key**: line — fall through to the key dispatchers above
+                # by handling it here (the only other recognized key is
+                # **Conflict type**, already handled). For unknown keys, treat
+                # the line as answer body.
+                if stripped.startswith("**Conflict type**:"):
+                    conflict_type = stripped.removeprefix(
+                        "**Conflict type**:"
+                    ).strip()
+                    continue
+                # Unknown **Key**: — treat as answer body.
+                answer_lines.append(raw_line)
+                continue
+            # Plain continuation line: append, preserving raw formatting.
+            description = (description + "\n" + raw_line).lstrip("\n")
             continue
         # Otherwise: treat as part of the user's answer body.
         answer_lines.append(raw_line)
@@ -308,6 +355,10 @@ def ingest_answers(pending_path: Path, raw_root: Path) -> int:
 
     unanswered: list[PendingQuestion] = []
     archived_new: list[str] = []
+    # Parallel arrays used only for dedup-skip logging and for matching each
+    # rendered archive block back to the raw block text that originated it.
+    _archived_entities: list[str] = []
+    _archived_raw_blocks: list[str] = []
     ingested = 0
 
     now = datetime.now(timezone.utc)
@@ -351,6 +402,8 @@ def ingest_answers(pending_path: Path, raw_root: Path) -> int:
             counter += 1
         candidate.write_text(_render_answer_raw_file(pq, iso_ts), encoding="utf-8")
         archived_new.append(_render_archive_block(pq, iso_ts))
+        _archived_entities.append(pq.entity)
+        _archived_raw_blocks.append(pq.raw_block)
         ingested += 1
 
     if ingested == 0:
@@ -369,7 +422,35 @@ def ingest_answers(pending_path: Path, raw_root: Path) -> int:
     if archive_path.exists():
         existing_archive = archive_path.read_text(encoding="utf-8")
 
-    new_section = "\n\n---\n\n".join(archived_new)
+    # Dedup guard — if the raw block text of an answered item already appears
+    # in the existing archive, skip re-appending it. Protects against the
+    # "user re-pasted an already-answered block into the primary file"
+    # failure mode noted in Quine Q5.
+    filtered_archived: list[str] = []
+    for rendered, raw_block, entity in zip(
+        archived_new, _archived_raw_blocks, _archived_entities
+    ):
+        if raw_block.strip() and raw_block in existing_archive:
+            print(
+                f"[warn] skipping duplicate archive entry for entity={entity}",
+                file=sys.stderr,
+            )
+            log.info(
+                "Skipping duplicate archive entry for entity=%s", entity
+            )
+            continue
+        filtered_archived.append(rendered)
+
+    if not filtered_archived:
+        # Nothing new to archive — we still ingested raw intake files above.
+        log.info(
+            "Ingested %d answer(s) but archive already contained all of them; "
+            "no archive update.",
+            ingested,
+        )
+        return ingested
+
+    new_section = "\n\n---\n\n".join(filtered_archived)
     if existing_archive.strip():
         # newest-first: new answers go at the top, under the header.
         if existing_archive.startswith("# Answered Questions"):
@@ -429,16 +510,45 @@ def resolve_by_id(pending_path: Path, question_id: str, answer: str) -> dict:
     """Locate a block by id, flip ``[ ]`` -> ``[x]``, append the answer body.
 
     Does NOT archive — archival happens on the next ``ingest_answers`` run
-    so the write path stays small. Returns a dict with ``ok`` and either
-    ``block`` (the rewritten block text) or ``error``.
+    so the write path stays small.
+
+    Returns a dict shaped for machine inspection:
+
+    - ``ok`` (bool): true on success, false on any error.
+    - ``error_code`` (str | None): one of ``id_not_found``,
+      ``already_answered``, ``file_missing``, ``invalid_answer`` when
+      ``ok`` is false; ``None`` on success.
+    - ``message`` (str): human-readable status / failure text.
+    - ``resolved_block`` (str | None): the rewritten block on success;
+      ``None`` otherwise.
+    - ``block`` (str | None): legacy alias for ``resolved_block`` kept
+      for backward compatibility with early callers.
+    - ``error`` (str | None): legacy alias for ``message`` on failure,
+      kept for backward compatibility.
     """
     if not pending_path.exists():
-        return {"ok": False, "error": f"pending questions file not found: {pending_path}"}
+        msg = f"pending questions file not found: {pending_path}"
+        return {
+            "ok": False,
+            "error_code": "file_missing",
+            "message": msg,
+            "resolved_block": None,
+            "block": None,
+            "error": msg,
+        }
 
     text = pending_path.read_text(encoding="utf-8")
     blocks = _split_blocks(text)
     if not blocks:
-        return {"ok": False, "error": "no pending question blocks in file"}
+        msg = "no pending question blocks in file"
+        return {
+            "ok": False,
+            "error_code": "id_not_found",
+            "message": msg,
+            "resolved_block": None,
+            "block": None,
+            "error": msg,
+        }
 
     new_block_text: str | None = None
     rewritten_blocks: list[str] = []
@@ -452,9 +562,14 @@ def resolve_by_id(pending_path: Path, question_id: str, answer: str) -> dict:
             rewritten_blocks.append(block_text)
             continue
         if pq.answered:
+            msg = f"question {question_id} already answered"
             return {
                 "ok": False,
-                "error": f"question {question_id} already answered",
+                "error_code": "already_answered",
+                "message": msg,
+                "resolved_block": None,
+                "block": None,
+                "error": msg,
             }
 
         updated = _rewrite_block_as_answered(block_text, answer)
@@ -462,13 +577,28 @@ def resolve_by_id(pending_path: Path, question_id: str, answer: str) -> dict:
         rewritten_blocks.append(updated)
 
     if new_block_text is None:
-        return {"ok": False, "error": f"question id not found: {question_id}"}
+        msg = f"question id not found: {question_id}"
+        return {
+            "ok": False,
+            "error_code": "id_not_found",
+            "message": msg,
+            "resolved_block": None,
+            "block": None,
+            "error": msg,
+        }
 
     primary_parts = ["# Pending Questions", *rewritten_blocks]
     primary_body = "\n\n---\n\n".join(primary_parts) + "\n"
     pending_path.write_text(primary_body, encoding="utf-8")
 
-    return {"ok": True, "block": new_block_text}
+    return {
+        "ok": True,
+        "error_code": None,
+        "message": "ok",
+        "resolved_block": new_block_text,
+        "block": new_block_text,
+        "error": None,
+    }
 
 
 def _rewrite_block_as_answered(block_text: str, answer: str) -> str:

--- a/src/athenaeum/mcp_server.py
+++ b/src/athenaeum/mcp_server.py
@@ -312,13 +312,35 @@ def create_server(
             answer: The answer body (markdown; may be multi-line).
 
         Returns:
-            ``{"ok": true, "block": "..."}`` on success, or
-            ``{"ok": false, "error": "..."}`` if the id is not found,
-            already answered, or the file is missing.
+            A dict with:
+
+            - ``ok`` (bool)
+            - ``error_code`` (str | None): one of ``id_not_found``,
+              ``already_answered``, ``file_missing``, ``invalid_answer``
+              on failure; ``None`` on success.
+            - ``message`` (str): human-readable status.
+            - ``resolved_block`` (str | None): the rewritten block on
+              success; ``None`` on failure.
+
+            For backward compatibility the dict also includes legacy
+            aliases ``block`` (= ``resolved_block``) and ``error``
+            (= ``message`` on failure). New callers should prefer
+            ``error_code`` + ``message`` + ``resolved_block``.
         """
         from athenaeum.answers import resolve_by_id
 
-        pending_path = wiki_root / "_pending_questions.md"
-        return resolve_by_id(pending_path, id, answer)
+        result = resolve_by_id(pending_path=wiki_root / "_pending_questions.md",
+                               question_id=id, answer=answer)
+        # Surface the structured keys explicitly so consumers see them at
+        # the top of the dict even when legacy aliases are also present.
+        return {
+            "ok": result["ok"],
+            "error_code": result.get("error_code"),
+            "message": result.get("message", ""),
+            "resolved_block": result.get("resolved_block"),
+            # legacy aliases:
+            "block": result.get("block"),
+            "error": result.get("error"),
+        }
 
     return mcp

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -492,8 +492,14 @@ def tier4_escalate(items: list[EscalationItem], pending_path: Path) -> None:
         question = _question_from_description(
             item.description, item.entity_name, item.conflict_type
         )
+        # Escape backslashes first, then quotes — paired with the parser's
+        # unescape logic in athenaeum.answers so entity names containing
+        # double quotes round-trip cleanly. raw_ref is NOT escaped: paths
+        # should survive in storage untouched; the parser anchors to the
+        # final ")\n" to tolerate parens inside refs.
+        escaped_entity = item.entity_name.replace("\\", "\\\\").replace("\"", "\\\"")
         sections.append(
-            f"## [{today}] Entity: \"{item.entity_name}\" (from {item.raw_ref})\n"
+            f"## [{today}] Entity: \"{escaped_entity}\" (from {item.raw_ref})\n"
             f"- [ ] {question}\n\n"
             f"**Conflict type**: {item.conflict_type}\n"
             f"**Description**: {item.description}\n"

--- a/tests/test_answers.py
+++ b/tests/test_answers.py
@@ -343,12 +343,14 @@ class TestResolveById:
         pending_path.write_text("# Pending Questions\n\n" + _block())
         result = resolve_by_id(pending_path, "doesnotexist", "answer")
         assert result["ok"] is False
-        assert "not found" in result["error"]
+        assert result["error_code"] == "id_not_found"
+        assert "not found" in result["message"]
 
     def test_missing_file_returns_error(self, pending_path: Path) -> None:
         result = resolve_by_id(pending_path, "anyid", "answer")
         assert result["ok"] is False
-        assert "not found" in result["error"]
+        assert result["error_code"] == "file_missing"
+        assert "not found" in result["message"]
 
     def test_already_answered_returns_error(
         self, pending_path: Path
@@ -357,14 +359,15 @@ class TestResolveById:
         items = list_unanswered(pending_path)
         qid = items[0]["id"]
         assert resolve_by_id(pending_path, qid, "first")["ok"] is True
-        # Second call on the same id: checkbox already [x].
+        # Second call on the same id: checkbox already [x]. Because the id
+        # hash is over header + question text only (not checkbox state),
+        # the id is stable across the `[ ]` -> `[x]` flip and the error
+        # path we want is `already_answered` — this positively asserts the
+        # id invariant documented on `_make_id`.
         result = resolve_by_id(pending_path, qid, "second")
         assert result["ok"] is False
-        # Either "already answered" or "not found" (id may shift when
-        # checkbox line changes depending on hash inputs). We only hash
-        # header + question (not checkbox state), so the id is stable and
-        # the error path we want is "already answered".
-        assert "already answered" in result["error"]
+        assert result["error_code"] == "already_answered"
+        assert "already answered" in result["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -462,3 +465,131 @@ def test_pending_question_is_dataclass() -> None:
     )
     assert pq.id == "abc"
     assert pq.answered is False
+
+
+# ---------------------------------------------------------------------------
+# Q4: multi-line description capture
+# ---------------------------------------------------------------------------
+
+
+def test_description_captures_multiple_lines(pending_path: Path) -> None:
+    """A **Description**: that spans 3+ lines should survive the parse.
+
+    Prior implementation captured only the first line, silently dropping
+    continuation text. Guards Quine Q4.
+    """
+    content = (
+        "# Pending Questions\n\n"
+        "## [2026-04-20] Entity: \"Acme Corp\" (from sessions/x.md)\n"
+        "- [ ] Is Acme still Series A?\n"
+        "**Conflict type**: principled\n"
+        "**Description**: Line one of description.\n"
+        "Line two continues the description.\n"
+        "Line three wraps it up.\n"
+    )
+    pending_path.write_text(content)
+    parsed = parse_pending_questions(pending_path)
+    assert len(parsed) == 1
+    desc = parsed[0].description
+    assert "Line one of description." in desc
+    assert "Line two continues the description." in desc
+    assert "Line three wraps it up." in desc
+
+
+# ---------------------------------------------------------------------------
+# Q5: archive dedup guard
+# ---------------------------------------------------------------------------
+
+
+def test_archive_skips_duplicate_entry(
+    pending_path: Path, raw_root: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """If the exact raw_block of an answered item is already in the archive,
+    a second ingest must not duplicate it. Guards Quine Q5.
+    """
+    answered = _block(checkbox="[x]", answer="Confirmed.")
+    pending_path.write_text("# Pending Questions\n\n" + answered)
+
+    first = ingest_answers(pending_path, raw_root)
+    assert first == 1
+
+    archive_path = pending_path.parent / "_pending_questions_archive.md"
+    after_first = archive_path.read_text(encoding="utf-8")
+    first_count = after_first.count("Acme Corp")
+    assert first_count == 1
+
+    # Simulate the user re-pasting the already-answered block into the
+    # primary file (for example after restoring from a backup).
+    pending_path.write_text("# Pending Questions\n\n" + answered)
+    second = ingest_answers(pending_path, raw_root)
+    # The block is still "answered" so it is ingested once for the raw
+    # intake step, but the archive dedup guard should catch the duplicate.
+    assert second == 1
+
+    after_second = archive_path.read_text(encoding="utf-8")
+    second_count = after_second.count("Acme Corp")
+    assert second_count == 1, (
+        f"archive must not duplicate: before={first_count}, after={second_count}"
+    )
+    err = capsys.readouterr().err
+    assert "skipping duplicate archive entry" in err
+
+
+# ---------------------------------------------------------------------------
+# Q7: id stability invariant (locked on both sides)
+# ---------------------------------------------------------------------------
+
+
+def test_id_stable_across_checkbox_flip(pending_path: Path) -> None:
+    """Flipping ``- [ ]`` to ``- [x]`` must not change the question id.
+
+    This is the contract that lets an agent cache the id from
+    list_pending_questions and still call resolve_question against it —
+    without this invariant, resolve_question would be a race with id churn.
+    """
+    pending_path.write_text("# Pending Questions\n\n" + _block(checkbox="[ ]"))
+    id_before = parse_pending_questions(pending_path)[0].id
+
+    pending_path.write_text("# Pending Questions\n\n" + _block(checkbox="[x]"))
+    id_after = parse_pending_questions(pending_path)[0].id
+
+    assert id_before == id_after
+
+
+def test_id_changes_when_question_edited(pending_path: Path) -> None:
+    """Editing the question text itself MUST produce a new id.
+
+    The inverse of test_id_stable_across_checkbox_flip — locks the id
+    invariant on both sides so a future refactor can't silently break it.
+    """
+    pending_path.write_text(
+        "# Pending Questions\n\n" + _block(question="Original question?")
+    )
+    id_before = parse_pending_questions(pending_path)[0].id
+
+    pending_path.write_text(
+        "# Pending Questions\n\n" + _block(question="Rephrased question?")
+    )
+    id_after = parse_pending_questions(pending_path)[0].id
+
+    assert id_before != id_after
+
+
+# ---------------------------------------------------------------------------
+# Q6: structured error codes (happy path)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_by_id_success_returns_structured_fields(pending_path: Path) -> None:
+    pending_path.write_text("# Pending Questions\n\n" + _block())
+    items = list_unanswered(pending_path)
+    qid = items[0]["id"]
+    result = resolve_by_id(pending_path, qid, "Confirmed.")
+    assert result["ok"] is True
+    assert result["error_code"] is None
+    assert result["message"] == "ok"
+    assert result["resolved_block"] is not None
+    assert "[x]" in result["resolved_block"]
+    # Legacy aliases retained for backward compat.
+    assert result["block"] == result["resolved_block"]

--- a/tests/test_answers.py
+++ b/tests/test_answers.py
@@ -403,6 +403,50 @@ def test_tier4_render_round_trips_through_parser(tmp_path: Path) -> None:
     assert pq.question  # non-empty
 
 
+@pytest.mark.parametrize(
+    ("entity_name", "raw_ref"),
+    [
+        ('Acme Corp', 'sessions/foo.md'),  # clean baseline
+        ('Acme "The Great" Corp', 'sessions/foo.md'),  # embedded quotes
+        ('Acme Corp', 'sessions/foo (v2).md'),  # parens in ref
+        ('Acme "The Great" Corp', 'sessions/foo (v2).md'),  # both
+        ('Université "Étoile" Inc', 'sessions/straße.md'),  # unicode entity + ref
+        ('Globex', 'sessions/notes (rev 3) (final).md'),  # multiple parens in ref
+    ],
+)
+def test_tier4_round_trip_hostile_inputs(
+    tmp_path: Path, entity_name: str, raw_ref: str
+) -> None:
+    """tier4_escalate output must round-trip through parse_pending_questions
+    cleanly even when entity_name contains double quotes and raw_ref contains
+    parentheses. Guards the renderer/parser contract documented in #61.
+    """
+    from athenaeum.models import EscalationItem
+    from athenaeum.tiers import tier4_escalate
+
+    pending = tmp_path / "_pending_questions.md"
+    items = [
+        EscalationItem(
+            raw_ref=raw_ref,
+            entity_name=entity_name,
+            conflict_type="principled",
+            description="Conflict description; contract test.",
+        ),
+    ]
+    tier4_escalate(items, pending)
+
+    # Raw file frontmatter sanity: header uses the escaped form for quotes
+    # but the raw ref is written unmolested.
+    raw_text = pending.read_text(encoding="utf-8")
+    assert raw_ref in raw_text  # paths stored verbatim
+
+    parsed = parse_pending_questions(pending)
+    assert len(parsed) == 1, f"expected 1 block, got {len(parsed)}"
+    pq = parsed[0]
+    assert pq.entity == entity_name  # round-trips after unescape
+    assert pq.source == raw_ref  # paths preserved
+
+
 def test_pending_question_is_dataclass() -> None:
     pq = PendingQuestion(
         id="abc",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -349,7 +349,8 @@ class TestPendingQuestionMCPTools:
         pending_path = root / "wiki" / "_pending_questions.md"
         result = resolve_by_id(pending_path, "nope", "answer")
         assert result["ok"] is False
-        assert "not found" in result["error"]
+        assert result["error_code"] == "id_not_found"
+        assert "not found" in result["message"]
 
     def test_list_empty_when_file_missing(self, tmp_path: Path) -> None:
         from athenaeum.answers import list_unanswered


### PR DESCRIPTION
## Summary

Follow-up to merged PR #62 — applies Quine QA's must-fix and should-fix findings on the pending-question ingest loop (#61).

Two commits:

- **d66741c** `fix(answers): harden renderer/parser contract against quotes and parens (#61)`
  - Q1+Q2: entity names with embedded `"` and raw_refs with `()` silently truncated. Renderer now escapes backslashes + quotes in entity_name; parser tolerates escaped quotes and anchors the ref group to a trailing `)`.
  - Q3: parametrized round-trip test covering quotes-in-entity, parens-in-ref, both together, unicode, and multi-paren refs.

- **3d12d9a** `fix(answers): multiline descriptions, archive dedup, structured error codes, id invariant (#61)`
  - Q4: `**Description**:` now captures continuation lines until a blank line or another `**Key**:` tag (prior impl silently dropped lines 2+).
  - Q5: `ingest_answers` skips archive entries whose raw_block already appears in `_pending_questions_archive.md`, preventing re-paste-duplicates.
  - Q6: `resolve_by_id` returns structured `error_code` / `message` / `resolved_block` alongside legacy `error` / `block` aliases; MCP tool surfaces `error_code`.
  - Q7: `_make_id` docstring explicitly locks the "id stable across checkbox flip and description edits, changes on question edit" invariant; new tests `test_id_stable_across_checkbox_flip` and `test_id_changes_when_question_edited` lock both sides. The hedging comment in `test_already_answered_returns_error` is replaced with a positive assertion.

## Context

Q8 (`assert` to explicit check) and Q10 (CLI bare-except class name) are deliberately out of scope — the briefing owner will file follow-up issues for those after this lands.

PR #62 was already merged before this work started, so these fixes ride as a follow-up PR on top of the merged history rather than amending the open PR.

## Test plan

- [x] Local `pytest`: 258 to 269 tests pass (6 parametrized hostile-round-trip, 1 multi-line description, 1 archive dedup, 2 id stability, 1 structured-ok-result, plus updated error-path assertions).
- [x] `ruff check` clean on all modified files.
- [ ] CI on this PR: unit/lint green across Python 3.11 / 3.12 / 3.13.

Refs #61.
