### PR TITLE
chore: Quine follow-ups (closes #64 #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-21
+
+Quine follow-ups from the 0.3.0 review. Two small hardening fixes on
+error-path code; no behavior change under normal execution.
+
+### Fixed
+- **`answers._parse_block` no longer relies on `assert` for control flow**
+  (#64). Under `python -O` the assert is stripped and the subsequent
+  `cb_match.group(...)` would raise `AttributeError` on malformed blocks
+  instead of returning `None`. Replaced with an explicit `if cb_match is
+  None: return None` guard so `-O` behaves the same as default execution.
+- **CLI error output now includes the exception class name** (#65).
+  `Error: {msg}` → `Error ({ExceptionClass}): {msg}`. Makes operator
+  triage and Sentry correlation meaningfully easier without changing the
+  exit-code contract.
+
 ## [0.3.0] - 2026-04-20
 
 Headline feature: **the Tier 4 escalation path is no longer write-only.**
@@ -240,7 +256,8 @@ knowledge librarian.
 - Test suite extracted from upstream + CI coverage enforcement (`>=75%`)
 - Transactional writes, type-safety hardening, prompt-injection mitigation, API budget caps
 
-[Unreleased]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.1...v0.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "athenaeum"
-version = "0.3.0"
+version = "0.3.1"
 description = "Open source knowledge management pipeline — append-only intake, tiered compilation, configurable schemas"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/athenaeum/__init__.py
+++ b/src/athenaeum/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Athenaeum — open source knowledge management pipeline."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from athenaeum.init import init_knowledge_dir
 from athenaeum.librarian import discover_raw_files, process_one, rebuild_index, run

--- a/src/athenaeum/answers.py
+++ b/src/athenaeum/answers.py
@@ -200,7 +200,8 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
         return None
 
     cb_match = _CHECKBOX_RE.match(lines[checkbox_idx])
-    assert cb_match is not None  # guarded above
+    if cb_match is None:
+        return None
     answered = cb_match.group("state").lower() == "x"
     question = cb_match.group("question").strip()
 

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -314,7 +314,10 @@ def _cmd_ingest_answers(args: argparse.Namespace) -> int:
     try:
         count = ingest_answers(pending_path, raw_root)
     except Exception as exc:  # noqa: BLE001 — surface a clean CLI error
-        print(f"Fatal error ingesting answers: {exc}", file=sys.stderr)
+        print(
+            f"Fatal error ingesting answers ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
         return 2
 
     print(f"Ingested {count} answered question(s).")


### PR DESCRIPTION
## Summary

Two trivial Quine follow-up polish fixes, bundled for bisect-friendly split commits.

- **closes #64** — `src/athenaeum/answers.py`: replaced `assert cb_match is not None` in `_parse_block` with an explicit `if cb_match is None: return None` guard. Asserts strip under `python -O`, so this is correctness hardening against optimized-bytecode deployments.
- **closes #65** — `src/athenaeum/cli.py`: the `ingest-answers` subcommand's bare `except Exception` handler now includes `type(exc).__name__` in the error message, so users see *what class* of failure occurred (FileNotFoundError vs PermissionError vs ValueError) rather than just its `str()`.

## Test plan

- [x] Full suite green: `.venv/bin/pytest tests/ -x` → 269 passed
- [x] No existing tests asserted on the old `"Fatal error ingesting answers:"` literal prose, so no test updates required
- [x] Two commits, each independently green, to keep `git bisect` usable:
  - `4bbe1ca` fix(answers): replace assert with explicit None guard in _parse_block (closes #64)
  - `9eef729` fix(cli): include exception class name in error output (closes #65)

## Notes

- Both changes are one-liners (well, a two-liner after the `if` expansion).
- `closes #N` keywords are in the commit subjects *and* in this body, so GitHub will auto-close both issues on merge. (Avoids the #61 orphan-issue failure mode where only the PR title carried the keyword.)
