### PR TITLE
feat(cli): add athenaeum recall subcommand for shell-accessible recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`athenaeum recall <query>` CLI** (#71) — shell-accessible wrapper around
+  the MCP `recall` tool for validation harnesses and operator debugging.
+  Prints one tab-separated hit per line (`<score>\t<filename>\t<preview>`).
+  Respects configured `search_backend` and extra intake roots; `--top-k`,
+  `--path`, `--cache-dir`, and `--backend` flags supported.
+
 ## [0.3.1] - 2026-04-21
 
 Quine follow-ups from the 0.3.0 review. Two small hardening fixes on

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -120,6 +120,34 @@ def main(argv: list[str] | None = None) -> int:
         help="Knowledge directory (default: ~/knowledge)",
     )
 
+    # recall command — shell-accessible recall for validation harnesses
+    # and operator debugging. Wraps the MCP `recall` tool so scripts and
+    # `gh_wait_status.sh`-style tooling can exercise the same search path
+    # without spinning up a Claude Code session.
+    recall_parser = subparsers.add_parser(
+        "recall",
+        help="Search the wiki from the shell (one tab-separated hit per line)",
+    )
+    recall_parser.add_argument(
+        "query", type=str, help="Search query string",
+    )
+    recall_parser.add_argument(
+        "--top-k", type=int, default=5,
+        help="Maximum results to return (default: 5)",
+    )
+    recall_parser.add_argument(
+        "--path", type=Path, default=Path("~/knowledge"),
+        help="Knowledge directory (default: ~/knowledge)",
+    )
+    recall_parser.add_argument(
+        "--cache-dir", type=Path, default=None,
+        help="Cache directory (default: ~/.cache/athenaeum)",
+    )
+    recall_parser.add_argument(
+        "--backend", choices=["keyword", "fts5", "vector"], default=None,
+        help="Override configured backend (default: read from athenaeum.yaml)",
+    )
+
     # rebuild-index command — rebuild the search index out-of-band
     rebuild_parser = subparsers.add_parser(
         "rebuild-index",
@@ -161,6 +189,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "rebuild-index":
         return _cmd_rebuild_index(args)
+
+    if args.command == "recall":
+        return _cmd_recall(args)
 
     if args.command == "query-topics":
         return _cmd_query_topics(args)
@@ -375,6 +406,64 @@ def _cmd_rebuild_index(args: argparse.Namespace) -> int:
 
     print(f"Unknown search backend: {backend}", file=sys.stderr)
     return 1
+
+
+def _cmd_recall(args: argparse.Namespace) -> int:
+    """Shell-accessible recall — prints one tab-separated hit per line.
+
+    Output format per line: ``<score>\\t<filename>\\t<preview>``, where
+    ``<preview>`` is the first 80 chars of the wiki page body (post
+    frontmatter), newlines collapsed to spaces. Used by validation
+    harnesses and operator debugging scripts that can't rely on an MCP
+    session. Reads ``search_backend`` + extra intake roots from
+    ``athenaeum.yaml`` the same way ``serve`` and ``rebuild-index`` do,
+    so results match what the MCP ``recall`` tool would return.
+    """
+    from athenaeum.config import load_config, resolve_extra_intake_roots
+    from athenaeum.models import parse_frontmatter
+    from athenaeum.search import get_backend
+
+    knowledge_root = args.path.expanduser().resolve()
+    wiki_root = knowledge_root / "wiki"
+
+    if not wiki_root.exists():
+        print(f"Wiki directory not found: {wiki_root}", file=sys.stderr)
+        return 1
+
+    cfg = load_config(knowledge_root)
+    backend_name = args.backend or cfg.get("search_backend", "fts5")
+    cache_dir = (args.cache_dir or Path("~/.cache/athenaeum")).expanduser().resolve()
+    extra_roots = resolve_extra_intake_roots(knowledge_root, cfg)
+
+    try:
+        backend = get_backend(backend_name)
+    except KeyError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        hits = backend.query(
+            args.query, cache_dir, n=args.top_k, wiki_root=wiki_root,
+        )
+    except NotImplementedError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    from athenaeum.mcp_server import _resolve_hit_path
+
+    for filename, _name, score in hits:
+        page_path, _display = _resolve_hit_path(filename, wiki_root, extra_roots)
+        preview = ""
+        if page_path is not None and page_path.is_file():
+            try:
+                text = page_path.read_text(encoding="utf-8")
+                _fm, body = parse_frontmatter(text)
+                preview = " ".join(body.split())[:80]
+            except (OSError, UnicodeDecodeError):
+                pass
+        print(f"{score:.2f}\t{filename}\t{preview}")
+
+    return 0
 
 
 def _cmd_stopwords(_args: argparse.Namespace) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -331,6 +331,92 @@ class TestTestMcp:
         assert "2 passed, 1 failed" in captured.out
 
 
+class TestRecall:
+    """`athenaeum recall <query>` subcommand (issue #71). Shell-accessible
+    wrapper around the MCP recall tool — used by validation harnesses and
+    operator debugging. Output contract: one tab-separated hit per line,
+    ``<score>\\t<filename>\\t<preview>``."""
+
+    def test_keyword_backend_prints_tab_separated_hits(
+        self, knowledge_with_wiki: Path, tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main([
+            "recall", "lean startup",
+            "--path", str(knowledge_with_wiki),
+            "--cache-dir", str(tmp_path / "cache"),
+            "--backend", "keyword",
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [line for line in out.splitlines() if line.strip()]
+        assert lines, "expected at least one hit"
+        # First hit should be the lean-startup page.
+        first = lines[0].split("\t")
+        assert len(first) == 3, f"expected 3 tab-separated fields, got: {first!r}"
+        score_str, filename, preview = first
+        float(score_str)  # parseable as float
+        assert filename == "lean-startup.md"
+        assert "Lean Startup" in preview
+
+    def test_top_k_limits_output(
+        self, knowledge_with_wiki: Path, tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main([
+            "recall", "methodology framework",
+            "--path", str(knowledge_with_wiki),
+            "--cache-dir", str(tmp_path / "cache"),
+            "--backend", "keyword",
+            "--top-k", "1",
+        ])
+        assert rc == 0
+        lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+        assert len(lines) <= 1
+
+    def test_missing_wiki_returns_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main([
+            "recall", "anything",
+            "--path", str(tmp_path / "nope"),
+            "--cache-dir", str(tmp_path / "cache"),
+            "--backend", "keyword",
+        ])
+        assert rc == 1
+        assert "Wiki directory not found" in capsys.readouterr().err
+
+    def test_fts5_backend_uses_prebuilt_index(
+        self, knowledge_with_wiki: Path, tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Recall with fts5 must use the on-disk cache the user built with
+        ``athenaeum rebuild-index``. Regression guard: if the handler
+        silently falls back to keyword when the fts5 index is missing,
+        validation harnesses reading `athenaeum.yaml: vector` would see
+        wrong results."""
+        cache = tmp_path / "cache"
+        rc = main([
+            "rebuild-index",
+            "--path", str(knowledge_with_wiki),
+            "--cache-dir", str(cache),
+            "--backend", "fts5",
+        ])
+        assert rc == 0
+        capsys.readouterr()  # drain rebuild-index output
+
+        rc = main([
+            "recall", "lean",
+            "--path", str(knowledge_with_wiki),
+            "--cache-dir", str(cache),
+            "--backend", "fts5",
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [line for line in out.splitlines() if line.strip()]
+        assert any("lean-startup.md" in line for line in lines)
+
+
 class TestIngestAnswers:
     """`athenaeum ingest-answers` subcommand (issue #61)."""
 


### PR DESCRIPTION
## Summary

- Adds `athenaeum recall <query>` subcommand — shell-accessible wrapper around the MCP `recall` tool, for validation harnesses and operator debugging that can't spin up a Claude Code session.
- Prints one tab-separated hit per line: `<score>\t<filename>\t<preview>`, where `<preview>` is the first 80 chars of the post-frontmatter body with newlines collapsed.
- Flags: `--top-k` (default 5), `--path` (default `~/knowledge`), `--cache-dir`, `--backend` (override configured backend).

Closes #71

## Design notes

- `recall_search()` in `mcp_server.py` returns a formatted Markdown string, not structured data. To honor the tab-separated output contract in the issue, `_cmd_recall` calls `athenaeum.search.get_backend(...).query(...)` directly (which returns `list[tuple[str, str, float]]`) instead of `recall_search`. Frontmatter parsing and extra-root path resolution reuse existing helpers (`parse_frontmatter`, `_resolve_hit_path`) so we stay on one code path.
- Config flow mirrors `serve` and `rebuild-index`: `load_config` + `resolve_extra_intake_roots` so the same `athenaeum.yaml` that drives MCP recall also drives this CLI.
- Tradeoff: imports `_resolve_hit_path` (underscore-prefixed) from `mcp_server`. Cleaner than copying the logic; if it moves to a shared module later, one callsite to update.

## Test plan

- [x] `TestRecall.test_keyword_backend_prints_tab_separated_hits` — asserts the three-field tab schema and first-hit relevance.
- [x] `TestRecall.test_top_k_limits_output` — `--top-k 1` caps output.
- [x] `TestRecall.test_missing_wiki_returns_error` — exit 1 + error on stderr when `~/knowledge/wiki` missing.
- [x] `TestRecall.test_fts5_backend_uses_prebuilt_index` — end-to-end via `rebuild-index` → `recall --backend fts5`, guards against silent keyword fallback when the index path is wrong.
- [x] Full `tests/test_cli.py` suite green locally (26 passed).
- [x] Manual smoke: `athenaeum recall "auto memory phase" --top-k 3` against `~/knowledge` returned three tab-separated hits with correct scores and previews.

## Out of scope

- No changes to `src/athenaeum/config.py` (Lane B / #68).
- No workflow changes.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
