### PR TITLE
feat(config): warn when extra_intake_root path is missing

### DIFF
--- a/src/athenaeum/config.py
+++ b/src/athenaeum/config.py
@@ -9,10 +9,13 @@ Missing config or missing keys fall back to sensible defaults.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 _DEFAULTS: dict[str, Any] = {
     "auto_recall": True,
@@ -110,9 +113,11 @@ def resolve_extra_intake_roots(
 
     Values under ``recall.extra_intake_roots`` that are relative are
     resolved against ``knowledge_root``; absolute paths are passed through.
-    Missing directories are silently dropped — a half-initialized
+    Missing directories are dropped (with a warning) — a half-initialized
     knowledge base (no ``raw/auto-memory`` yet) should not break index
-    rebuild. Returns an empty list when no extras are configured.
+    rebuild, but operators should see a diagnostic when a configured
+    root is typo'd or unmounted. Returns an empty list when no extras
+    are configured.
     """
     if config is None:
         config = load_config(knowledge_root)
@@ -132,4 +137,6 @@ def resolve_extra_intake_roots(
         candidate = candidate.expanduser()
         if candidate.is_dir():
             resolved.append(candidate.resolve())
+        else:
+            logger.warning("extra_intake_root not found: %s", candidate)
     return resolved

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
+
+import pytest
 
 from athenaeum.config import (
     load_config,
@@ -19,9 +22,7 @@ class TestLoadConfig:
         assert cfg["vector"]["provider"] == "chromadb"
 
     def test_reads_yaml(self, tmp_path: Path) -> None:
-        (tmp_path / "athenaeum.yaml").write_text(
-            "auto_recall: false\nsearch_backend: vector\n"
-        )
+        (tmp_path / "athenaeum.yaml").write_text("auto_recall: false\nsearch_backend: vector\n")
         cfg = load_config(tmp_path)
         assert cfg["auto_recall"] is False
         assert cfg["search_backend"] == "vector"
@@ -33,9 +34,7 @@ class TestLoadConfig:
         assert cfg["search_backend"] == "vector"
 
     def test_vector_nested_merge(self, tmp_path: Path) -> None:
-        (tmp_path / "athenaeum.yaml").write_text(
-            "vector:\n  provider: faiss\n"
-        )
+        (tmp_path / "athenaeum.yaml").write_text("vector:\n  provider: faiss\n")
         cfg = load_config(tmp_path)
         assert cfg["vector"]["provider"] == "faiss"
         assert cfg["vector"]["collection"] == "wiki"  # default preserved
@@ -61,9 +60,7 @@ class TestRecallExtraIntakeRootsDefault:
         assert cfg["recall"]["extra_intake_roots"] == ["raw/auto-memory"]
 
     def test_user_override_replaces_list(self, tmp_path: Path) -> None:
-        (tmp_path / "athenaeum.yaml").write_text(
-            "recall:\n  extra_intake_roots: []\n"
-        )
+        (tmp_path / "athenaeum.yaml").write_text("recall:\n  extra_intake_roots: []\n")
         cfg = load_config(tmp_path)
         assert cfg["recall"]["extra_intake_roots"] == []
 
@@ -76,34 +73,48 @@ class TestResolveExtraIntakeRoots:
         assert resolved[0].name == "auto-memory"
         assert resolved[0].is_absolute()
 
-    def test_drops_missing_roots(self, tmp_path: Path) -> None:
-        """Missing intake roots must not blow up index build."""
-        resolved = resolve_extra_intake_roots(tmp_path)
+    def test_drops_missing_roots(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Missing intake roots must not blow up index build, but they
+        should emit a WARNING so operators notice a typo'd or unmounted
+        path rather than silently losing recall coverage.
+        """
+        with caplog.at_level(logging.WARNING, logger="athenaeum.config"):
+            resolved = resolve_extra_intake_roots(tmp_path)
         assert resolved == []
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "extra_intake_root not found" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "raw/auto-memory" in warnings[0].getMessage()
 
     def test_accepts_absolute_path(self, tmp_path: Path) -> None:
         extra = tmp_path / "extra"
         extra.mkdir()
-        (tmp_path / "athenaeum.yaml").write_text(
-            f"recall:\n  extra_intake_roots:\n    - {extra}\n"
-        )
+        (tmp_path / "athenaeum.yaml").write_text(f"recall:\n  extra_intake_roots:\n    - {extra}\n")
         resolved = resolve_extra_intake_roots(tmp_path)
         assert resolved == [extra.resolve()]
 
-    def test_empty_list_returns_empty(self, tmp_path: Path) -> None:
-        (tmp_path / "athenaeum.yaml").write_text(
-            "recall:\n  extra_intake_roots: []\n"
-        )
-        resolved = resolve_extra_intake_roots(tmp_path)
+    def test_empty_list_returns_empty(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        (tmp_path / "athenaeum.yaml").write_text("recall:\n  extra_intake_roots: []\n")
+        with caplog.at_level(logging.WARNING, logger="athenaeum.config"):
+            resolved = resolve_extra_intake_roots(tmp_path)
         assert resolved == []
+        # Empty list must stay silent — no dropped paths to warn about.
+        assert not [r for r in caplog.records if "extra_intake_root not found" in r.getMessage()]
 
-    def test_non_list_returns_empty(self, tmp_path: Path) -> None:
+    def test_non_list_returns_empty(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """Malformed config (scalar instead of list) degrades gracefully."""
-        (tmp_path / "athenaeum.yaml").write_text(
-            "recall:\n  extra_intake_roots: raw/auto-memory\n"
-        )
-        resolved = resolve_extra_intake_roots(tmp_path)
+        (tmp_path / "athenaeum.yaml").write_text("recall:\n  extra_intake_roots: raw/auto-memory\n")
+        with caplog.at_level(logging.WARNING, logger="athenaeum.config"):
+            resolved = resolve_extra_intake_roots(tmp_path)
         assert resolved == []
+        # Non-list config is a distinct failure mode (malformed yaml),
+        # not per-root warnings — stay silent here too.
+        assert not [r for r in caplog.records if "extra_intake_root not found" in r.getMessage()]
 
 
 class TestWriteDefaultConfig:


### PR DESCRIPTION
## Summary

- `resolve_extra_intake_roots` in `src/athenaeum/config.py` now emits a `WARNING`-level log entry per configured `extra_intake_root` whose directory does not exist, instead of silently dropping it. This surfaces config typos and unmounted volumes to operators.
- Empty-list and malformed (non-list) configuration cases remain silent — those are distinct scenarios, not per-root drops.
- Adds a module-level `logger = logging.getLogger(__name__)` and uses lazy `%s` formatting.

## Test plan

- [x] `pytest tests/test_config.py` — 15/15 pass
- [x] `test_drops_missing_roots` extended to assert exactly one `WARNING` via `caplog` with the dropped path in the message
- [x] `test_empty_list_returns_empty` / `test_non_list_returns_empty` extended to assert no warnings fire
- [x] `ruff check` and `ruff format` clean

Closes #68
