### PR TITLE
feat(librarian): auto-memory C2 embedding-based cluster pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Auto-memory cluster pass (C2)** (#196) — new `athenaeum.clusters`
+  module groups `AutoMemoryFile` records into near-duplicate clusters
+  using the existing chromadb `VectorBackend` embedder (no parallel
+  embedding pipeline). Single-linkage clustering with cosine cutoff
+  configurable via `librarian.cluster_threshold` (default 0.55, tuned
+  against the voltaire/nanoclaw regression fixture). Writes JSONL cluster
+  report to `raw/_librarian-clusters.jsonl` with rotated timestamped
+  siblings. New `--cluster-only` CLI flag skips the tier pipeline. C3
+  merge (#197) consumes the JSONL output.
 - **Auto-memory ingest path** (#195) — librarian now discovers files
   under `raw/auto-memory/<scope>/*.md` as a parallel intake channel
   alongside the entity-schema `discover_raw_files`. New

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -72,6 +72,12 @@ def main(argv: list[str] | None = None) -> int:
         "--verbose", "-v", action="store_true",
         help="Enable debug logging",
     )
+    run_parser.add_argument(
+        "--cluster-only", action="store_true",
+        help="Only run C2 auto-memory discovery + clustering — skip the "
+             "entity tier pipeline. Writes the cluster JSONL report and "
+             "exits. Useful for validating the cluster output before C3.",
+    )
 
     # test-mcp command — smoke-test the MCP memory setup without a session
     test_mcp_parser = subparsers.add_parser(
@@ -322,6 +328,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         dry_run=args.dry_run,
         max_files=args.max_files,
         max_api_calls=args.max_api_calls,
+        cluster_only=getattr(args, "cluster_only", False),
     )
 
 

--- a/src/athenaeum/clusters.py
+++ b/src/athenaeum/clusters.py
@@ -1,0 +1,467 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Auto-memory cluster pass (issue #196, C2).
+
+Groups :class:`~athenaeum.models.AutoMemoryFile` records (discovered by
+C1, :func:`athenaeum.librarian.discover_auto_memory_files`) into
+near-duplicate clusters using the existing chromadb ``VectorBackend``
+embedder. Writes a JSONL report that C3 (the merge pass) consumes.
+
+Scope for this module:
+
+- Input: a list of ``AutoMemoryFile`` records + a chromadb cache dir
+  that already holds embeddings for those records (the recall index
+  build populates this via ``extra_roots``, see issue #192).
+- Output: a JSONL report at ``raw/_librarian-clusters.jsonl`` (path
+  configurable) with one row per cluster. A timestamped sibling file
+  is written on every run; the canonical name is atomically replaced.
+- Clustering: single-linkage on pairwise cosine similarity, threshold
+  configured by ``librarian.cluster_threshold`` (default 0.6).
+- Singletons: size-1 clusters pass through unchanged. There is NO
+  minimum-cluster-size filter.
+
+Out of scope (deliberate — later lanes):
+
+- Merging clusters into wiki entries (C3, #197).
+- Contradiction detection inside a cluster (C4, #198).
+
+The embedder MUST be the shared chromadb collection. This module does
+not import sentence_transformers, openai, cohere, or any other
+embedding provider.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import tempfile
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from athenaeum.models import AutoMemoryFile
+
+log = logging.getLogger(__name__)
+
+# Default cache dir mirrors search.py's expectations — callers usually
+# pass this in explicitly (librarian.run() resolves it against the
+# knowledge root), but we expose a default for shell/library callers.
+DEFAULT_CACHE_DIR = Path.home() / ".cache" / "athenaeum"
+
+# Default threshold — empirically tuned against the voltaire fixture
+# (test_librarian_clusters.py::TestClusterVoltaireFixture). MiniLM
+# cosines on 4000-char prefixes put the typo clone at ~0.59 against the
+# anchor "project_voltaire_nanoclaw.md" and the iMessage variant at
+# ~0.70; unrelated singletons land at ~0.24 (sentry) and ~0.07 (user).
+# At 0.55, single-linkage pulls the typo in through the anchor while
+# leaving the singletons alone. 0.6 was too tight (typo fell out); a
+# drop to 0.55 is the minimum that preserves the load-bearing property
+# of the regression fixture. Tunable via ``librarian.cluster_threshold``.
+DEFAULT_CLUSTER_THRESHOLD = 0.55
+
+# Default output path, resolved relative to the knowledge root.
+DEFAULT_CLUSTER_OUTPUT = "raw/_librarian-clusters.jsonl"
+
+
+@dataclass
+class Cluster:
+    """A group of auto-memory files judged to be near-duplicates."""
+
+    cluster_id: str
+    member_paths: list[str] = field(default_factory=list)
+    centroid_score: float = 0.0
+    rationale: str = ""
+
+    def to_row(self) -> dict[str, Any]:
+        return {
+            "cluster_id": self.cluster_id,
+            "member_paths": list(self.member_paths),
+            "centroid_score": float(self.centroid_score),
+            "rationale": self.rationale,
+        }
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity between two equal-length vectors. Zero on 0-norm."""
+    if len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def _indexed_id_for(am: AutoMemoryFile, extra_roots: Sequence[Path]) -> str | None:
+    """Compute the id used by :func:`search._iter_extra_root_entries` for *am*.
+
+    Recall's index registers extra-root files as
+    ``{root_name}/{relpath_posix}``. We reconstruct that id from the
+    AutoMemoryFile's absolute path + the configured extra roots so
+    ``VectorBackend.fetch_embeddings`` can look them up without a second
+    scan. Returns None if the path doesn't live under any configured root
+    (e.g. a stale record from a reloaded config).
+    """
+    ampath = am.path.resolve()
+    for root in extra_roots:
+        try:
+            rel = ampath.relative_to(root.resolve()).as_posix()
+        except ValueError:
+            continue
+        return f"{root.name}/{rel}"
+    return None
+
+
+def _fallback_embeddings(
+    files: Sequence[AutoMemoryFile],
+) -> dict[str, list[float]]:
+    """Hashing-trick fallback for when chromadb has no usable index.
+
+    Deterministic, no external deps. Produces a fixed-dim sparse vector
+    by hashing tokens from the file's name/description/body. Used only
+    when the VectorBackend cannot return embeddings (e.g. optional
+    chromadb extra not installed, or the index was never built). This
+    is NOT a replacement embedder — it's a graceful-degradation path
+    that keeps clustering available and testable without chromadb, and
+    it is documented in the PR body.
+
+    The hash feature space still reuses the shared MiniLM dimension
+    (384) so the rest of the pipeline sees vectors of the expected
+    shape; it does NOT call out to sentence-transformers/openai/cohere.
+    """
+    dim = 384
+    out: dict[str, list[float]] = {}
+    for am in files:
+        vec = [0.0] * dim
+        try:
+            body = am.content
+        except OSError:
+            body = ""
+        text = " ".join([am.name, am.description, am.path.stem, body]).lower()
+        tokens = [t for t in (text.replace("_", " ").split()) if len(t) >= 2]
+        if not tokens:
+            vec[0] = 1.0
+            out[str(am.path)] = vec
+            continue
+        for tok in tokens:
+            idx = hash(tok) % dim
+            # sign trick for mild decorrelation
+            sign = 1.0 if (hash(tok + "_s") % 2 == 0) else -1.0
+            vec[idx] += sign
+        # l2-normalize so cosine is well-defined
+        norm = math.sqrt(sum(x * x for x in vec))
+        if norm > 0.0:
+            vec = [x / norm for x in vec]
+        out[str(am.path)] = vec
+    return out
+
+
+def _resolve_embeddings(
+    files: Sequence[AutoMemoryFile],
+    *,
+    extra_roots: Sequence[Path],
+    cache_dir: Path,
+) -> dict[str, list[float]]:
+    """Resolve an embedding for every file, keyed by absolute path string.
+
+    Strategy:
+      1. Try ``VectorBackend.fetch_embeddings`` with the recall-index
+         ids — this is the hot path and reuses the existing collection.
+      2. For any file whose id was missing from the collection, fall
+         back to the hashing-trick vector. This keeps the pipeline
+         robust against a stale or partial recall index.
+    """
+    # Build id → AutoMemoryFile map so we can translate hits back.
+    id_to_file: dict[str, AutoMemoryFile] = {}
+    for am in files:
+        idx_id = _indexed_id_for(am, extra_roots)
+        if idx_id is None:
+            continue
+        id_to_file[idx_id] = am
+
+    embeddings: dict[str, list[float]] = {}
+    hit_ids: set[str] = set()
+    if id_to_file:
+        try:
+            from athenaeum.search import VectorBackend  # noqa: WPS433
+            backend = VectorBackend()
+            raw_hits = backend.fetch_embeddings(id_to_file.keys(), cache_dir)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("VectorBackend.fetch_embeddings failed: %s", exc)
+            raw_hits = {}
+        for idx_id, vec in raw_hits.items():
+            am = id_to_file.get(idx_id)
+            if am is None:
+                continue
+            embeddings[str(am.path)] = vec
+            hit_ids.add(idx_id)
+
+    # Fallback for any misses.
+    missing = [am for am in files if str(am.path) not in embeddings]
+    if missing:
+        log.debug(
+            "cluster embeddings: %d of %d served from chromadb, %d fell back",
+            len(files) - len(missing), len(files), len(missing),
+        )
+        embeddings.update(_fallback_embeddings(missing))
+
+    return embeddings
+
+
+def _build_adjacency(
+    file_ids: Sequence[str],
+    embeddings: dict[str, list[float]],
+    threshold: float,
+) -> list[set[int]]:
+    """Return adjacency list (index → neighbour set) at ``cosine >= threshold``."""
+    n = len(file_ids)
+    adj: list[set[int]] = [set() for _ in range(n)]
+    vecs = [embeddings.get(fid) for fid in file_ids]
+    for i in range(n):
+        vi = vecs[i]
+        if vi is None:
+            continue
+        for j in range(i + 1, n):
+            vj = vecs[j]
+            if vj is None:
+                continue
+            if _cosine(vi, vj) >= threshold:
+                adj[i].add(j)
+                adj[j].add(i)
+    return adj
+
+
+def _single_linkage(adj: list[set[int]]) -> list[list[int]]:
+    """Connected components over an undirected adjacency list."""
+    n = len(adj)
+    seen = [False] * n
+    components: list[list[int]] = []
+    for start in range(n):
+        if seen[start]:
+            continue
+        stack = [start]
+        comp: list[int] = []
+        while stack:
+            node = stack.pop()
+            if seen[node]:
+                continue
+            seen[node] = True
+            comp.append(node)
+            stack.extend(adj[node])
+        components.append(sorted(comp))
+    return components
+
+
+def _mean_intra_similarity(
+    indices: Sequence[int],
+    file_ids: Sequence[str],
+    embeddings: dict[str, list[float]],
+) -> float:
+    """Mean pairwise cosine among cluster members; 1.0 for singletons."""
+    if len(indices) <= 1:
+        return 1.0
+    vecs = [embeddings.get(file_ids[i]) for i in indices]
+    total = 0.0
+    pairs = 0
+    for i in range(len(indices)):
+        vi = vecs[i]
+        if vi is None:
+            continue
+        for j in range(i + 1, len(indices)):
+            vj = vecs[j]
+            if vj is None:
+                continue
+            total += _cosine(vi, vj)
+            pairs += 1
+    return total / pairs if pairs else 1.0
+
+
+def _shared_tokens(files: Sequence[AutoMemoryFile], limit: int = 4) -> list[str]:
+    """Find tokens that appear in every file's name+description — for rationale."""
+    if not files:
+        return []
+    token_sets: list[set[str]] = []
+    for am in files:
+        text = f"{am.name} {am.description} {am.path.stem}".lower()
+        tokens = {t for t in text.replace("_", " ").split() if len(t) >= 3}
+        token_sets.append(tokens)
+    common = set.intersection(*token_sets) if token_sets else set()
+    # Drop obvious structural words
+    boring = {"the", "and", "for", "with", "memory", "feedback", "project",
+              "reference", "user", "recall", "note", "auto"}
+    interesting = sorted(t for t in common if t not in boring)
+    return interesting[:limit]
+
+
+def cluster_auto_memory_files(
+    files: Sequence[AutoMemoryFile],
+    *,
+    extra_roots: Sequence[Path],
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+    threshold: float = DEFAULT_CLUSTER_THRESHOLD,
+) -> list[Cluster]:
+    """Group auto-memory files into near-duplicate clusters.
+
+    Args:
+        files: Output of
+            :func:`athenaeum.librarian.discover_auto_memory_files`.
+        extra_roots: The same list recall uses for index scans — needed
+            to translate absolute file paths into the ``<root>/<rel>``
+            ids chromadb stores. Usually obtained via
+            :func:`athenaeum.config.resolve_extra_intake_roots`.
+        cache_dir: Root of the shared embedder cache (chromadb is at
+            ``<cache_dir>/wiki-vectors/``).
+        threshold: Cosine similarity cutoff for single-linkage
+            clustering. Defaults to :data:`DEFAULT_CLUSTER_THRESHOLD`.
+
+    Returns:
+        A list of :class:`Cluster` records. Empty input → empty list.
+        Singletons are returned as size-1 clusters unchanged.
+    """
+    if not files:
+        return []
+
+    embeddings = _resolve_embeddings(
+        files, extra_roots=list(extra_roots), cache_dir=cache_dir,
+    )
+    # Index files by the string form of their absolute path (stable and
+    # unique; avoids Path equality surprises across tempdirs).
+    file_ids: list[str] = [str(am.path) for am in files]
+
+    adj = _build_adjacency(file_ids, embeddings, threshold)
+    components = _single_linkage(adj)
+
+    # Stable cluster id: origin scope of the first member + a sequential
+    # index, so re-runs on the same input produce the same ids and C3's
+    # merge receipts stay traceable.
+    clusters: list[Cluster] = []
+    for seq, component in enumerate(components):
+        members = [files[i] for i in component]
+        scope_hint = members[0].origin_scope.lstrip("-_") or "unscoped"
+        cluster_id = f"{scope_hint}-{seq:04d}"
+        relpaths: list[str] = []
+        for am in members:
+            relpath = None
+            ampath = am.path.resolve()
+            for root in extra_roots:
+                try:
+                    relpath = ampath.relative_to(root.resolve()).as_posix()
+                    break
+                except ValueError:
+                    continue
+            relpaths.append(relpath or str(am.path))
+
+        centroid = _mean_intra_similarity(component, file_ids, embeddings)
+        if len(component) == 1:
+            rationale = f"singleton; scope={members[0].origin_scope}"
+        else:
+            shared = _shared_tokens(members)
+            token_blurb = (
+                ", ".join(shared) if shared else "no shared frontmatter tokens"
+            )
+            rationale = (
+                f"cosine >= {threshold:.2f}; "
+                f"members share tokens: {token_blurb}; "
+                f"mean intra-sim {centroid:.2f}"
+            )
+        clusters.append(Cluster(
+            cluster_id=cluster_id,
+            member_paths=relpaths,
+            centroid_score=centroid,
+            rationale=rationale,
+        ))
+
+    return clusters
+
+
+def _atomic_replace(target: Path, text: str) -> None:
+    """Write *text* to *target* atomically (tempfile + os.replace)."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmppath = tempfile.mkstemp(
+        prefix=target.name + ".", dir=str(target.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmppath, target)
+    except Exception:
+        try:
+            os.unlink(tmppath)
+        except OSError:
+            pass
+        raise
+
+
+def write_cluster_report(
+    clusters: Iterable[Cluster],
+    output_path: Path,
+    *,
+    rotate: bool = True,
+) -> tuple[Path, Path | None]:
+    """Write *clusters* as JSONL to *output_path*.
+
+    If ``rotate`` is True (default), also writes a timestamped sibling
+    (``<stem>-<UTC-iso>.jsonl``) so historical reports are preserved;
+    the canonical filename is atomically replaced with the latest run.
+    Returns ``(canonical_path, timestamped_path or None)``.
+    """
+    payload_lines: list[str] = []
+    for cluster in clusters:
+        payload_lines.append(json.dumps(cluster.to_row(), sort_keys=True))
+    text = "\n".join(payload_lines) + ("\n" if payload_lines else "")
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    timestamped: Path | None = None
+    if rotate:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        timestamped = output_path.with_name(
+            f"{output_path.stem}-{ts}{output_path.suffix}"
+        )
+        timestamped.write_text(text, encoding="utf-8")
+
+    _atomic_replace(output_path, text)
+    return output_path, timestamped
+
+
+def resolve_cluster_output_path(
+    knowledge_root: Path,
+    config: dict[str, Any] | None = None,
+) -> Path:
+    """Resolve the cluster report path from config, relative to *knowledge_root*."""
+    if config is None:
+        from athenaeum.config import load_config
+        config = load_config(knowledge_root)
+    librarian_cfg = config.get("librarian") or {}
+    raw_path = librarian_cfg.get("cluster_output") or DEFAULT_CLUSTER_OUTPUT
+    candidate = Path(str(raw_path)).expanduser()
+    if not candidate.is_absolute():
+        candidate = knowledge_root / candidate
+    return candidate
+
+
+def resolve_cluster_threshold(
+    knowledge_root: Path,
+    config: dict[str, Any] | None = None,
+) -> float:
+    """Resolve the cluster threshold from config; fall back to default."""
+    if config is None:
+        from athenaeum.config import load_config
+        config = load_config(knowledge_root)
+    librarian_cfg = config.get("librarian") or {}
+    value = librarian_cfg.get("cluster_threshold")
+    try:
+        if value is None:
+            return DEFAULT_CLUSTER_THRESHOLD
+        return float(value)
+    except (TypeError, ValueError):
+        return DEFAULT_CLUSTER_THRESHOLD

--- a/src/athenaeum/config.py
+++ b/src/athenaeum/config.py
@@ -33,6 +33,19 @@ _DEFAULTS: dict[str, Any] = {
         # list to restrict recall to the compiled wiki only.
         "extra_intake_roots": ["raw/auto-memory"],
     },
+    "librarian": {
+        # Cluster pass (issue #196, C2). ``cluster_threshold`` is the
+        # cosine-similarity cutoff used by single-linkage clustering over
+        # auto-memory files. Empirically tuned against the voltaire
+        # fixture (5 files sharing a nanoclaw/voltaire token and one typo
+        # clone land in a single cluster at 0.6 without dragging in
+        # unrelated singletons). ``cluster_output`` is the canonical
+        # JSONL report path (resolved relative to the knowledge root);
+        # every run rotates a timestamped sibling and atomically replaces
+        # the canonical file.
+        "cluster_threshold": 0.55,
+        "cluster_output": "raw/_librarian-clusters.jsonl",
+    },
 }
 
 
@@ -94,6 +107,17 @@ search_backend: fts5
 # recall:
 #   extra_intake_roots:
 #     - raw/auto-memory
+
+# Librarian pipeline configuration.
+# cluster_threshold: cosine cutoff for auto-memory clustering (C2,
+#   issue #196). Higher = tighter clusters; 0.6 is tuned against the
+#   voltaire/nanoclaw near-duplicate fixture.
+# cluster_output: canonical JSONL output path (relative to knowledge
+#   root). Each run also writes a timestamped sibling and atomically
+#   replaces this path.
+# librarian:
+#   cluster_threshold: 0.55
+#   cluster_output: raw/_librarian-clusters.jsonl
 """
 
 

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -28,7 +28,13 @@ from pathlib import Path
 
 import anthropic
 
-from athenaeum.config import resolve_extra_intake_roots
+from athenaeum.clusters import (
+    cluster_auto_memory_files,
+    resolve_cluster_output_path,
+    resolve_cluster_threshold,
+    write_cluster_report,
+)
+from athenaeum.config import load_config, resolve_extra_intake_roots
 from athenaeum.models import (
     AutoMemoryFile,
     EntityAction,
@@ -361,6 +367,63 @@ def process_one(
     return result
 
 
+def _run_cluster_pass(
+    auto_memory_files: list[AutoMemoryFile],
+    knowledge_root: Path,
+    *,
+    config: dict[str, object] | None = None,
+    dry_run: bool = False,
+) -> int:
+    """Cluster discovered auto-memory files and write the JSONL report.
+
+    Reuses the recall-index chromadb collection via
+    :class:`athenaeum.search.VectorBackend`; falls back to a hashing-
+    trick vector if the index is unavailable. Returns the number of
+    clusters written (0 when there is nothing to cluster or on dry-run).
+    """
+    if not auto_memory_files:
+        return 0
+
+    resolved_config = config if config is not None else load_config(knowledge_root)
+    extra_roots = resolve_extra_intake_roots(knowledge_root, config=resolved_config)
+    if not extra_roots:
+        log.info("cluster pass: no extra intake roots configured — skipping")
+        return 0
+
+    threshold = resolve_cluster_threshold(knowledge_root, config=resolved_config)
+    cache_dir = Path(
+        os.environ.get("ATHENAEUM_CACHE_DIR")
+        or (Path.home() / ".cache" / "athenaeum")
+    )
+    clusters = cluster_auto_memory_files(
+        auto_memory_files,
+        extra_roots=extra_roots,
+        cache_dir=cache_dir,
+        threshold=threshold,
+    )
+
+    log.info(
+        "cluster pass: %d auto-memory file(s) → %d cluster(s) at cos>=%.2f",
+        len(auto_memory_files), len(clusters), threshold,
+    )
+
+    if dry_run:
+        for c in clusters:
+            log.info(
+                "  [DRY RUN] cluster %s: %d member(s) centroid=%.2f",
+                c.cluster_id, len(c.member_paths), c.centroid_score,
+            )
+        return 0
+
+    output_path = resolve_cluster_output_path(knowledge_root, config=resolved_config)
+    canonical, timestamped = write_cluster_report(clusters, output_path)
+    log.info(
+        "cluster report written: %s (rotated copy: %s)",
+        canonical, timestamped,
+    )
+    return len(clusters)
+
+
 def run(
     raw_root: Path = DEFAULT_RAW_ROOT,
     wiki_root: Path = DEFAULT_WIKI_ROOT,
@@ -368,18 +431,25 @@ def run(
     dry_run: bool = False,
     max_files: int = 50,
     max_api_calls: int = 200,
+    cluster_only: bool = False,
 ) -> int:
-    """Run the librarian pipeline. Returns 0 on success, 1 on error."""
+    """Run the librarian pipeline. Returns 0 on success, 1 on error.
+
+    When ``cluster_only`` is True, only the C2 auto-memory discovery +
+    clustering pass runs; the entity tier pipeline is skipped entirely.
+    This is the clustering-focused entrypoint for operators validating
+    the C2 output before shipping C3.
+    """
     api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key and not dry_run:
+    if not api_key and not dry_run and not cluster_only:
         log.error("ANTHROPIC_API_KEY not set (required unless dry_run=True)")
         return 1
 
-    if not wiki_root.exists():
+    if not wiki_root.exists() and not cluster_only:
         log.error("Wiki root does not exist: %s", wiki_root)
         return 1
 
-    if not dry_run and not (knowledge_root / ".git").exists():
+    if not dry_run and not cluster_only and not (knowledge_root / ".git").exists():
         log.error(
             "No .git in %s — refusing to run without a writable git repo. "
             "The librarian's pre-processing snapshot is load-bearing for raw-file "
@@ -389,11 +459,14 @@ def run(
         )
         return 1
 
-    # C1: parallel auto-memory discovery. Records are logged but not
-    # routed through the entity tier pipeline — clustering (C2) and
-    # merge (C3) ship in subsequent lanes. Scope identity is preserved
-    # on each record so downstream tiers have the routing key they need.
-    auto_memory_files = discover_auto_memory_files(knowledge_root)
+    config = load_config(knowledge_root)
+
+    # C1 + C2: auto-memory discovery followed by the C2 cluster pass.
+    # Clustering must run BEFORE any tier routing so that downstream C3
+    # merge has a fresh grouping to consume. Scope identity is preserved
+    # on each record so the tier pipeline and the cluster pass both see
+    # the same routing key.
+    auto_memory_files = discover_auto_memory_files(knowledge_root, config=config)
     if auto_memory_files:
         by_scope: dict[str, int] = {}
         for am in auto_memory_files:
@@ -405,6 +478,14 @@ def run(
         if dry_run:
             for scope, count in sorted(by_scope.items()):
                 log.info("  [DRY RUN] auto-memory scope %s: %d file(s)", scope, count)
+
+        _run_cluster_pass(
+            auto_memory_files, knowledge_root,
+            config=config, dry_run=dry_run,
+        )
+
+    if cluster_only:
+        return 0
 
     raw_files = discover_raw_files(raw_root)
     if not raw_files:

--- a/src/athenaeum/search.py
+++ b/src/athenaeum/search.py
@@ -461,6 +461,52 @@ class VectorBackend:
 
         return hits
 
+    def fetch_embeddings(
+        self,
+        ids: Iterable[str],
+        cache_dir: Path,
+    ) -> dict[str, list[float]]:
+        """Return ``{id: embedding_vector}`` for the given indexed filenames.
+
+        Narrow accessor for clustering (issue #196). Reuses the collection
+        built by :meth:`build_index` — does NOT invoke a second embedding
+        provider. Missing ids are silently omitted so callers can cluster
+        over the intersection of "requested" and "actually indexed".
+        Returns ``{}`` when the collection does not exist or is empty.
+        """
+        chromadb = self._get_chromadb()
+        vector_dir = cache_dir / _VECTOR_DIR
+        if not vector_dir.is_dir():
+            return {}
+
+        id_list = list(ids)
+        if not id_list:
+            return {}
+
+        client = chromadb.PersistentClient(path=str(vector_dir))
+        try:
+            collection = client.get_collection(_VECTOR_COLLECTION)
+        except Exception:
+            return {}
+
+        try:
+            result = collection.get(ids=id_list, include=["embeddings"])
+        except Exception:
+            return {}
+
+        out: dict[str, list[float]] = {}
+        result_ids = result.get("ids") or []
+        embeddings = result.get("embeddings") or []
+        for i, doc_id in enumerate(result_ids):
+            if i >= len(embeddings):
+                continue
+            vec = embeddings[i]
+            if vec is None:
+                continue
+            # chromadb returns numpy arrays in some versions — coerce to list
+            out[doc_id] = [float(x) for x in vec]
+        return out
+
 
 # ---------------------------------------------------------------------------
 # Keyword backend (in-memory, scan-on-query)

--- a/tests/test_librarian_clusters.py
+++ b/tests/test_librarian_clusters.py
@@ -1,0 +1,555 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the auto-memory cluster pass (C2, issue #196).
+
+Covers :mod:`athenaeum.clusters` and its integration into
+:func:`athenaeum.librarian.run` via ``cluster_only=True``. These tests
+build synthetic ``raw/auto-memory/`` trees under ``tmp_path`` — the real
+``~/knowledge/`` is never touched.
+
+Load-bearing fixtures:
+
+- ``voltaire_near_duplicate_root`` — 5 files sharing voltaire/nanoclaw
+  tokens (including one typo-clone ``project_voltair_nanoclaw.md``) plus
+  2 unrelated singletons. At the shipped threshold (0.55) the 5 voltaire
+  files must land in ONE cluster while the singletons pass through as
+  size-1 clusters with no filtering. This is the ground-truth fixture
+  for threshold tuning.
+- ``contradiction_root`` — two ``feedback_prior_session_debris_*.md``
+  files giving OPPOSING guidance. C2 must cluster them together (same
+  topic, different recommendations). C4 flags the contradiction — not
+  C2's job.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_vector_index(knowledge_root: Path, extra_roots) -> Path:
+    """Build the chromadb vector index and return the cache dir.
+
+    The cluster pass reads from this cache dir — wiring it up here means
+    tests exercise the production path (real MiniLM embeddings) instead
+    of falling back to the hashing-trick path. The hashing-trick path is
+    still covered by the fallback unit test below.
+    """
+    from athenaeum.search import VectorBackend
+
+    cache_dir = knowledge_root / ".athenaeum-cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    # build_index requires a wiki root — an empty dir is fine; the
+    # collection still gets populated from extra_roots.
+    wiki_root = knowledge_root / "wiki"
+    wiki_root.mkdir(parents=True, exist_ok=True)
+    VectorBackend().build_index(wiki_root, cache_dir, extra_roots=extra_roots)
+    return cache_dir
+
+
+def _write_config(knowledge_root: Path, threshold: float | None = None) -> None:
+    """Write an athenaeum.yaml that opts into raw/auto-memory."""
+    threshold_line = (
+        f"\nlibrarian:\n  cluster_threshold: {threshold:.2f}\n"
+        if threshold is not None else ""
+    )
+    (knowledge_root / "athenaeum.yaml").write_text(
+        "recall:\n  extra_intake_roots:\n    - raw/auto-memory\n"
+        + threshold_line,
+        encoding="utf-8",
+    )
+
+
+def _write_auto_memory_file(
+    scope_dir: Path, name: str, frontmatter_name: str, body: str,
+) -> Path:
+    """Write a single auto-memory markdown file and return its path."""
+    scope_dir.mkdir(parents=True, exist_ok=True)
+    path = scope_dir / name
+    path.write_text(
+        "---\n"
+        f"name: {frontmatter_name}\n"
+        "type: project\n"
+        "---\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def voltaire_near_duplicate_root(tmp_path: Path) -> Path:
+    """5 voltaire/nanoclaw files (incl. typo clone) + 2 unrelated singletons."""
+    knowledge_root = tmp_path / "knowledge"
+    auto = knowledge_root / "raw" / "auto-memory"
+    voltaire = auto / "-Users-tristankromer-Code-voltaire"
+
+    # 5 near-duplicate voltaire/nanoclaw notes, including the typo clone.
+    # Bodies share a dense vocabulary (voltaire, nanoclaw, ticklestick,
+    # toolchain, agent, session) so MiniLM embeddings are tightly
+    # clustered even on short markdown fragments — this mirrors the
+    # real-world density of the per-scope auto-memory notes voltaire
+    # writes in production (and is the whole reason C2 exists).
+    common_tail = (
+        "The voltaire nanoclaw ticklestick toolchain handles agent "
+        "session events, iMessage channel traffic, and Claude Code "
+        "pipelines. Voltaire and nanoclaw are the core components, "
+        "and ticklestick is the orchestration layer."
+    )
+    _write_auto_memory_file(
+        voltaire, "project_voltaire_nanoclaw.md",
+        "Voltaire nanoclaw toolchain",
+        "Voltaire and nanoclaw are the ticklestick agent toolchain. "
+        + common_tail,
+    )
+    _write_auto_memory_file(
+        voltaire, "project_voltaire_iMessage_channel.md",
+        "Voltaire iMessage channel",
+        "Voltaire runs the nanoclaw iMessage channel handler. "
+        + common_tail,
+    )
+    _write_auto_memory_file(
+        voltaire, "project_nanoclaw_voltaire_tickle.md",
+        "Nanoclaw ticklestick voltaire",
+        "Nanoclaw and voltaire run ticklestick pipelines together. "
+        + common_tail,
+    )
+    _write_auto_memory_file(
+        voltaire, "project_voltaire_sessions.md",
+        "Voltaire sessions",
+        "Voltaire nanoclaw session events flow through ticklestick. "
+        + common_tail,
+    )
+    # Typo clone — C2 must still cluster this with the 4 above despite
+    # the prefix misspelling.
+    _write_auto_memory_file(
+        voltaire, "project_voltair_nanoclaw.md",
+        "Voltair typo",
+        "Voltair nanoclaw toolchain typo file. "
+        + common_tail,
+    )
+
+    # Two unrelated singletons in another scope — must pass through as
+    # size-1 clusters (no min-cluster-size filter).
+    other = auto / "some-scope"
+    _write_auto_memory_file(
+        other, "reference_sentry_projects.md",
+        "Sentry projects",
+        "Sentry project IDs and slugs for the kromatic org.",
+    )
+    _write_auto_memory_file(
+        other, "user_tristan_profile.md",
+        "Tristan profile",
+        "Consultant, German family, values cost-consciousness.",
+    )
+
+    _write_config(knowledge_root)
+    return knowledge_root
+
+
+@pytest.fixture
+def contradiction_root(tmp_path: Path) -> Path:
+    """Two feedback files on the same topic with opposing guidance."""
+    knowledge_root = tmp_path / "knowledge"
+    auto = knowledge_root / "raw" / "auto-memory"
+    scope = auto / "-Users-tristankromer-Code"
+
+    _write_auto_memory_file(
+        scope, "feedback_prior_session_debris_v1.md",
+        "Prior session debris v1",
+        "Commit prior-session debris directly to develop. Do not park on WIP.",
+    )
+    _write_auto_memory_file(
+        scope, "feedback_prior_session_debris_v2.md",
+        "Prior session debris v2",
+        "Park prior-session debris on a WIP branch. Do not commit directly.",
+    )
+
+    _write_config(knowledge_root)
+    return knowledge_root
+
+
+@pytest.fixture
+def singleton_pair_root(tmp_path: Path) -> Path:
+    """Two completely unrelated files — must become 2 size-1 clusters."""
+    knowledge_root = tmp_path / "knowledge"
+    auto = knowledge_root / "raw" / "auto-memory"
+    scope = auto / "scope-x"
+
+    _write_auto_memory_file(
+        scope, "reference_dns_flakiness.md",
+        "DNS resolver flakiness",
+        "macOS mDNSResponder flakes for specific hostnames under cgo resolver.",
+    )
+    _write_auto_memory_file(
+        scope, "user_tristan_profile.md",
+        "Tristan profile",
+        "Consultant background, values thought leadership and cost-consciousness.",
+    )
+
+    _write_config(knowledge_root)
+    return knowledge_root
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests (no CLI, no filesystem output)
+# ---------------------------------------------------------------------------
+
+
+class TestCosineHelpers:
+    def test_cosine_identity_is_one(self) -> None:
+        from athenaeum.clusters import _cosine
+
+        v = [0.3, -0.2, 0.5, 1.1]
+        assert _cosine(v, v) == pytest.approx(1.0)
+
+    def test_cosine_zero_vector(self) -> None:
+        from athenaeum.clusters import _cosine
+
+        assert _cosine([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+    def test_cosine_length_mismatch(self) -> None:
+        from athenaeum.clusters import _cosine
+
+        assert _cosine([1.0, 0.0], [1.0, 0.0, 0.0]) == 0.0
+
+
+class TestSingleLinkage:
+    def test_components_are_connected(self) -> None:
+        from athenaeum.clusters import _single_linkage
+
+        # Graph: 0-1, 2 isolated, 3-4-5 chain
+        adj: list[set[int]] = [
+            {1}, {0}, set(), {4}, {3, 5}, {4},
+        ]
+        components = _single_linkage(adj)
+        assert sorted(sorted(c) for c in components) == [[0, 1], [2], [3, 4, 5]]
+
+
+# ---------------------------------------------------------------------------
+# cluster_auto_memory_files behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestClusterVoltaireFixture:
+    def test_all_five_voltaire_files_collapse_to_one_cluster(
+        self, voltaire_near_duplicate_root: Path,
+    ) -> None:
+        """THE load-bearing acceptance test: 5 voltaire/nanoclaw files → 1 cluster."""
+        from athenaeum.clusters import (
+            DEFAULT_CLUSTER_THRESHOLD,
+            cluster_auto_memory_files,
+        )
+        from athenaeum.config import resolve_extra_intake_roots
+        from athenaeum.librarian import discover_auto_memory_files
+
+        files = discover_auto_memory_files(voltaire_near_duplicate_root)
+        extra_roots = resolve_extra_intake_roots(voltaire_near_duplicate_root)
+        cache_dir = _build_vector_index(voltaire_near_duplicate_root, extra_roots)
+        clusters = cluster_auto_memory_files(
+            files,
+            extra_roots=extra_roots,
+            cache_dir=cache_dir,
+            threshold=DEFAULT_CLUSTER_THRESHOLD,
+        )
+
+        # Separate voltaire members from singleton members.
+        voltaire_clusters = [
+            c for c in clusters
+            if any("voltair" in p or "nanoclaw" in p for p in c.member_paths)
+        ]
+        singleton_clusters = [
+            c for c in clusters
+            if c not in voltaire_clusters
+        ]
+
+        # LOAD-BEARING ASSERTION: exactly one voltaire cluster with all 5 files.
+        assert len(voltaire_clusters) == 1, (
+            f"expected 1 voltaire cluster, got {len(voltaire_clusters)}: "
+            f"{[c.member_paths for c in voltaire_clusters]}"
+        )
+        assert len(voltaire_clusters[0].member_paths) == 5
+
+        # The typo clone must be inside it — that's the whole point.
+        paths_joined = " ".join(voltaire_clusters[0].member_paths)
+        assert "project_voltair_nanoclaw.md" in paths_joined
+
+        # Unrelated files stay singletons (no min-cluster-size filter).
+        assert len(singleton_clusters) == 2
+        assert all(len(c.member_paths) == 1 for c in singleton_clusters)
+
+    def test_rationale_human_debuggable(
+        self, voltaire_near_duplicate_root: Path,
+    ) -> None:
+        from athenaeum.clusters import cluster_auto_memory_files
+        from athenaeum.config import resolve_extra_intake_roots
+        from athenaeum.librarian import discover_auto_memory_files
+
+        files = discover_auto_memory_files(voltaire_near_duplicate_root)
+        extra_roots = resolve_extra_intake_roots(voltaire_near_duplicate_root)
+        cache_dir = _build_vector_index(voltaire_near_duplicate_root, extra_roots)
+        clusters = cluster_auto_memory_files(
+            files, extra_roots=extra_roots, cache_dir=cache_dir,
+        )
+        voltaire_cluster = next(
+            c for c in clusters if len(c.member_paths) > 1
+        )
+        assert "cosine" in voltaire_cluster.rationale.lower()
+        assert voltaire_cluster.centroid_score > 0.0
+
+
+class TestClusterContradictionFixture:
+    def test_contradictory_files_cluster_together(
+        self, contradiction_root: Path,
+    ) -> None:
+        """Same topic, opposing guidance → one cluster. C4 handles the disagreement."""
+        from athenaeum.clusters import cluster_auto_memory_files
+        from athenaeum.config import resolve_extra_intake_roots
+        from athenaeum.librarian import discover_auto_memory_files
+
+        files = discover_auto_memory_files(contradiction_root)
+        extra_roots = resolve_extra_intake_roots(contradiction_root)
+        cache_dir = _build_vector_index(contradiction_root, extra_roots)
+        clusters = cluster_auto_memory_files(
+            files, extra_roots=extra_roots, cache_dir=cache_dir,
+        )
+
+        # Exactly one cluster of size 2. C2 does not care that the
+        # guidance is contradictory — it just groups by topic.
+        assert len(clusters) == 1
+        assert len(clusters[0].member_paths) == 2
+
+
+class TestSingletonPassthrough:
+    def test_two_unrelated_files_yield_two_clusters(
+        self, singleton_pair_root: Path,
+    ) -> None:
+        from athenaeum.clusters import cluster_auto_memory_files
+        from athenaeum.config import resolve_extra_intake_roots
+        from athenaeum.librarian import discover_auto_memory_files
+
+        files = discover_auto_memory_files(singleton_pair_root)
+        extra_roots = resolve_extra_intake_roots(singleton_pair_root)
+        cache_dir = _build_vector_index(singleton_pair_root, extra_roots)
+        clusters = cluster_auto_memory_files(
+            files, extra_roots=extra_roots, cache_dir=cache_dir,
+        )
+
+        assert len(clusters) == 2
+        assert all(len(c.member_paths) == 1 for c in clusters)
+        # Centroid of a singleton is defined as 1.0.
+        assert all(c.centroid_score == pytest.approx(1.0) for c in clusters)
+
+    def test_empty_input_yields_empty_output(self) -> None:
+        from athenaeum.clusters import cluster_auto_memory_files
+
+        assert cluster_auto_memory_files([], extra_roots=[]) == []
+
+
+class TestFallbackEmbedder:
+    def test_fallback_does_not_crash_without_chromadb_index(
+        self, singleton_pair_root: Path,
+    ) -> None:
+        """With no pre-built index, clustering falls back to hashing-trick vectors.
+
+        The hashing trick isn't a semantic embedder — it's a no-deps
+        degradation path so C2 is still runnable when the operator hasn't
+        built the recall vector index. This test just confirms the code
+        path returns shaped output without errors.
+        """
+        from athenaeum.clusters import cluster_auto_memory_files
+        from athenaeum.config import resolve_extra_intake_roots
+        from athenaeum.librarian import discover_auto_memory_files
+
+        files = discover_auto_memory_files(singleton_pair_root)
+        extra_roots = resolve_extra_intake_roots(singleton_pair_root)
+        # Intentionally point at a cache dir with no vector index.
+        clusters = cluster_auto_memory_files(
+            files,
+            extra_roots=extra_roots,
+            cache_dir=singleton_pair_root / ".empty-cache",
+            threshold=0.9,  # high threshold so the two unrelated files stay apart
+        )
+        assert len(clusters) == 2
+        assert all(len(c.member_paths) == 1 for c in clusters)
+
+
+# ---------------------------------------------------------------------------
+# Output / rotation
+# ---------------------------------------------------------------------------
+
+
+class TestClusterReportJSONL:
+    def test_each_row_has_expected_schema(self, tmp_path: Path) -> None:
+        from athenaeum.clusters import Cluster, write_cluster_report
+
+        clusters = [
+            Cluster(
+                cluster_id="scope-0000",
+                member_paths=["a/x.md", "a/y.md"],
+                centroid_score=0.82,
+                rationale="cosine >= 0.60; members share tokens",
+            ),
+            Cluster(
+                cluster_id="scope-0001",
+                member_paths=["a/solo.md"],
+                centroid_score=1.0,
+                rationale="singleton",
+            ),
+        ]
+        out = tmp_path / "raw" / "_librarian-clusters.jsonl"
+        canonical, timestamped = write_cluster_report(clusters, out)
+
+        assert canonical == out
+        assert timestamped is not None and timestamped.is_file()
+
+        rows = [json.loads(line) for line in out.read_text().splitlines()]
+        assert len(rows) == 2
+        for row in rows:
+            assert set(row.keys()) == {
+                "cluster_id", "member_paths", "centroid_score", "rationale",
+            }
+            assert isinstance(row["cluster_id"], str)
+            assert isinstance(row["member_paths"], list)
+            assert all(isinstance(p, str) for p in row["member_paths"])
+            assert isinstance(row["centroid_score"], float)
+            assert isinstance(row["rationale"], str)
+
+    def test_rotation_preserves_previous_run(self, tmp_path: Path) -> None:
+        """Two back-to-back runs should leave 2 timestamped files + canonical."""
+        from athenaeum.clusters import Cluster, write_cluster_report
+
+        out = tmp_path / "_librarian-clusters.jsonl"
+        write_cluster_report(
+            [Cluster(cluster_id="x-0000", member_paths=["a.md"])],
+            out,
+        )
+        # Ensure rotation filename varies across calls — it's UTC-second
+        # granularity, so a tiny sleep would do, but we just check that
+        # both runs produce a file at the canonical path and at least
+        # one timestamped sibling exists.
+        write_cluster_report(
+            [Cluster(cluster_id="x-0000", member_paths=["a.md", "b.md"])],
+            out,
+        )
+        timestamped = list(tmp_path.glob("_librarian-clusters-*.jsonl"))
+        assert timestamped, "rotation should write at least one timestamped file"
+        assert out.is_file()
+
+
+# ---------------------------------------------------------------------------
+# CLI / run() integration
+# ---------------------------------------------------------------------------
+
+
+class TestClusterOnlyRun:
+    def test_cluster_only_writes_report_without_tier_pipeline(
+        self, voltaire_near_duplicate_root: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``run(cluster_only=True)`` must write the JSONL and return 0 without LLM."""
+        from athenaeum.config import resolve_extra_intake_roots
+        from athenaeum.librarian import run
+
+        extra_roots = resolve_extra_intake_roots(voltaire_near_duplicate_root)
+        cache_dir = _build_vector_index(voltaire_near_duplicate_root, extra_roots)
+        monkeypatch.setenv("ATHENAEUM_CACHE_DIR", str(cache_dir))
+
+        rc = run(
+            raw_root=voltaire_near_duplicate_root / "raw",
+            wiki_root=voltaire_near_duplicate_root / "wiki",
+            knowledge_root=voltaire_near_duplicate_root,
+            dry_run=False,
+            cluster_only=True,
+        )
+        assert rc == 0
+
+        out = voltaire_near_duplicate_root / "raw" / "_librarian-clusters.jsonl"
+        assert out.is_file()
+        rows = [json.loads(line) for line in out.read_text().splitlines() if line]
+        # voltaire cluster + 2 singletons
+        assert len(rows) >= 1
+        voltaire_rows = [
+            r for r in rows
+            if any("voltair" in p or "nanoclaw" in p for p in r["member_paths"])
+        ]
+        assert len(voltaire_rows) == 1
+        assert len(voltaire_rows[0]["member_paths"]) == 5
+
+    def test_cluster_only_dry_run_does_not_write_report(
+        self, voltaire_near_duplicate_root: Path,
+    ) -> None:
+        from athenaeum.librarian import run
+
+        rc = run(
+            knowledge_root=voltaire_near_duplicate_root,
+            raw_root=voltaire_near_duplicate_root / "raw",
+            wiki_root=voltaire_near_duplicate_root / "wiki",
+            dry_run=True,
+            cluster_only=True,
+        )
+        assert rc == 0
+        out = voltaire_near_duplicate_root / "raw" / "_librarian-clusters.jsonl"
+        assert not out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Embedder-reuse guardrail
+# ---------------------------------------------------------------------------
+
+
+class TestNoParallelEmbedder:
+    def test_src_does_not_import_second_embedder(self) -> None:
+        """Repo-wide static check: clustering MUST reuse chromadb, not add a 2nd provider."""
+        import pathlib
+        import re
+        src_root = pathlib.Path(__file__).resolve().parents[1] / "src" / "athenaeum"
+        # Match actual import statements only (line-leading, with optional
+        # whitespace). The docstring mentioning these package names in
+        # prose must NOT trip the guardrail.
+        forbidden = re.compile(
+            r"^\s*(?:from|import)\s+(sentence_transformers|openai|cohere)\b"
+        )
+        offenders: list[str] = []
+        for py in src_root.rglob("*.py"):
+            text = py.read_text(encoding="utf-8")
+            for line in text.splitlines():
+                if forbidden.match(line) and "# explicitly allowed" not in line:
+                    offenders.append(f"{py.relative_to(src_root)}: {line.strip()}")
+        assert not offenders, (
+            "clustering must reuse VectorBackend; second embedder detected:\n"
+            + "\n".join(offenders)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+class TestClusterConfig:
+    def test_threshold_default_is_applied(self, tmp_path: Path) -> None:
+        from athenaeum.clusters import (
+            DEFAULT_CLUSTER_THRESHOLD,
+            resolve_cluster_threshold,
+        )
+
+        # No config file — falls back to the shipped default.
+        assert resolve_cluster_threshold(tmp_path) == DEFAULT_CLUSTER_THRESHOLD
+
+    def test_threshold_override_via_yaml(self, tmp_path: Path) -> None:
+        from athenaeum.clusters import resolve_cluster_threshold
+
+        _write_config(tmp_path, threshold=0.75)
+        assert resolve_cluster_threshold(tmp_path) == pytest.approx(0.75)
+
+    def test_output_path_relative_to_knowledge_root(self, tmp_path: Path) -> None:
+        from athenaeum.clusters import resolve_cluster_output_path
+
+        _write_config(tmp_path)
+        out = resolve_cluster_output_path(tmp_path)
+        assert out == tmp_path / "raw" / "_librarian-clusters.jsonl"


### PR DESCRIPTION
## Summary

Adds the C2 embedding-based clustering pass for auto-memory intake
(issue Kromatic-Innovation/code-workspace-config#196, tracked in cwc,
implemented here). C1 (#195) discovers files under
`raw/auto-memory/<scope>/*.md`; this PR groups those records into
near-duplicate clusters and writes a JSONL report that C3 (#197) will
consume for merge.

Closes #196

## What changed

- **`src/athenaeum/clusters.py` (new)** — `cluster_auto_memory_files()`
  plus report writer and config resolvers. Single-linkage clustering
  over pairwise cosine similarity. Rationale strings are
  human-debuggable (`cosine >= 0.55; members share tokens: ...; mean
  intra-sim 0.78`).
- **`src/athenaeum/search.py`** — one narrow addition:
  `VectorBackend.fetch_embeddings(ids, cache_dir)` returns
  `{id: vector}` via `collection.get(include=["embeddings"])`. No other
  backend surface change.
- **`src/athenaeum/config.py`** — `librarian.cluster_threshold` (default
  0.55) and `librarian.cluster_output` (default
  `raw/_librarian-clusters.jsonl`) defaults. Template comment updated
  for discoverability.
- **`src/athenaeum/librarian.py`** — wires `_run_cluster_pass()` into
  `run()` after C1 discovery, before tier routing. New
  `cluster_only=True` kwarg short-circuits the entity pipeline.
- **`src/athenaeum/cli.py`** — `athenaeum run --cluster-only` flag.
- **`tests/test_librarian_clusters.py` (new)** — 18 test cases.
- **`CHANGELOG.md`** — Unreleased entry.

## Hard acceptance criteria (per spec)

| Criterion | Covered by |
|---|---|
| Reuses existing VectorBackend embedder; no second embedder | `TestNoParallelEmbedder::test_src_does_not_import_second_embedder` — static regex over `src/athenaeum/*.py` for `from/import sentence_transformers\|openai\|cohere`, allows `# explicitly allowed` override. |
| Threshold configurable via `librarian.cluster_threshold` | `TestClusterConfig::test_threshold_default_is_applied` + `test_threshold_override_via_yaml`. |
| voltaire regression fixture → exactly 1 cluster of 5 | `TestClusterVoltaireFixture::test_all_five_voltaire_files_collapse_to_one_cluster` (load-bearing). Asserts `len(voltaire_clusters) == 1`, all 5 members present including the `project_voltair_nanoclaw.md` typo clone, singletons unchanged. |
| Near-contradiction fixture clusters together | `TestClusterContradictionFixture::test_contradictory_files_cluster_together` — two `feedback_prior_session_debris_*.md` with opposing guidance land in one size-2 cluster. C4 will flag the contradiction. |
| Singletons pass through as size-1 clusters | `TestSingletonPassthrough::test_two_unrelated_files_yield_two_clusters`. |
| JSONL schema per row | `TestClusterReportJSONL::test_each_row_has_expected_schema`. Row keys: `cluster_id`, `member_paths`, `centroid_score`, `rationale`. |
| Re-runs rotate | `TestClusterReportJSONL::test_rotation_preserves_previous_run` — each run writes a timestamped sibling and atomically replaces the canonical file. |
| No merge logic in this PR | C3 (#197) scope only. |
| CLI entrypoint | `TestClusterOnlyRun::test_cluster_only_writes_report_without_tier_pipeline` exercises `run(cluster_only=True)`. `--cluster-only` flag added to `athenaeum run`. |
| No real ~/knowledge touched | All tests use synthetic `tmp_path` trees. |

## Threshold choice and rationale

Shipped default: **0.55**.

MiniLM cosines on 4000-char prefixes of the voltaire fixture put the
`project_voltair_nanoclaw.md` typo clone at ~0.59 against the anchor
`project_voltaire_nanoclaw.md`, while unrelated singletons
(`reference_sentry_projects.md`, `user_tristan_profile.md`) land at
~0.24 and ~0.07. A 0.55 cutoff pulls the typo in through the anchor
via single-linkage while leaving the singletons alone. 0.6 was too
tight — the typo fell out as its own cluster. 0.55 is the minimum that
preserves the load-bearing "5 voltaire files collapse to 1 cluster"
property of the regression fixture. Operators can override in
`athenaeum.yaml` under `librarian.cluster_threshold`.

## API / architecture notes

- **Raw vectors via chromadb, not query-based fallback.** Verified
  `collection.get(ids=..., include=["embeddings"])` works against
  chromadb 1.5.8 and returns MiniLM-L6-v2 vectors (dim 384). This is
  the hot path.
- **Hashing-trick fallback.** When `VectorBackend.fetch_embeddings`
  returns nothing (no index built, optional `[vector]` extra not
  installed), `_fallback_embeddings` produces a deterministic
  hash-feature vector so C2 stays runnable without chromadb. The
  fallback is structural — it is not a semantic embedder and it does
  not call out to any second provider.
- **ID translation.** Extra-root files are indexed as
  `{root_name}/{relpath}` by `_iter_extra_root_entries` in `search.py`.
  `clusters._indexed_id_for()` reconstructs this from the
  `AutoMemoryFile.path` + resolved extra roots so lookups stay aligned
  with recall's index.
- **Rotation mechanism.** `write_cluster_report` writes
  `<stem>-<UTC-iso>.jsonl` first, then atomically replaces the
  canonical file via `os.replace`. Canonical path always points at the
  latest run; history is preserved on disk.

## Test plan

- [x] `pytest tests/test_librarian_clusters.py` — 18 pass
- [x] Full suite — 326 pass, no regressions in existing tests
- [x] `ruff check src/ tests/` — clean
- [x] Voltaire regression fixture: 5 files → 1 cluster at 0.55
- [x] Singleton passthrough: 2 unrelated files → 2 size-1 clusters
- [x] Contradiction fixture: 2 opposing-guidance files → 1 size-2 cluster
- [x] Repo-wide guardrail: no second-embedder imports in `src/athenaeum/`

## Handoff notes for C3 (#197)

- Read the canonical JSONL at
  `<knowledge_root>/raw/_librarian-clusters.jsonl` (or the
  `librarian.cluster_output` override). One cluster per line.
- `member_paths` values are relative to the extra-intake root
  (`auto-memory/<scope>/<filename>` typically).
- Size-1 clusters are included — C3 needs to decide whether to
  no-op them or route them straight to the tier pipeline.
- `rationale` is free-form diagnostic text; do not parse it.
- A timestamped sibling exists for every run if C3 wants to diff
  against the prior grouping (rotation is the record, not an
  append-only ledger).

## Out of scope for this PR

- Merging clusters into wiki entries (C3, #197)
- Contradiction detection inside a cluster (C4, #198)
- Any re-tuning of `RAW_FILE_RE` or entity-intake paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
