### PR TITLE
feat(librarian): auto-memory C3 cluster-merge pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Auto-memory cluster merge (C3)** (#197) — new `athenaeum.merge`
+  module consumes the C2 cluster JSONL and emits one consolidated wiki
+  entry per cluster at `wiki/auto-<topic-slug>.md` with a deduped
+  `sources[]` union (dedupe key: `(session, turn)`), propagated
+  `origin_scope` per source, and a `contradictions_detected` heuristic
+  flag (`centroid_score < 0.75`) for the C4 review queue. Size-1
+  clusters ARE emitted as wiki entries; raw intake files remain
+  untouched. New `--merge-only` CLI flag mirrors `--cluster-only` for
+  iterating on merge output without re-embedding.
 - **p95 search-latency benchmark harness** (#69) — new
   `tests/benchmarks/test_search_bench.py` checks in the ad-hoc benchmark
   used for the Session-2 recall budget as a pytest-benchmark fixture.

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -78,6 +78,12 @@ def main(argv: list[str] | None = None) -> int:
              "entity tier pipeline. Writes the cluster JSONL report and "
              "exits. Useful for validating the cluster output before C3.",
     )
+    run_parser.add_argument(
+        "--merge-only", action="store_true",
+        help="Only run C3 cluster merge — read the canonical cluster "
+             "JSONL from the last C2 run and emit wiki/auto-*.md entries. "
+             "Skips discovery, clustering, and the entity tier pipeline.",
+    )
 
     # test-mcp command — smoke-test the MCP memory setup without a session
     test_mcp_parser = subparsers.add_parser(
@@ -329,6 +335,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         max_files=args.max_files,
         max_api_calls=args.max_api_calls,
         cluster_only=getattr(args, "cluster_only", False),
+        merge_only=getattr(args, "merge_only", False),
     )
 
 

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -35,6 +35,7 @@ from athenaeum.clusters import (
     write_cluster_report,
 )
 from athenaeum.config import load_config, resolve_extra_intake_roots
+from athenaeum.merge import merge_clusters_to_wiki
 from athenaeum.models import (
     AutoMemoryFile,
     EntityAction,
@@ -432,6 +433,7 @@ def run(
     max_files: int = 50,
     max_api_calls: int = 200,
     cluster_only: bool = False,
+    merge_only: bool = False,
 ) -> int:
     """Run the librarian pipeline. Returns 0 on success, 1 on error.
 
@@ -439,17 +441,24 @@ def run(
     clustering pass runs; the entity tier pipeline is skipped entirely.
     This is the clustering-focused entrypoint for operators validating
     the C2 output before shipping C3.
+
+    When ``merge_only`` is True, only the C3 merge pass runs: it reads
+    the canonical cluster JSONL from a previous C2 run and writes
+    ``wiki/auto-<topic-slug>.md`` entries. Neither discovery, clustering,
+    nor the entity tier pipeline runs. Useful for iterating on the merge
+    output without re-embedding or re-clustering.
     """
+    skip_entity_tiers = cluster_only or merge_only
     api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key and not dry_run and not cluster_only:
+    if not api_key and not dry_run and not skip_entity_tiers:
         log.error("ANTHROPIC_API_KEY not set (required unless dry_run=True)")
         return 1
 
-    if not wiki_root.exists() and not cluster_only:
+    if not wiki_root.exists() and not skip_entity_tiers:
         log.error("Wiki root does not exist: %s", wiki_root)
         return 1
 
-    if not dry_run and not cluster_only and not (knowledge_root / ".git").exists():
+    if not dry_run and not skip_entity_tiers and not (knowledge_root / ".git").exists():
         log.error(
             "No .git in %s — refusing to run without a writable git repo. "
             "The librarian's pre-processing snapshot is load-bearing for raw-file "
@@ -460,6 +469,16 @@ def run(
         return 1
 
     config = load_config(knowledge_root)
+
+    if merge_only:
+        # Merge-only path skips discovery + clustering entirely; it reads
+        # the canonical cluster JSONL written by a prior C2 run and
+        # compiles ``wiki/auto-*.md`` entries from it. Discovery still
+        # happens inside merge_clusters_to_wiki() for source propagation.
+        merge_clusters_to_wiki(
+            knowledge_root, config=config, dry_run=dry_run,
+        )
+        return 0
 
     # C1 + C2: auto-memory discovery followed by the C2 cluster pass.
     # Clustering must run BEFORE any tier routing so that downstream C3
@@ -482,6 +501,16 @@ def run(
         _run_cluster_pass(
             auto_memory_files, knowledge_root,
             config=config, dry_run=dry_run,
+        )
+
+        # C3: merge clusters into canonical wiki/auto-*.md entries. Runs
+        # after C2 in the same pipeline so a full librarian run refreshes
+        # cluster + merge together. Uses the cluster JSONL written above.
+        merge_clusters_to_wiki(
+            knowledge_root,
+            auto_memory_files=auto_memory_files,
+            config=config,
+            dry_run=dry_run,
         )
 
     if cluster_only:

--- a/src/athenaeum/merge.py
+++ b/src/athenaeum/merge.py
@@ -1,0 +1,594 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Auto-memory merge pass (issue #197, C3).
+
+Consumes the JSONL cluster report produced by C2
+(:mod:`athenaeum.clusters`) and emits ONE canonical wiki entry per
+cluster at ``wiki/auto-<topic-slug>.md``. Every member's content is
+concatenated into a synthesized body; every member's ``sources[]`` is
+unioned into a single deduped cited list.
+
+Scope for this module (kept narrow on purpose — see issue #197):
+
+- Input: canonical cluster JSONL path + knowledge root.
+- Output: ``wiki/auto-<topic-slug>.md`` per cluster.
+- Dedupe key for ``sources[]``: ``(session, turn)``. Two turns in the
+  same session stay distinct; duplicate citations of the same turn are
+  collapsed. ``(session, date)`` is explicitly NOT used.
+- ``origin_scope`` is propagated from C1's record onto every source
+  entry.
+- Singletons ARE emitted (size-1 clusters → size-1 source list). There
+  is no minimum-cluster-size filter; the wiki read path wants a uniform
+  surface.
+- Contradiction heuristic: the PR flags ``contradictions_detected: true``
+  in frontmatter when the cluster's ``centroid_score`` falls below
+  :data:`CONTRADICTION_COHESION_THRESHOLD` (0.75). C4 (#198) replaces
+  this with real contradiction detection — this module is only the
+  cheap proxy so the human-review queue has a seed.
+
+Out of scope (deliberate — later lanes):
+
+- LLM-based body synthesis. C3's strategy is deterministic:
+  concatenate member bodies, drop identical paragraphs, prefix each
+  block with a scope/filename header. Rich paraphrase is a follow-up.
+- Real contradiction detection (C4, #198).
+- Rewrites to ``raw/auto-memory/*`` — raw is append-only; the wiki is
+  the compiled view.
+- A cross-scope ``wiki/MEMORY.md`` — Phase B explicitly removed it and
+  this module does NOT recreate it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from athenaeum.clusters import resolve_cluster_output_path
+from athenaeum.config import load_config, resolve_extra_intake_roots
+from athenaeum.models import (
+    AutoMemoryFile,
+    parse_frontmatter,
+    render_frontmatter,
+)
+
+log = logging.getLogger(__name__)
+
+# Centroid score below which a cluster is flagged for C4 human review.
+# Cohesive clusters (identical/near-identical members) sit near 1.0;
+# members that share a topic but disagree drift below. 0.75 is the
+# documented first-pass heuristic for this PR — C4 replaces it with
+# real contradiction detection. Keeping it here (not in config) makes
+# the PR diff self-contained; C4 can promote to config when it lands.
+CONTRADICTION_COHESION_THRESHOLD = 0.75
+
+# Filesystem prefix that distinguishes auto-memory wiki entries from
+# entity-schema entries (``<uid>-<kebab>.md``). Callers reading the
+# wiki directory can branch on this prefix without parsing frontmatter.
+AUTO_WIKI_PREFIX = "auto-"
+
+# Stopword-ish tokens dropped when deriving a topic slug from member
+# filenames — these carry no semantic weight and would otherwise win
+# the frequency contest on naturally-clustered files (``feedback_`` is
+# the dominant prefix across memories, for example).
+_SLUG_BORING_TOKENS: frozenset[str] = frozenset({
+    "feedback", "project", "reference", "user", "recall", "auto",
+    "memory", "note", "the", "and", "for", "with", "file", "files",
+    "md",
+})
+
+
+@dataclass
+class MergedWikiEntry:
+    """In-memory shape of one consolidated wiki entry."""
+
+    topic_slug: str
+    cluster_id: str
+    cluster_centroid_score: float
+    contradictions_detected: bool
+    origin_scopes: list[str] = field(default_factory=list)
+    sources: list[dict[str, Any]] = field(default_factory=list)
+    body: str = ""
+    member_paths: list[str] = field(default_factory=list)
+
+    @property
+    def filename(self) -> str:
+        return f"{AUTO_WIKI_PREFIX}{self.topic_slug}.md"
+
+
+# ---------------------------------------------------------------------------
+# Cluster JSONL reader
+# ---------------------------------------------------------------------------
+
+
+def read_cluster_rows(jsonl_path: Path) -> list[dict[str, Any]]:
+    """Read the canonical cluster JSONL; return rows in file order.
+
+    The canonical file is always the latest run (C2 atomically replaces
+    it). Timestamped siblings (``<stem>-<iso>.jsonl``) are NOT read —
+    historical runs are for auditing, not for merging.
+    """
+    if not jsonl_path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    with jsonl_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                log.warning(
+                    "skipping malformed cluster row in %s: %s",
+                    jsonl_path, exc,
+                )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Member-path resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_member_path(
+    member_ref: str, extra_roots: list[Path],
+) -> Path | None:
+    """Resolve a cluster row's ``member_paths`` entry to an absolute file.
+
+    C2 writes each member_path as a POSIX path relative to the FIRST
+    configured extra intake root (i.e. ``<scope>/<filename>.md`` under
+    ``raw/auto-memory/``). If a member_path is already absolute (stale
+    fallback from a reloaded-config path), it is returned as-is. Otherwise
+    we try each configured extra root in order and return the first hit.
+    """
+    candidate = Path(member_ref)
+    if candidate.is_absolute():
+        return candidate if candidate.is_file() else None
+    for root in extra_roots:
+        attempt = (root / candidate).resolve()
+        if attempt.is_file():
+            return attempt
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Topic-slug derivation
+# ---------------------------------------------------------------------------
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _slug_tokens_from_filename(filename: str) -> list[str]:
+    stem = filename.lower()
+    if stem.endswith(".md"):
+        stem = stem[:-3]
+    # Split on non-alnum so ``project_voltair_nanoclaw`` → voltair, nanoclaw.
+    return [t for t in _TOKEN_RE.findall(stem) if t not in _SLUG_BORING_TOKENS]
+
+
+def derive_topic_slug(
+    member_paths: list[str], cluster_id: str,
+) -> str:
+    """Derive a filesystem-safe topic slug from cluster member filenames.
+
+    Strategy (intentionally simple — see PR body for rationale):
+
+    1. Tokenize each member's filename (drop ``.md``, split on non-alnum,
+       drop boring prefixes like ``feedback_``/``project_`` and words
+       shorter than 3 chars).
+    2. Rank tokens by member-frequency (in how many files the token
+       appears), break ties by total-frequency, then alphabetical.
+    3. Take up to 3 top-ranked tokens, join with ``-``.
+    4. If no usable tokens (every member is pure boring-prefix), fall
+       back to ``cluster_id`` sanitized to slug form.
+
+    Rationale vs. LLM-picked slug: the cheap heuristic gets the
+    regression fixture right (``voltaire-nanoclaw`` from five
+    voltaire/nanoclaw files) while staying deterministic and
+    testable without network. LLM polish can ride on top in C4+.
+    """
+    member_freq: dict[str, int] = {}
+    total_freq: dict[str, int] = {}
+    for mp in member_paths:
+        filename = Path(mp).name
+        seen_in_file: set[str] = set()
+        for tok in _slug_tokens_from_filename(filename):
+            if len(tok) < 3:
+                continue
+            total_freq[tok] = total_freq.get(tok, 0) + 1
+            if tok not in seen_in_file:
+                member_freq[tok] = member_freq.get(tok, 0) + 1
+                seen_in_file.add(tok)
+
+    if member_freq:
+        ranked = sorted(
+            member_freq.items(),
+            key=lambda kv: (-kv[1], -total_freq.get(kv[0], 0), kv[0]),
+        )
+        top = [tok for tok, _ in ranked[:3]]
+        slug = "-".join(top)
+        if slug:
+            return slug
+
+    # Fallback: sanitize cluster_id to slug form. cluster_id format is
+    # ``<scope_hint>-<seq>`` from clusters.py — already slug-ish.
+    fallback = re.sub(r"[^a-z0-9]+", "-", cluster_id.lower()).strip("-")
+    return fallback or "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Source parsing + dedupe
+# ---------------------------------------------------------------------------
+
+
+def _parse_one_source(raw: Any, fallback_scope: str) -> dict[str, Any] | None:
+    """Normalize one ``sources[]`` entry into a plain dict + origin_scope.
+
+    Accepts dict (the shape defined in
+    ``policies/auto-memory-citation.md``) or raw string (legacy bare
+    session UUID). Returns ``None`` for unparseable input.
+    """
+    if isinstance(raw, dict):
+        entry: dict[str, Any] = {}
+        session = raw.get("session")
+        if session is None:
+            return None
+        entry["session"] = str(session)
+        turn = raw.get("turn")
+        if turn is not None:
+            try:
+                entry["turn"] = int(turn)
+            except (TypeError, ValueError):
+                entry["turn"] = turn
+        date = raw.get("date")
+        if date is not None:
+            entry["date"] = str(date)
+        excerpt = raw.get("excerpt")
+        if excerpt is not None:
+            entry["excerpt"] = str(excerpt)
+        entry["origin_scope"] = str(raw.get("origin_scope", fallback_scope))
+        return entry
+    if isinstance(raw, str):
+        return {"session": raw, "origin_scope": fallback_scope}
+    return None
+
+
+def _am_as_implicit_source(am: AutoMemoryFile) -> dict[str, Any] | None:
+    """Fallback source entry when an auto-memory file has no sources[].
+
+    If the file carries ``originSessionId`` + ``originTurn`` we emit a
+    synthetic source citing the original write. This preserves the
+    AC that every consolidated entry can cite every member — even
+    members written before the citation policy landed (Phase A).
+    """
+    if am.origin_session_id is None:
+        return None
+    entry: dict[str, Any] = {
+        "session": am.origin_session_id,
+        "origin_scope": am.origin_scope,
+    }
+    if am.origin_turn is not None:
+        entry["turn"] = int(am.origin_turn)
+    return entry
+
+
+def dedupe_sources(entries: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Dedupe on ``(session, turn)``. First occurrence wins.
+
+    ``(session, turn)`` is the Phase-A granularity lock — two turns
+    within the same session are distinct memories. Two citations of
+    the same (session, turn) are merged (first wins, stable order).
+    Entries missing a turn fall back to ``(session, None)`` and only
+    collapse among themselves.
+    """
+    seen: set[tuple[str, Any]] = set()
+    out: list[dict[str, Any]] = []
+    for entry in entries:
+        key = (
+            str(entry.get("session", "")),
+            entry.get("turn"),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(entry)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Body synthesis (deterministic concatenate-with-dedupe)
+# ---------------------------------------------------------------------------
+
+
+def synthesize_body(
+    member_bodies: list[tuple[str, str, str]],
+) -> str:
+    """Concatenate member bodies, dropping paragraphs seen verbatim before.
+
+    Args:
+        member_bodies: list of ``(scope, filename, body)`` triples, in
+            cluster input order. Scope + filename become the section
+            header so readers can trace a paragraph back to its origin
+            raw file without hunting.
+
+    The dedupe is exact-match paragraph level (whitespace-trimmed). Two
+    files saying "X causes Y" with identical wording contribute that
+    paragraph once; variant phrasings are kept. This is the deliberately
+    simple strategy documented in the PR body — LLM paraphrase/merge is
+    a follow-up in C4+.
+    """
+    seen_paragraphs: set[str] = set()
+    sections: list[str] = []
+    for scope, filename, body in member_bodies:
+        kept_paragraphs: list[str] = []
+        for para in re.split(r"\n\s*\n", body):
+            canonical = " ".join(para.split())
+            if not canonical:
+                continue
+            if canonical in seen_paragraphs:
+                continue
+            seen_paragraphs.add(canonical)
+            kept_paragraphs.append(para.strip())
+        if not kept_paragraphs:
+            continue
+        header = f"## From `{scope}/{filename}`"
+        sections.append(header + "\n\n" + "\n\n".join(kept_paragraphs))
+    return "\n\n".join(sections) + ("\n" if sections else "")
+
+
+# ---------------------------------------------------------------------------
+# Top-level merge orchestration
+# ---------------------------------------------------------------------------
+
+
+def _collect_am_by_path(
+    auto_memory_files: Iterable[AutoMemoryFile],
+) -> dict[str, AutoMemoryFile]:
+    """Index :class:`AutoMemoryFile` records by resolved absolute-path string."""
+    by_path: dict[str, AutoMemoryFile] = {}
+    for am in auto_memory_files:
+        try:
+            by_path[str(am.path.resolve())] = am
+        except OSError:
+            by_path[str(am.path)] = am
+    return by_path
+
+
+def merge_cluster_row(
+    row: dict[str, Any],
+    *,
+    extra_roots: list[Path],
+    am_by_path: dict[str, AutoMemoryFile],
+) -> MergedWikiEntry | None:
+    """Build one :class:`MergedWikiEntry` from a cluster JSONL row.
+
+    Returns ``None`` when every member path fails to resolve to a live
+    file on disk — C2's rotated reports may reference files that have
+    been removed between runs, and we prefer to skip such rows with a
+    log line rather than crash the whole merge pass.
+    """
+    cluster_id = str(row.get("cluster_id", ""))
+    member_paths_raw: list[str] = [str(m) for m in row.get("member_paths", [])]
+    centroid_score_raw = row.get("centroid_score", 1.0)
+    try:
+        centroid_score = float(centroid_score_raw)
+    except (TypeError, ValueError):
+        centroid_score = 1.0
+
+    members: list[tuple[str, AutoMemoryFile]] = []
+    resolved_member_paths: list[str] = []
+    for mp in member_paths_raw:
+        resolved = resolve_member_path(mp, extra_roots)
+        if resolved is None:
+            log.warning(
+                "cluster %s: member %s did not resolve; skipping that member",
+                cluster_id, mp,
+            )
+            continue
+        key = str(resolved)
+        am = am_by_path.get(key)
+        if am is None:
+            # The clusters file referenced a real file that C1 didn't
+            # discover (e.g. intermediate edits mid-run). Build a minimal
+            # shim so we can still read its body + frontmatter — this
+            # keeps C3 resilient to discovery skew.
+            try:
+                text = resolved.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                log.warning(
+                    "cluster %s: %s unreadable; skipping that member",
+                    cluster_id, resolved,
+                )
+                continue
+            meta, _ = parse_frontmatter(text)
+            scope_guess = resolved.parent.name
+            origin_session_id = meta.get("originSessionId") if meta else None
+            origin_turn_raw = meta.get("originTurn") if meta else None
+            try:
+                origin_turn = (
+                    int(origin_turn_raw) if origin_turn_raw is not None else None
+                )
+            except (TypeError, ValueError):
+                origin_turn = None
+            sources_raw = meta.get("sources") if meta else None
+            if isinstance(sources_raw, list):
+                sources = [str(s) for s in sources_raw if isinstance(s, str)]
+            else:
+                sources = []
+            am = AutoMemoryFile(
+                path=resolved,
+                origin_scope=scope_guess,
+                memory_type="unknown",
+                name=str(meta.get("name", "")) if meta else "",
+                description=str(meta.get("description", "")) if meta else "",
+                origin_session_id=(
+                    str(origin_session_id)
+                    if origin_session_id is not None else None
+                ),
+                origin_turn=origin_turn,
+                sources=sources,
+            )
+        members.append((mp, am))
+        resolved_member_paths.append(mp)
+
+    if not members:
+        return None
+
+    topic_slug = derive_topic_slug(resolved_member_paths, cluster_id)
+    origin_scopes_set: list[str] = []
+    for _mp, am in members:
+        if am.origin_scope not in origin_scopes_set:
+            origin_scopes_set.append(am.origin_scope)
+
+    # Sources: parse each member's sources[] from frontmatter (source of
+    # truth), plus a synthetic entry from originSessionId/turn when a
+    # member has no sources[] at all.
+    raw_sources: list[dict[str, Any]] = []
+    for _mp, am in members:
+        try:
+            text = am.path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            text = ""
+        meta, _ = parse_frontmatter(text) if text else ({}, "")
+        sources_raw = meta.get("sources") if meta else None
+        if isinstance(sources_raw, list) and sources_raw:
+            for s in sources_raw:
+                parsed = _parse_one_source(s, am.origin_scope)
+                if parsed is not None:
+                    raw_sources.append(parsed)
+        else:
+            implicit = _am_as_implicit_source(am)
+            if implicit is not None:
+                raw_sources.append(implicit)
+
+    deduped = dedupe_sources(raw_sources)
+
+    # Body: concatenate member bodies (minus frontmatter) with a scope/
+    # filename header and paragraph-level dedupe.
+    member_bodies: list[tuple[str, str, str]] = []
+    for _mp, am in members:
+        try:
+            text = am.path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        _, body = parse_frontmatter(text)
+        member_bodies.append((am.origin_scope, am.path.name, body))
+
+    body = synthesize_body(member_bodies)
+
+    return MergedWikiEntry(
+        topic_slug=topic_slug,
+        cluster_id=cluster_id,
+        cluster_centroid_score=centroid_score,
+        contradictions_detected=centroid_score < CONTRADICTION_COHESION_THRESHOLD,
+        origin_scopes=origin_scopes_set,
+        sources=deduped,
+        body=body,
+        member_paths=resolved_member_paths,
+    )
+
+
+def render_merged_entry(entry: MergedWikiEntry) -> str:
+    """Render a :class:`MergedWikiEntry` as a full wiki markdown file."""
+    meta: dict[str, Any] = {
+        "name": entry.topic_slug,
+        "type": "auto-memory",
+        "cluster_id": entry.cluster_id,
+        "cluster_centroid_score": round(entry.cluster_centroid_score, 4),
+        "contradictions_detected": bool(entry.contradictions_detected),
+        "origin_scopes": list(entry.origin_scopes),
+        "sources": list(entry.sources),
+    }
+    return render_frontmatter(meta) + "\n" + entry.body
+
+
+def merge_clusters_to_wiki(
+    knowledge_root: Path,
+    *,
+    auto_memory_files: Iterable[AutoMemoryFile] | None = None,
+    config: dict[str, Any] | None = None,
+    dry_run: bool = False,
+) -> list[MergedWikiEntry]:
+    """Read the canonical cluster JSONL and emit one wiki entry per cluster.
+
+    Args:
+        knowledge_root: Root of the knowledge directory (where ``wiki/``,
+            ``raw/``, and ``athenaeum.yaml`` live).
+        auto_memory_files: Optional pre-discovered list of
+            :class:`AutoMemoryFile` records (pass the exact list C1's
+            discovery returned in the same run to avoid double-scanning).
+            When ``None``, this function lazily imports and calls
+            :func:`athenaeum.librarian.discover_auto_memory_files`.
+        config: Optional resolved config dict.
+        dry_run: If True, build the entries in memory but do NOT write
+            to ``wiki/``. Returns the entries for caller inspection.
+
+    Returns:
+        The list of :class:`MergedWikiEntry` records in cluster-file order.
+    """
+    resolved_config = config if config is not None else load_config(knowledge_root)
+    cluster_path = resolve_cluster_output_path(knowledge_root, config=resolved_config)
+    rows = read_cluster_rows(cluster_path)
+    if not rows:
+        log.info("merge pass: no clusters at %s — nothing to merge", cluster_path)
+        return []
+
+    extra_roots = resolve_extra_intake_roots(knowledge_root, config=resolved_config)
+
+    if auto_memory_files is None:
+        # Lazy import to avoid a circular dep on librarian when this
+        # module is imported standalone from a test.
+        from athenaeum.librarian import discover_auto_memory_files
+
+        auto_memory_files = discover_auto_memory_files(
+            knowledge_root, config=resolved_config,
+        )
+
+    am_by_path = _collect_am_by_path(auto_memory_files)
+
+    entries: list[MergedWikiEntry] = []
+    for row in rows:
+        entry = merge_cluster_row(
+            row, extra_roots=extra_roots, am_by_path=am_by_path,
+        )
+        if entry is None:
+            continue
+        entries.append(entry)
+
+    # Topic-slug collisions: if two clusters derive the same slug, suffix
+    # each after the first with a short cluster_id tail so filenames stay
+    # distinct. Rare but possible when two clusters share dominant tokens.
+    slug_counts: dict[str, int] = {}
+    for entry in entries:
+        base = entry.topic_slug
+        if base in slug_counts:
+            slug_counts[base] += 1
+            suffix = re.sub(r"[^a-z0-9]+", "-", entry.cluster_id.lower()).strip("-")
+            entry.topic_slug = f"{base}-{suffix}" if suffix else f"{base}-{slug_counts[base]}"
+        else:
+            slug_counts[base] = 1
+
+    if dry_run:
+        for entry in entries:
+            log.info(
+                "  [DRY RUN] merge %s → wiki/%s (%d source(s), contradictions=%s)",
+                entry.cluster_id, entry.filename,
+                len(entry.sources), entry.contradictions_detected,
+            )
+        return entries
+
+    wiki_root = knowledge_root / "wiki"
+    wiki_root.mkdir(parents=True, exist_ok=True)
+    for entry in entries:
+        page_path = wiki_root / entry.filename
+        page_path.write_text(render_merged_entry(entry), encoding="utf-8")
+        log.info(
+            "merge: wrote %s (cluster %s, %d source(s))",
+            page_path, entry.cluster_id, len(entry.sources),
+        )
+    return entries

--- a/tests/test_librarian_merge.py
+++ b/tests/test_librarian_merge.py
@@ -1,0 +1,552 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the auto-memory merge pass (C3, issue #197).
+
+Covers :mod:`athenaeum.merge`. All fixtures synthesize a full
+``raw/auto-memory/<scope>/`` tree plus a pre-written cluster JSONL
+under ``tmp_path`` — the real ``~/knowledge/`` is never touched.
+
+Load-bearing fixtures:
+
+- ``voltaire_merge_root`` — 5 voltaire/nanoclaw files with real citation
+  frontmatter under one cluster row. Regression guarantee: exactly one
+  ``wiki/auto-voltaire*.md`` with 5 sources carrying session/turn/scope.
+- ``contradiction_merge_root`` — two opposing-guidance files in one
+  low-cohesion cluster. Must emit a single wiki entry with
+  ``contradictions_detected: true`` in frontmatter.
+- ``session_turn_dedupe_root`` — one file whose ``sources[]`` contains
+  two different-turn-same-session entries plus a duplicate-turn entry.
+  Asserts ``(session, turn)`` key, not ``(session, date)``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from athenaeum.merge import (
+    AUTO_WIKI_PREFIX,
+    CONTRADICTION_COHESION_THRESHOLD,
+    dedupe_sources,
+    derive_topic_slug,
+    merge_clusters_to_wiki,
+    read_cluster_rows,
+    resolve_member_path,
+    synthesize_body,
+)
+from athenaeum.models import parse_frontmatter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_am_file(
+    scope_dir: Path,
+    filename: str,
+    *,
+    frontmatter_name: str,
+    description: str = "",
+    origin_session_id: str | None = None,
+    origin_turn: int | None = None,
+    sources: list[dict[str, object]] | None = None,
+    body: str = "",
+) -> Path:
+    """Write an auto-memory markdown file with full citation frontmatter."""
+    scope_dir.mkdir(parents=True, exist_ok=True)
+    path = scope_dir / filename
+    meta_lines = [
+        "---",
+        f"name: {frontmatter_name}",
+        f"description: {description}",
+        "type: feedback",
+    ]
+    if origin_session_id is not None:
+        meta_lines.append(f"originSessionId: {origin_session_id}")
+    if origin_turn is not None:
+        meta_lines.append(f"originTurn: {origin_turn}")
+    if sources:
+        meta_lines.append("sources:")
+        for s in sources:
+            meta_lines.append(f"  - session: {s['session']}")
+            if "turn" in s:
+                meta_lines.append(f"    turn: {s['turn']}")
+            if "date" in s:
+                meta_lines.append(f"    date: {s['date']}")
+            if "excerpt" in s:
+                meta_lines.append(f"    excerpt: \"{s['excerpt']}\"")
+    meta_lines.append("---")
+    text = "\n".join(meta_lines) + "\n" + body + "\n"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_config(knowledge_root: Path) -> None:
+    (knowledge_root / "athenaeum.yaml").write_text(
+        "recall:\n  extra_intake_roots:\n    - raw/auto-memory\n",
+        encoding="utf-8",
+    )
+
+
+def _write_cluster_jsonl(
+    knowledge_root: Path, rows: list[dict[str, object]],
+) -> Path:
+    out = knowledge_root / "raw" / "_librarian-clusters.jsonl"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        "\n".join(json.dumps(r, sort_keys=True) for r in rows) + "\n",
+        encoding="utf-8",
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def voltaire_merge_root(tmp_path: Path) -> Path:
+    """5 voltaire/nanoclaw files + matching cluster JSONL (one cluster, 5 members)."""
+    knowledge_root = tmp_path / "knowledge"
+    scope = knowledge_root / "raw" / "auto-memory" / "-Users-tristankromer-Code-voltaire"
+
+    specs = [
+        ("project_voltaire_nanoclaw.md", "s-aaa", 1, "Voltaire+nanoclaw"),
+        (
+            "project_voltaire_iMessage_channel.md",
+            "s-bbb", 2,
+            "Voltaire iMessage channel via NanoClaw",
+        ),
+        (
+            "project_nanoclaw_voltaire_tickle.md",
+            "s-ccc", 3,
+            "Nanoclaw ticklestick voltaire",
+        ),
+        (
+            "project_voltaire_sessions.md",
+            "s-ddd", 4,
+            "Voltaire sessions via box-claude",
+        ),
+        ("project_voltair_nanoclaw.md", "s-eee", 5, "Voltair typo clone"),
+    ]
+    for filename, session, turn, body in specs:
+        _write_am_file(
+            scope, filename,
+            frontmatter_name=filename.replace("_", " ").replace(".md", ""),
+            description="voltaire toolchain note",
+            origin_session_id=session,
+            origin_turn=turn,
+            sources=[{
+                "session": session,
+                "turn": turn,
+                "date": f"2026-04-{10 + turn:02d}",
+                "excerpt": body,
+            }],
+            body=body,
+        )
+
+    member_paths = [f"-Users-tristankromer-Code-voltaire/{s[0]}" for s in specs]
+    _write_cluster_jsonl(knowledge_root, [
+        {
+            "cluster_id": "voltaire-0001",
+            "member_paths": member_paths,
+            "centroid_score": 0.88,
+            "rationale": "cosine >= 0.55; shares tokens: voltaire, nanoclaw",
+        },
+    ])
+    _write_config(knowledge_root)
+    return knowledge_root
+
+
+@pytest.fixture
+def contradiction_merge_root(tmp_path: Path) -> Path:
+    """Two opposing-guidance feedback files in one low-cohesion cluster."""
+    knowledge_root = tmp_path / "knowledge"
+    scope = knowledge_root / "raw" / "auto-memory" / "-Users-tristankromer-Code"
+
+    _write_am_file(
+        scope, "feedback_prior_session_debris_v1.md",
+        frontmatter_name="Prior session debris v1",
+        description="commit directly",
+        origin_session_id="s-111", origin_turn=1,
+        sources=[{"session": "s-111", "turn": 1, "date": "2026-04-10",
+                  "excerpt": "commit to develop, do not park"}],
+        body="Commit prior-session debris directly to develop. Do not park on WIP.",
+    )
+    _write_am_file(
+        scope, "feedback_prior_session_debris_v2.md",
+        frontmatter_name="Prior session debris v2",
+        description="park on WIP",
+        origin_session_id="s-222", origin_turn=2,
+        sources=[{"session": "s-222", "turn": 2, "date": "2026-04-11",
+                  "excerpt": "park on WIP, do not commit"}],
+        body="Park prior-session debris on a WIP branch. Do not commit directly.",
+    )
+
+    _write_cluster_jsonl(knowledge_root, [
+        {
+            "cluster_id": "code-0001",
+            "member_paths": [
+                "-Users-tristankromer-Code/feedback_prior_session_debris_v1.md",
+                "-Users-tristankromer-Code/feedback_prior_session_debris_v2.md",
+            ],
+            # Below the 0.75 cohesion threshold → contradictions flag fires.
+            "centroid_score": 0.62,
+            "rationale": "cosine >= 0.55; shares tokens: prior, session, debris",
+        },
+    ])
+    _write_config(knowledge_root)
+    return knowledge_root
+
+
+@pytest.fixture
+def session_turn_dedupe_root(tmp_path: Path) -> Path:
+    """One file whose sources[] stresses the (session, turn) dedupe key."""
+    knowledge_root = tmp_path / "knowledge"
+    scope = knowledge_root / "raw" / "auto-memory" / "scope-x"
+
+    _write_am_file(
+        scope, "feedback_dedupe_probe.md",
+        frontmatter_name="Dedupe probe",
+        description="probe",
+        origin_session_id="s-shared", origin_turn=1,
+        sources=[
+            {"session": "s-shared", "turn": 1, "date": "2026-04-10",
+             "excerpt": "turn 1"},
+            # Same session, different turn — MUST NOT collapse.
+            {"session": "s-shared", "turn": 2, "date": "2026-04-10",
+             "excerpt": "turn 2"},
+            # Same session+turn, different date — MUST collapse into turn-1.
+            {"session": "s-shared", "turn": 1, "date": "2026-04-11",
+             "excerpt": "turn 1 duplicate"},
+        ],
+        body="Dedupe probe body.",
+    )
+
+    _write_cluster_jsonl(knowledge_root, [
+        {
+            "cluster_id": "scope-x-0001",
+            "member_paths": ["scope-x/feedback_dedupe_probe.md"],
+            "centroid_score": 1.0,
+            "rationale": "singleton",
+        },
+    ])
+    _write_config(knowledge_root)
+    return knowledge_root
+
+
+@pytest.fixture
+def singleton_merge_root(tmp_path: Path) -> Path:
+    """Two unrelated size-1 clusters — both MUST emit wiki entries."""
+    knowledge_root = tmp_path / "knowledge"
+    scope = knowledge_root / "raw" / "auto-memory" / "scope-x"
+
+    _write_am_file(
+        scope, "reference_dns_flakiness.md",
+        frontmatter_name="DNS flakiness",
+        description="macOS dns",
+        origin_session_id="s-dns", origin_turn=1,
+        sources=[{"session": "s-dns", "turn": 1, "date": "2026-04-10",
+                  "excerpt": "dns"}],
+        body="mDNSResponder flakes.",
+    )
+    _write_am_file(
+        scope, "user_tristan_profile.md",
+        frontmatter_name="Tristan profile",
+        description="profile",
+        origin_session_id="s-prof", origin_turn=1,
+        sources=[{"session": "s-prof", "turn": 1, "date": "2026-04-10",
+                  "excerpt": "profile"}],
+        body="Consultant.",
+    )
+
+    _write_cluster_jsonl(knowledge_root, [
+        {"cluster_id": "scope-x-0001",
+         "member_paths": ["scope-x/reference_dns_flakiness.md"],
+         "centroid_score": 1.0, "rationale": "singleton"},
+        {"cluster_id": "scope-x-0002",
+         "member_paths": ["scope-x/user_tristan_profile.md"],
+         "centroid_score": 1.0, "rationale": "singleton"},
+    ])
+    _write_config(knowledge_root)
+    return knowledge_root
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveTopicSlug:
+    def test_voltaire_members_produce_voltaire_slug(self) -> None:
+        paths = [
+            "-Users-tristankromer-Code-voltaire/project_voltaire_nanoclaw.md",
+            "-Users-tristankromer-Code-voltaire/project_voltaire_iMessage_channel.md",
+            "-Users-tristankromer-Code-voltaire/project_nanoclaw_voltaire_tickle.md",
+            "-Users-tristankromer-Code-voltaire/project_voltaire_sessions.md",
+            "-Users-tristankromer-Code-voltaire/project_voltair_nanoclaw.md",
+        ]
+        slug = derive_topic_slug(paths, "voltaire-0001")
+        # voltaire and nanoclaw must dominate; slug contains both tokens.
+        assert "voltaire" in slug
+        assert "nanoclaw" in slug
+
+    def test_singleton_falls_back_on_useful_tokens(self) -> None:
+        slug = derive_topic_slug(
+            ["scope-x/reference_dns_flakiness.md"], "scope-x-0001",
+        )
+        assert "dns" in slug or "flakiness" in slug
+
+    def test_falls_back_to_cluster_id_when_no_tokens(self) -> None:
+        # All tokens are boring prefixes → fall back.
+        slug = derive_topic_slug(["scope/feedback_auto.md"], "scope-0007")
+        assert slug == "scope-0007"
+
+
+class TestDedupeSources:
+    def test_session_turn_is_the_key(self) -> None:
+        """Two turns in the same session stay distinct; same turn dedupes."""
+        entries = [
+            {"session": "s", "turn": 1, "date": "2026-04-10"},
+            {"session": "s", "turn": 2, "date": "2026-04-10"},
+            {"session": "s", "turn": 1, "date": "2026-04-11"},  # dup of #1
+        ]
+        out = dedupe_sources(entries)
+        assert len(out) == 2
+        turns = {e["turn"] for e in out}
+        assert turns == {1, 2}
+
+    def test_session_alone_is_not_the_key(self) -> None:
+        """Bare-session entries (no turn) collapse among themselves only."""
+        entries = [
+            {"session": "s"},
+            {"session": "s"},
+            {"session": "t", "turn": 1},
+        ]
+        out = dedupe_sources(entries)
+        assert len(out) == 2
+
+
+class TestResolveMemberPath:
+    def test_resolves_relative_to_first_root(self, tmp_path: Path) -> None:
+        root = tmp_path / "raw" / "auto-memory"
+        scope = root / "scope-x"
+        scope.mkdir(parents=True)
+        f = scope / "feedback_probe.md"
+        f.write_text("body\n", encoding="utf-8")
+        got = resolve_member_path("scope-x/feedback_probe.md", [root])
+        assert got == f.resolve()
+
+    def test_returns_none_when_missing(self, tmp_path: Path) -> None:
+        root = tmp_path / "raw" / "auto-memory"
+        root.mkdir(parents=True)
+        assert resolve_member_path("scope-x/missing.md", [root]) is None
+
+
+class TestReadClusterRows:
+    def test_reads_canonical_only(self, tmp_path: Path) -> None:
+        path = tmp_path / "clusters.jsonl"
+        path.write_text(
+            '{"cluster_id":"a","member_paths":["p"]}\n'
+            '{"cluster_id":"b","member_paths":["q"]}\n',
+            encoding="utf-8",
+        )
+        rows = read_cluster_rows(path)
+        assert [r["cluster_id"] for r in rows] == ["a", "b"]
+
+    def test_skips_malformed_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / "clusters.jsonl"
+        path.write_text(
+            '{"cluster_id":"a","member_paths":["p"]}\n'
+            'NOT JSON\n'
+            '{"cluster_id":"c","member_paths":["r"]}\n',
+            encoding="utf-8",
+        )
+        rows = read_cluster_rows(path)
+        assert [r["cluster_id"] for r in rows] == ["a", "c"]
+
+
+class TestSynthesizeBody:
+    def test_dedupes_identical_paragraphs(self) -> None:
+        body = synthesize_body([
+            ("scope-a", "file1.md", "Shared paragraph.\n\nUnique A."),
+            ("scope-b", "file2.md", "Shared paragraph.\n\nUnique B."),
+        ])
+        # Shared paragraph appears once (under file1's header); unique
+        # paragraphs survive.
+        assert body.count("Shared paragraph.") == 1
+        assert "Unique A." in body
+        assert "Unique B." in body
+
+    def test_prefixes_each_section_with_scope_and_filename(self) -> None:
+        body = synthesize_body([("scope-a", "file1.md", "only para")])
+        assert "scope-a/file1.md" in body
+
+
+# ---------------------------------------------------------------------------
+# Full merge integration
+# ---------------------------------------------------------------------------
+
+
+class TestVoltaireFixture:
+    """The load-bearing regression fixture from the issue."""
+
+    def test_exactly_one_voltaire_entry_with_five_sources(
+        self, voltaire_merge_root: Path,
+    ) -> None:
+        entries = merge_clusters_to_wiki(voltaire_merge_root)
+        assert len(entries) == 1
+        entry = entries[0]
+
+        # Exactly one file on disk, prefixed with auto-.
+        wiki = voltaire_merge_root / "wiki"
+        outputs = sorted(wiki.glob(f"{AUTO_WIKI_PREFIX}*.md"))
+        assert len(outputs) == 1
+        assert outputs[0].name == entry.filename
+
+        # Slug mentions voltaire + nanoclaw (the load-bearing tokens).
+        assert "voltaire" in entry.topic_slug
+        assert "nanoclaw" in entry.topic_slug
+
+        # 5 sources, each carrying session/turn/origin_scope.
+        assert len(entry.sources) == 5
+        sessions = {s["session"] for s in entry.sources}
+        assert sessions == {"s-aaa", "s-bbb", "s-ccc", "s-ddd", "s-eee"}
+        turns = {s["turn"] for s in entry.sources}
+        assert turns == {1, 2, 3, 4, 5}
+        for s in entry.sources:
+            assert s["origin_scope"] == "-Users-tristankromer-Code-voltaire"
+
+    def test_body_retains_loadbearing_tokens(
+        self, voltaire_merge_root: Path,
+    ) -> None:
+        merge_clusters_to_wiki(voltaire_merge_root)
+        wiki = voltaire_merge_root / "wiki"
+        entry_file = next(wiki.glob(f"{AUTO_WIKI_PREFIX}*.md"))
+        text = entry_file.read_text(encoding="utf-8")
+        _, body = parse_frontmatter(text)
+        assert "Voltaire" in body or "voltaire" in body.lower()
+        assert "nanoclaw" in body.lower()
+        # At least one hostname/path-y token from the 5 inputs.
+        assert "NanoClaw" in body or "iMessage" in body or "box-claude" in body
+
+    def test_frontmatter_shape(self, voltaire_merge_root: Path) -> None:
+        merge_clusters_to_wiki(voltaire_merge_root)
+        wiki = voltaire_merge_root / "wiki"
+        entry_file = next(wiki.glob(f"{AUTO_WIKI_PREFIX}*.md"))
+        text = entry_file.read_text(encoding="utf-8")
+        meta, _ = parse_frontmatter(text)
+        assert meta["type"] == "auto-memory"
+        assert meta["cluster_id"] == "voltaire-0001"
+        assert meta["contradictions_detected"] is False  # 0.88 > 0.75
+        assert meta["origin_scopes"] == ["-Users-tristankromer-Code-voltaire"]
+        assert isinstance(meta["sources"], list)
+        assert len(meta["sources"]) == 5
+
+
+class TestContradictionFixture:
+    def test_contradictions_detected_flag_fires(
+        self, contradiction_merge_root: Path,
+    ) -> None:
+        entries = merge_clusters_to_wiki(contradiction_merge_root)
+        assert len(entries) == 1
+        assert entries[0].contradictions_detected is True
+        wiki = contradiction_merge_root / "wiki"
+        entry_file = next(wiki.glob(f"{AUTO_WIKI_PREFIX}*.md"))
+        meta, _ = parse_frontmatter(entry_file.read_text(encoding="utf-8"))
+        assert meta["contradictions_detected"] is True
+        # Both sources present.
+        assert len(meta["sources"]) == 2
+
+    def test_threshold_is_the_documented_value(self) -> None:
+        # Lock in the heuristic threshold so a later silent drift is caught.
+        assert CONTRADICTION_COHESION_THRESHOLD == 0.75
+
+
+class TestSessionTurnDedupe:
+    def test_same_session_different_turns_not_collapsed(
+        self, session_turn_dedupe_root: Path,
+    ) -> None:
+        entries = merge_clusters_to_wiki(session_turn_dedupe_root)
+        assert len(entries) == 1
+        # Input had 3 source rows; turn-1 dup collapses → 2 remain.
+        assert len(entries[0].sources) == 2
+        turns = {s["turn"] for s in entries[0].sources}
+        assert turns == {1, 2}
+        # Both entries retain the shared session id.
+        assert {s["session"] for s in entries[0].sources} == {"s-shared"}
+
+
+class TestSingletonsEmitted:
+    def test_every_singleton_becomes_a_wiki_entry(
+        self, singleton_merge_root: Path,
+    ) -> None:
+        entries = merge_clusters_to_wiki(singleton_merge_root)
+        # Both singletons become wiki entries — no min-size filter.
+        assert len(entries) == 2
+        wiki = singleton_merge_root / "wiki"
+        outputs = sorted(wiki.glob(f"{AUTO_WIKI_PREFIX}*.md"))
+        assert len(outputs) == 2
+
+    def test_no_memory_md_is_emitted(
+        self, singleton_merge_root: Path,
+    ) -> None:
+        merge_clusters_to_wiki(singleton_merge_root)
+        wiki = singleton_merge_root / "wiki"
+        # Phase B removed the cross-scope wiki/MEMORY.md — we must not
+        # recreate it.
+        assert not (wiki / "MEMORY.md").exists()
+
+
+class TestDryRun:
+    def test_dry_run_builds_entries_without_writing(
+        self, voltaire_merge_root: Path,
+    ) -> None:
+        entries = merge_clusters_to_wiki(voltaire_merge_root, dry_run=True)
+        assert len(entries) == 1
+        wiki = voltaire_merge_root / "wiki"
+        # Directory may exist but must be empty of auto-* files.
+        outputs = list(wiki.glob(f"{AUTO_WIKI_PREFIX}*.md")) if wiki.exists() else []
+        assert outputs == []
+
+
+class TestRawFilesUntouched:
+    def test_raw_files_remain_after_merge(
+        self, voltaire_merge_root: Path,
+    ) -> None:
+        raw_root = (
+            voltaire_merge_root / "raw" / "auto-memory"
+            / "-Users-tristankromer-Code-voltaire"
+        )
+        before = sorted(p.name for p in raw_root.glob("*.md"))
+        merge_clusters_to_wiki(voltaire_merge_root)
+        after = sorted(p.name for p in raw_root.glob("*.md"))
+        assert before == after
+        assert len(before) == 5
+
+
+class TestMergeOnlyCLI:
+    def test_merge_only_run_skips_clustering(
+        self,
+        voltaire_merge_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``run(merge_only=True)`` reads the JSONL and writes wiki entries."""
+        from athenaeum.librarian import run
+
+        # Pre-existing cluster JSONL + no ANTHROPIC_API_KEY required.
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        rc = run(
+            raw_root=voltaire_merge_root / "raw",
+            wiki_root=voltaire_merge_root / "wiki",
+            knowledge_root=voltaire_merge_root,
+            merge_only=True,
+        )
+        assert rc == 0
+        wiki = voltaire_merge_root / "wiki"
+        outputs = sorted(wiki.glob(f"{AUTO_WIKI_PREFIX}*.md"))
+        assert len(outputs) == 1
+
+


### PR DESCRIPTION
## Summary

C3 of the auto-memory compile chain. Reads the canonical cluster JSONL produced by C2 (`raw/_librarian-clusters.jsonl`) and emits one consolidated wiki entry per cluster at `wiki/auto-<topic-slug>.md`, with every member's `sources[]` unioned into a single deduped cited list and every member's body concatenated with paragraph-level dedupe and scope/filename section headers.

Closes #197

## Design decisions (flagged for C4 follow-up)

- **Dedupe key is `(session, turn)`, never `(session, date)`.** Two turns in the same session stay distinct memories; duplicate citations of the same turn collapse. Covered by `TestSessionTurnDedupe::test_same_session_different_turns_not_collapsed`.
- **Topic-slug strategy:** member-frequency ranking over filename tokens after dropping boring prefixes (`feedback_`, `project_`, `reference_`, `user_`, `recall_`, `auto`, `memory`). Top 3 tokens joined with `-`. Collision suffix appends a sanitized `cluster_id` tail. Chose the cheap deterministic path over an LLM slug-pick so the regression fixture is testable without network — LLM polish is a C4+ follow-up. Voltaire fixture ends up as `voltaire-nanoclaw-<third-token>`; both load-bearing tokens always win.
- **Body synthesis is deterministic concatenate-with-paragraph-dedupe.** Each member contributes a `## From <scope>/<filename>` section; paragraphs seen verbatim in a prior section are dropped. LLM paraphrase/merge is a C4+ follow-up.
- **Contradiction heuristic:** `contradictions_detected: true` fires in the wiki frontmatter when `centroid_score < 0.75`. Real contradiction detection lands in C4 (#198). The threshold is module-local (not config) to keep the PR diff self-contained; C4 can promote it to config if the heuristic stays.
- **Size-1 clusters ARE emitted as wiki entries.** No minimum-cluster-size filter — the wiki read path wants a uniform surface, and single-source facts still carry value.
- **Raw intake files remain UNTOUCHED.** `raw/auto-memory/<scope>/*.md` is append-only; `wiki/auto-*.md` is the compiled view.
- **No cross-scope `wiki/MEMORY.md` is emitted.** Phase B explicitly removed it and this module does NOT recreate it.
- **Resilient to discovery skew.** If a cluster row references a file that C1 discovery didn't see (e.g. intermediate edits), the merge pass reads frontmatter directly and still cites it rather than crashing the run.

## New CLI

`--merge-only` mirrors `--cluster-only` so operators can iterate on merge output without re-embedding or re-clustering:

```
athenaeum run --merge-only --knowledge-root ~/knowledge
```

Full `run()` pipeline now runs C2 clustering and C3 merge back-to-back on a single invocation.

## Test plan

- [x] 22 new tests in `tests/test_librarian_merge.py` cover: topic-slug derivation (voltaire/singleton/all-boring fallback); `(session, turn)` dedupe including the shared-session / distinct-turn assertion; member-path resolution (relative + absolute + missing); JSONL read (canonical only, malformed-line skip); body synthesis dedupe + section headers; voltaire regression (1 entry, 5 sources with session/turn/origin_scope, slug contains `voltaire`+`nanoclaw`, body retains `Voltaire`/`nanoclaw`/at least one hostname-y token); contradiction cohesion flag fires at 0.62; singletons emit wiki entries; dry-run does not write; raw files remain after merge; `run(merge_only=True)` skips clustering and writes wiki entries from pre-existing JSONL.
- [x] Full existing suite (`pytest --ignore=tests/benchmarks`): 348 passed, no regressions.
- [x] `ruff check` clean on all touched files.

## Files changed

- `src/athenaeum/merge.py` — new module (core merge logic, topic-slug derivation, source dedupe, body synthesis, wiki rendering)
- `src/athenaeum/librarian.py` — import `merge_clusters_to_wiki`, add `merge_only` param to `run()`, wire C3 stage in after C2
- `src/athenaeum/cli.py` — new `--merge-only` flag, threaded into `_cmd_run`
- `tests/test_librarian_merge.py` — new, 22 tests across 9 classes
- `CHANGELOG.md` — Unreleased entry

## Out of scope (explicit for C4, #198 and later)

- LLM-based body synthesis and slug picking
- Real contradiction detection beyond the centroid-score heuristic
- Changes to `clusters.py`, discovery, or `search.py`
- Any benchmark or hybrid-rescue test changes

## Open questions for C4

- Promote `CONTRADICTION_COHESION_THRESHOLD` to `librarian.*` config when C4 keeps the heuristic as a first-pass gate
- Consider an LLM slug-rewrite pass for topic-slug polish on clusters where token frequency produces visibly awkward slugs
- Decide whether to surface `contradictions_detected: true` entries via a dedicated `_pending_review.md` queue (parallel to `_pending_questions.md`) so humans can audit them without grepping frontmatter
