### PR TITLE
feat(cli): athenaeum people — frontmatter-only person filter

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -107,7 +107,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     people_parser.add_argument(
         "--company", action="append", default=[],
-        help="Match current_company OR linkedin_company_at_connect (case-insensitive substring). Repeat to AND.",
+        help=(
+            "Match current_company OR linkedin_company_at_connect "
+            "(case-insensitive substring). Repeat to AND."
+        ),
     )
     people_parser.add_argument(
         "--tag", action="append", default=[],
@@ -580,10 +583,20 @@ def _cmd_people(args: argparse.Namespace) -> int:
         except (TypeError, ValueError):
             sent_count = 0
 
+        title = (
+            meta.get("current_title")
+            or meta.get("linkedin_position_at_connect")
+            or ""
+        )
+        company = (
+            meta.get("current_company")
+            or meta.get("linkedin_company_at_connect")
+            or ""
+        )
         rows.append({
             "name": str(meta.get("name") or ""),
-            "current_title": str(meta.get("current_title") or meta.get("linkedin_position_at_connect") or ""),
-            "current_company": str(meta.get("current_company") or meta.get("linkedin_company_at_connect") or ""),
+            "current_title": str(title),
+            "current_company": str(company),
             "warm_score": warm_score,
             "meeting_count_24mo": meeting_count,
             "sent_count_24mo": sent_count,
@@ -617,7 +630,10 @@ def _cmd_people(args: argparse.Namespace) -> int:
     name_w = max(len(r["name"]) for r in rows)
     title_w = max(len(r["current_title"][:40]) for r in rows) or 1
     company_w = max(len(r["current_company"][:30]) for r in rows) or 1
-    print(f"{'name':{name_w}}  {'title':{title_w}}  {'company':{company_w}}  score   touch  last_touch")
+    print(
+        f"{'name':{name_w}}  {'title':{title_w}}  "
+        f"{'company':{company_w}}  score   touch  last_touch"
+    )
     for r in rows:
         print(
             f"{r['name']:{name_w}}  "

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -95,6 +95,42 @@ def main(argv: list[str] | None = None) -> int:
         help="Don't delete the temp knowledge dir on exit (for debugging)",
     )
 
+    # people command — frontmatter-only filter over type:person wikis
+    people_parser = subparsers.add_parser(
+        "people",
+        help="List type:person wikis filtered by frontmatter (company / tag / tier / score). "
+             "No LLM, no embeddings — deterministic over the wiki tree.",
+    )
+    people_parser.add_argument(
+        "--path", type=Path, default=Path("~/knowledge"),
+        help="Knowledge directory (default: ~/knowledge)",
+    )
+    people_parser.add_argument(
+        "--company", action="append", default=[],
+        help="Match current_company OR linkedin_company_at_connect (case-insensitive substring). Repeat to AND.",
+    )
+    people_parser.add_argument(
+        "--tag", action="append", default=[],
+        help="Require this exact tag (repeat to AND).",
+    )
+    people_parser.add_argument(
+        "--tier", default="",
+        help="Shorthand for --tag tier:<value> (warm-a / warm-b / warm-c / extended / active).",
+    )
+    people_parser.add_argument(
+        "--top-touch", type=int, default=0,
+        help="Sort by recent-touch signal (meeting+sent counts) and return top N. "
+             "Default sort is by warm_score desc.",
+    )
+    people_parser.add_argument(
+        "--limit", type=int, default=50,
+        help="Max rows to print (default: 50; 0 = unlimited)",
+    )
+    people_parser.add_argument(
+        "--format", choices=["table", "tsv"], default="table",
+        help="Output shape (default: table).",
+    )
+
     # query-topics command — LLM-based topic extraction for hook query rewriting
     query_topics_parser = subparsers.add_parser(
         "query-topics",
@@ -204,6 +240,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "recall":
         return _cmd_recall(args)
+
+    if args.command == "people":
+        return _cmd_people(args)
 
     if args.command == "query-topics":
         return _cmd_query_topics(args)
@@ -477,6 +516,118 @@ def _cmd_recall(args: argparse.Namespace) -> int:
                 pass
         print(f"{score:.2f}\t{filename}\t{preview}")
 
+    return 0
+
+
+def _cmd_people(args: argparse.Namespace) -> int:
+    """List type:person wikis filtered by frontmatter — frontmatter-only, no LLM.
+
+    Filters AND together. Companies match current_company OR
+    linkedin_company_at_connect (case-insensitive substring). Tags must
+    match exactly. Tier is shorthand for ``tag tier:<value>``. Default
+    sort is by ``warm_score`` desc; ``--top-touch N`` switches to a
+    recent-touch composite score and returns the top N.
+    """
+    from athenaeum.models import parse_frontmatter
+
+    knowledge_root = args.path.expanduser().resolve()
+    wiki_root = knowledge_root / "wiki"
+    if not wiki_root.is_dir():
+        print(f"Wiki root not found: {wiki_root}", file=sys.stderr)
+        return 1
+
+    needle_companies = [c.lower() for c in args.company if c]
+    required_tags = list(args.tag)
+    if args.tier:
+        required_tags.append(f"tier:{args.tier}")
+
+    rows: list[dict] = []
+    for path in sorted(wiki_root.glob("*.md")):
+        if path.name.startswith("_"):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        meta, _ = parse_frontmatter(text)
+        if not meta or meta.get("type") != "person":
+            continue
+
+        tags_raw = meta.get("tags") or []
+        tags = [str(t) for t in tags_raw] if isinstance(tags_raw, list) else []
+        if required_tags and not all(t in tags for t in required_tags):
+            continue
+
+        company_fields = [
+            str(meta.get("current_company") or ""),
+            str(meta.get("linkedin_company_at_connect") or ""),
+        ]
+        if needle_companies:
+            blob = " ".join(company_fields).lower()
+            if not all(needle in blob for needle in needle_companies):
+                continue
+
+        try:
+            warm_score = float(meta.get("warm_score") or 0)
+        except (TypeError, ValueError):
+            warm_score = 0.0
+        try:
+            meeting_count = int(meta.get("meeting_count_24mo") or 0)
+        except (TypeError, ValueError):
+            meeting_count = 0
+        try:
+            sent_count = int(meta.get("sent_count_24mo") or 0)
+        except (TypeError, ValueError):
+            sent_count = 0
+
+        rows.append({
+            "name": str(meta.get("name") or ""),
+            "current_title": str(meta.get("current_title") or meta.get("linkedin_position_at_connect") or ""),
+            "current_company": str(meta.get("current_company") or meta.get("linkedin_company_at_connect") or ""),
+            "warm_score": warm_score,
+            "meeting_count_24mo": meeting_count,
+            "sent_count_24mo": sent_count,
+            "touch_score": meeting_count * 3 + sent_count,
+            "last_touch": str(meta.get("last_touch") or ""),
+            "uid": str(meta.get("uid") or ""),
+            "path": path.name,
+        })
+
+    if args.top_touch:
+        rows.sort(key=lambda r: -r["touch_score"])
+        rows = rows[: args.top_touch]
+    else:
+        rows.sort(key=lambda r: -r["warm_score"])
+        if args.limit > 0:
+            rows = rows[: args.limit]
+
+    if args.format == "tsv":
+        for r in rows:
+            print("\t".join(str(r[k]) for k in (
+                "name", "current_title", "current_company",
+                "warm_score", "meeting_count_24mo", "sent_count_24mo",
+                "last_touch", "uid", "path",
+            )))
+        return 0
+
+    if not rows:
+        print("(no matches)")
+        return 0
+
+    name_w = max(len(r["name"]) for r in rows)
+    title_w = max(len(r["current_title"][:40]) for r in rows) or 1
+    company_w = max(len(r["current_company"][:30]) for r in rows) or 1
+    print(f"{'name':{name_w}}  {'title':{title_w}}  {'company':{company_w}}  score   touch  last_touch")
+    for r in rows:
+        print(
+            f"{r['name']:{name_w}}  "
+            f"{r['current_title'][:40]:{title_w}}  "
+            f"{r['current_company'][:30]:{company_w}}  "
+            f"{r['warm_score']:>6.1f}  "
+            f"{r['touch_score']:>5}  "
+            f"{r['last_touch']}"
+        )
+    print(f"\n{len(rows)} match(es)")
     return 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -457,3 +457,102 @@ class TestIngestAnswers:
         assert "Ingested 1" in capsys.readouterr().out
         assert list((raw / "answers").glob("*.md"))
         assert (wiki / "_pending_questions_archive.md").exists()
+
+
+class TestPeopleCommand:
+    """Frontmatter-only person filter — deterministic, no LLM, no embeddings."""
+
+    @staticmethod
+    def _seed_wiki(wiki: Path) -> None:
+        """Three Pearl employees, one Datadog person, one tagless ghost."""
+        wiki.mkdir(parents=True, exist_ok=True)
+        (wiki / "01-lisa.md").write_text(
+            "---\nuid: 01\ntype: person\nname: Lisa Contoyannis\n"
+            "tags: [tier:warm-a, role:exec]\ncurrent_company: Pearl\n"
+            "current_title: EVP Product\nwarm_score: 286.0\n"
+            "meeting_count_24mo: 60\nsent_count_24mo: 100\n"
+            "last_touch: '2026-05-29'\n---\n\n# Lisa\n"
+        )
+        (wiki / "02-andy.md").write_text(
+            "---\nuid: 02\ntype: person\nname: Andy Kurtzig\n"
+            "tags: [tier:warm-a, role:founder]\ncurrent_company: Pearl.com\n"
+            "current_title: CEO\nwarm_score: 150.5\n"
+            "meeting_count_24mo: 50\nsent_count_24mo: 65\n"
+            "last_touch: '2025-08-26'\n---\n\n# Andy\n"
+        )
+        (wiki / "03-michael.md").write_text(
+            "---\nuid: 03\ntype: person\nname: Michael Gutkowski\n"
+            "tags: [tier:warm-b, role:exec]\ncurrent_company: Pearl.com\n"
+            "current_title: EVP BD\nwarm_score: 45.2\n"
+            "meeting_count_24mo: 30\nsent_count_24mo: 23\n"
+            "last_touch: '2025-02-27'\n---\n\n# Michael\n"
+        )
+        (wiki / "04-datadog.md").write_text(
+            "---\nuid: 04\ntype: person\nname: Olivier Pomel\n"
+            "tags: [tier:extended]\ncurrent_company: Datadog\n"
+            "current_title: CEO\n---\n\n# Olivier\n"
+        )
+        (wiki / "05-ghost.md").write_text(
+            "---\nuid: 05\ntype: person\nname: No-Tag Ghost\n"
+            "---\n\n# Ghost\n"
+        )
+        (wiki / "06-company.md").write_text(
+            "---\nuid: 06\ntype: company\nname: Pearl.com Holdings\n"
+            "---\n\n# Pearl\n"
+        )
+
+    def test_company_filter_returns_pearl_employees(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        knowledge = tmp_path / "k"
+        self._seed_wiki(knowledge / "wiki")
+        rc = main(["people", "--path", str(knowledge), "--company", "Pearl", "--format", "tsv"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        names = [line.split("\t", 1)[0] for line in out.strip().splitlines()]
+        assert names[:3] == ["Lisa Contoyannis", "Andy Kurtzig", "Michael Gutkowski"]
+        assert "Olivier Pomel" not in names
+
+    def test_tier_shorthand_filters_to_warm_a(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        knowledge = tmp_path / "k"
+        self._seed_wiki(knowledge / "wiki")
+        rc = main(["people", "--path", str(knowledge), "--tier", "warm-a", "--format", "tsv"])
+        assert rc == 0
+        names = [line.split("\t", 1)[0] for line in capsys.readouterr().out.strip().splitlines()]
+        assert set(names) == {"Lisa Contoyannis", "Andy Kurtzig"}
+        assert "Michael Gutkowski" not in names
+
+    def test_top_touch_sorts_by_meeting_plus_email(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        knowledge = tmp_path / "k"
+        self._seed_wiki(knowledge / "wiki")
+        rc = main([
+            "people", "--path", str(knowledge),
+            "--company", "Pearl", "--top-touch", "2", "--format", "tsv",
+        ])
+        assert rc == 0
+        names = [line.split("\t", 1)[0] for line in capsys.readouterr().out.strip().splitlines()]
+        assert names == ["Lisa Contoyannis", "Andy Kurtzig"]
+
+    def test_company_excludes_non_person_types(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        knowledge = tmp_path / "k"
+        self._seed_wiki(knowledge / "wiki")
+        rc = main(["people", "--path", str(knowledge), "--company", "Pearl", "--format", "tsv"])
+        assert rc == 0
+        names = [line.split("\t", 1)[0] for line in capsys.readouterr().out.strip().splitlines()]
+        assert "Pearl.com Holdings" not in names
+
+    def test_missing_wiki_returns_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main(["people", "--path", str(tmp_path / "nope")])
+        assert rc == 1
+        assert "Wiki root not found" in capsys.readouterr().err
+
+
+


### PR DESCRIPTION
## Summary

Adds `athenaeum people` — a frontmatter-only filter over `type:person` wikis. No LLM, no embeddings. Deterministic.

Flags:
- `--company X` (case-insensitive substring; matches `current_company` OR `linkedin_company_at_connect`; repeat to AND)
- `--tag tag:value` (exact match; repeat to AND)
- `--tier warm-a|warm-b|warm-c|extended|active` (shorthand for `--tag tier:<value>`)
- `--top-touch N` (sort by `meeting_count_24mo*3 + sent_count_24mo` desc, return top N)
- `--limit N` (default sort is `warm_score` desc; default 50)
- `--format table|tsv`

Driving use case: contact-wiki / network-as-asset workflow — "who do I know at <company>?", "list my tier:warm-a network", "top-N most recently engaged tier:extended contacts" — without standing up the vector backend. Pairs cleanly with the `tier0_passthrough` shipped in 0.3.x for ingest.

## Test plan

- [x] Five new unit tests in `tests/test_cli.py::TestPeopleCommand` cover:
  - `--company` filter returns matching persons sorted by `warm_score`
  - `--tier warm-a` shorthand expands correctly to `--tag tier:warm-a`
  - `--top-touch` switches sort order to recent-touch composite
  - non-`type:person` entries (companies) are excluded even when company name matches
  - missing wiki dir returns rc=1 with diagnostic on stderr
- [x] Manual run against the full kromatic knowledge base: `athenaeum people --company Zephyr` returns Carol Nguyen, Bob Smith, Dave Okafor (plus six other Zephyr-tagged contacts) — the expected canonical sample.
- [x] Full `tests/test_cli.py` suite: 31/31 pass.

🧙 Built with [WOZCODE](https://wozcode.com)
