### PR TITLE
feat(people): add --title-regex and --company-regex filters

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -121,6 +121,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Shorthand for --tag tier:<value> (warm-a / warm-b / warm-c / extended / active).",
     )
     people_parser.add_argument(
+        "--title-regex", action="append", default=[],
+        help=(
+            "Match current_title OR linkedin_position_at_connect against this "
+            "regex (case-insensitive). Repeat to AND multiple patterns."
+        ),
+    )
+    people_parser.add_argument(
+        "--company-regex", action="append", default=[],
+        help=(
+            "Match current_company OR linkedin_company_at_connect against this "
+            "regex (case-insensitive). Repeat to AND multiple patterns."
+        ),
+    )
+    people_parser.add_argument(
         "--top-touch", type=int, default=0,
         help="Sort by recent-touch signal (meeting+sent counts) and return top N. "
              "Default sort is by warm_score desc.",
@@ -531,6 +545,7 @@ def _cmd_people(args: argparse.Namespace) -> int:
     sort is by ``warm_score`` desc; ``--top-touch N`` switches to a
     recent-touch composite score and returns the top N.
     """
+    import re
     from athenaeum.models import parse_frontmatter
 
     knowledge_root = args.path.expanduser().resolve()
@@ -543,6 +558,9 @@ def _cmd_people(args: argparse.Namespace) -> int:
     required_tags = list(args.tag)
     if args.tier:
         required_tags.append(f"tier:{args.tier}")
+
+    title_regexes = [re.compile(p, re.IGNORECASE) for p in (args.title_regex or []) if p]
+    company_regexes = [re.compile(p, re.IGNORECASE) for p in (args.company_regex or []) if p]
 
     rows: list[dict] = []
     for path in sorted(wiki_root.glob("*.md")):
@@ -568,6 +586,19 @@ def _cmd_people(args: argparse.Namespace) -> int:
         if needle_companies:
             blob = " ".join(company_fields).lower()
             if not all(needle in blob for needle in needle_companies):
+                continue
+        if company_regexes:
+            company_blob = " ".join(company_fields)
+            if not all(rx.search(company_blob) for rx in company_regexes):
+                continue
+
+        title_fields = [
+            str(meta.get("current_title") or ""),
+            str(meta.get("linkedin_position_at_connect") or ""),
+        ]
+        if title_regexes:
+            title_blob = " ".join(title_fields)
+            if not all(rx.search(title_blob) for rx in title_regexes):
                 continue
 
         try:

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -546,6 +546,7 @@ def _cmd_people(args: argparse.Namespace) -> int:
     recent-touch composite score and returns the top N.
     """
     import re
+
     from athenaeum.models import parse_frontmatter
 
     knowledge_root = args.path.expanduser().resolve()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -554,5 +554,40 @@ class TestPeopleCommand:
         assert rc == 1
         assert "Wiki root not found" in capsys.readouterr().err
 
+    def test_title_regex_matches_role_pattern(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        knowledge = tmp_path / "k"
+        self._seed_wiki(knowledge / "wiki")
+        rc = main([
+            "people", "--path", str(knowledge),
+            "--title-regex", r"CEO|EVP",
+            "--format", "tsv",
+        ])
+        assert rc == 0
+        names = [line.split("\t", 1)[0] for line in capsys.readouterr().out.strip().splitlines()]
+        assert set(names) == {
+            "Lisa Contoyannis", "Andy Kurtzig", "Michael Gutkowski", "Olivier Pomel",
+        }
+        assert "No-Tag Ghost" not in names
+        assert "Pearl.com Holdings" not in names
+
+    def test_company_regex_intersects_with_title_regex(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Find CEOs at Pearl-family companies (excluding the Datadog CEO)."""
+        knowledge = tmp_path / "k"
+        self._seed_wiki(knowledge / "wiki")
+        rc = main([
+            "people", "--path", str(knowledge),
+            "--title-regex", r"CEO",
+            "--company-regex", r"Pearl",
+            "--format", "tsv",
+        ])
+        assert rc == 0
+        names = [line.split("\t", 1)[0] for line in capsys.readouterr().out.strip().splitlines()]
+        assert names == ["Andy Kurtzig"]
+        assert "Olivier Pomel" not in names
+
 
 


### PR DESCRIPTION
## Summary

- Adds `--title-regex` and `--company-regex` flags to `athenaeum people`
- Case-insensitive, repeatable, AND-composed with each other and existing `--tag` / `--tier` / `--company` filters
- Vector recall remains the right tool for natural-language queries; this fills the role + company structured-filter gap

Closes #83.

## Test plan

- [x] `pytest tests/test_cli.py` — 33 passed (5 existing + 2 new)
- [x] Live workspace: `athenaeum people --title-regex 'Founder|CEO|Director' --company-regex 'Accelerator|Incubator' --limit 10` returns sensible accelerator-runners (Bluth Institute, Soylent Ventures, Hooli, etc.)
- [x] Verified the new flags compose with `--tier extended` and `--company`

🧙 Built with [WOZCODE](https://wozcode.com)
