### PR TITLE
feat(repair): port YAML-frontmatter repair tools to athenaeum CLI

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -4,6 +4,7 @@
 import argparse
 import logging
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 
@@ -941,16 +942,17 @@ def _cmd_repair(args: argparse.Namespace) -> int:
         print(f"Wiki root not found: {wiki_root}", file=sys.stderr)
         return 1
 
-    passes: list[tuple[str, callable]] = []
-    if args.tag_indent:
-        passes.append(("tag-indent", repair_tag_indent))
-    if args.value_quoting:
-        passes.append(("value-quoting", repair_value_quoting))
+    RepairFn = Callable[[Path, bool], RepairReport]
+    passes: list[tuple[str, RepairFn]]
     if args.all:
         passes = [
             ("tag-indent", repair_tag_indent),
             ("value-quoting", repair_value_quoting),
         ]
+    elif args.tag_indent:
+        passes = [("tag-indent", repair_tag_indent)]
+    else:  # args.value_quoting (mutex group guarantees one of the three)
+        passes = [("value-quoting", repair_value_quoting)]
 
     total_changed = 0
     total_errors = 0

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -284,6 +284,42 @@ def main(argv: list[str] | None = None) -> int:
         help="Override configured backend (default: read from athenaeum.yaml)",
     )
 
+    # repair command — frontmatter YAML repair tools (tag-indent, value-quoting)
+    repair_parser = subparsers.add_parser(
+        "repair",
+        help="Repair YAML-frontmatter corruption in wiki files. "
+        "Default is dry-run; pass --apply to write fixes.",
+    )
+    repair_mode = repair_parser.add_mutually_exclusive_group(required=True)
+    repair_mode.add_argument(
+        "--tag-indent",
+        action="store_true",
+        help="Normalize block-list indentation under top-level keys "
+        "(tags:, emails:, aliases:, ...).",
+    )
+    repair_mode.add_argument(
+        "--value-quoting",
+        action="store_true",
+        help="Quote unquoted YAML values that break safe_load "
+        "(values starting with '-' or '[').",
+    )
+    repair_mode.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all repair passes in sequence (tag-indent then value-quoting).",
+    )
+    repair_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write fixes. Without this flag, the command is a dry-run.",
+    )
+    repair_parser.add_argument(
+        "--wiki-root",
+        type=Path,
+        default=None,
+        help="Wiki directory (default: ~/knowledge/wiki)",
+    )
+
     # rebuild-index command — rebuild the search index out-of-band
     rebuild_parser = subparsers.add_parser(
         "rebuild-index",
@@ -346,6 +382,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "stopwords":
         return _cmd_stopwords(args)
+
+    if args.command == "repair":
+        return _cmd_repair(args)
 
     return 0
 
@@ -884,6 +923,60 @@ def _cmd_test_mcp(args: argparse.Namespace) -> int:
 
     print(f"\n{len(passed)} passed, {len(failed)} failed")
     return 0 if not failed else 1
+
+
+def _cmd_repair(args: argparse.Namespace) -> int:
+    """Run frontmatter repair pass(es).
+
+    Exit codes:
+        0 — clean run (zero changes needed, OR ``--apply`` succeeded
+            with no errors).
+        1 — errors encountered (read/write/parse failures).
+        2 — dry-run found fixes (CI gate signal).
+    """
+    from athenaeum.repair import RepairReport, repair_tag_indent, repair_value_quoting
+
+    wiki_root = (args.wiki_root or Path("~/knowledge/wiki")).expanduser().resolve()
+    if not wiki_root.is_dir():
+        print(f"Wiki root not found: {wiki_root}", file=sys.stderr)
+        return 1
+
+    passes: list[tuple[str, callable]] = []
+    if args.tag_indent:
+        passes.append(("tag-indent", repair_tag_indent))
+    if args.value_quoting:
+        passes.append(("value-quoting", repair_value_quoting))
+    if args.all:
+        passes = [
+            ("tag-indent", repair_tag_indent),
+            ("value-quoting", repair_value_quoting),
+        ]
+
+    total_changed = 0
+    total_errors = 0
+    mode = "APPLY" if args.apply else "DRY RUN"
+
+    for name, func in passes:
+        report: RepairReport = func(wiki_root, apply=args.apply)
+        total_changed += report.files_changed
+        total_errors += len(report.errors)
+        print(f"=== repair {name} ({mode}) ===")
+        print(f"  files_scanned: {report.files_scanned}")
+        print(f"  files_changed: {report.files_changed}")
+        print(f"  errors:        {len(report.errors)}")
+        if report.changes and not args.apply:
+            for path, summary in report.changes[:20]:
+                print(f"    {path.name}: {summary}")
+            if len(report.changes) > 20:
+                print(f"    ... and {len(report.changes) - 20} more")
+        for path, err in report.errors[:20]:
+            print(f"  ERR {path.name}: {err}", file=sys.stderr)
+
+    if total_errors > 0:
+        return 1
+    if not args.apply and total_changed > 0:
+        return 2
+    return 0
 
 
 def _get_version() -> str:

--- a/src/athenaeum/repair.py
+++ b/src/athenaeum/repair.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 

--- a/src/athenaeum/repair.py
+++ b/src/athenaeum/repair.py
@@ -15,11 +15,18 @@ versions of cwc-side enricher scripts:
 Both functions default to dry-run (``apply=False``); idempotent on clean
 trees. Ported from ``cwc/scripts/knowledge-librarian/repair_tag_indent.py``
 and ``repair_yaml_value_quoting.py``.
+
+Repair runs **before** schema validation by design: these passes work on
+raw text via regex/line-walks because the corruption shapes prevent
+``yaml.safe_load`` from producing a document at all; pydantic validators
+are downstream consumers of already-parseable frontmatter.
 """
 
 from __future__ import annotations
 
+import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -68,6 +75,18 @@ def _iter_wiki_files(wiki_root: Path):
         if path.name.startswith("_"):
             continue
         yield path
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically via temp-file + ``os.replace``.
+
+    Avoids leaving a partial file on disk if the process is interrupted
+    mid-write — readers see either the old content or the complete new
+    content, never a truncated mix.
+    """
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, path)
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +182,7 @@ def repair_tag_indent(wiki_root: Path, apply: bool = False) -> RepairReport:
         report.changes.append((path, "tag-indent normalized to 2-space"))
         if apply:
             try:
-                path.write_text("---\n" + new_fm + "\n---\n" + body, encoding="utf-8")
+                _atomic_write(path, "---\n" + new_fm + "\n---\n" + body)
             except OSError as exc:
                 report.errors.append((path, f"write_error: {exc}"))
 
@@ -233,7 +252,7 @@ def repair_value_quoting(wiki_root: Path, apply: bool = False) -> RepairReport:
         report.changes.append((path, "value-quoting repaired"))
         if apply:
             try:
-                path.write_text("---\n" + new_fm + "\n---\n" + body, encoding="utf-8")
+                _atomic_write(path, "---\n" + new_fm + "\n---\n" + body)
             except OSError as exc:
                 report.errors.append((path, f"write_error: {exc}"))
 

--- a/src/athenaeum/repair.py
+++ b/src/athenaeum/repair.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+"""YAML-frontmatter repair utilities.
+
+Two corruption shapes are addressed, both originally introduced by older
+versions of cwc-side enricher scripts:
+
+1. **Tag-list indent splice** — Apollo enricher (pre-2026-05-08) spliced
+   ``  - apollo:enriched`` (2-space) into a 0-space block list, producing
+   mixed indentation that fails ``yaml.safe_load``.
+2. **Unquoted-value YAML break** — older raw-tier writers emitted bare
+   values starting with ``-`` or ``[`` for keys like ``title`` or
+   ``organization_name``. YAML interprets these as block-sequence starts
+   or flow-sequences and rejects the document.
+
+Both functions default to dry-run (``apply=False``); idempotent on clean
+trees. Ported from ``cwc/scripts/knowledge-librarian/repair_tag_indent.py``
+and ``repair_yaml_value_quoting.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class RepairReport:
+    """Result of a repair scan/apply pass.
+
+    Attributes:
+        files_scanned: total ``.md`` files inspected (top-level only,
+            ``_*`` files skipped — same convention as the original
+            cwc scripts).
+        files_changed: count that needed a fix (in dry-run, the count
+            that *would* be fixed; in apply, the count that *was*).
+        errors: list of ``(path, error-message)`` tuples for files that
+            could not be read, parsed, or written.
+        changes: list of ``(path, summary)`` tuples — one per fixed
+            file. ``summary`` is a short human-readable description.
+    """
+
+    files_scanned: int = 0
+    files_changed: int = 0
+    errors: list[tuple[Path, str]] = field(default_factory=list)
+    changes: list[tuple[Path, str]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+
+
+def _split_frontmatter(text: str) -> tuple[str, str] | None:
+    """Return ``(frontmatter, body)`` or ``None`` if the file has none."""
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        return None
+    return text[4:end], text[end + 5 :]
+
+
+def _iter_wiki_files(wiki_root: Path):
+    """Yield top-level ``*.md`` files, skipping ``_*`` (same as cwc scripts)."""
+    for path in sorted(wiki_root.glob("*.md")):
+        if path.name.startswith("_"):
+            continue
+        yield path
+
+
+# ---------------------------------------------------------------------------
+# 1. Tag-indent normalization
+
+
+def _normalize_block_lists(fm: str) -> tuple[str, bool]:
+    """Force every top-level scalar block-list to use 2-space dash indent.
+
+    Skips blocks where any item has a continuation line (i.e. it's a
+    map-list, not a scalar list) — those need different handling.
+    """
+    lines = fm.split("\n")
+    out: list[str] = []
+    i = 0
+    changed = False
+    while i < len(lines):
+        line = lines[i]
+        if (
+            line
+            and not line.startswith(" ")
+            and line.endswith(":")
+            and ":" in line
+            and " " not in line.rstrip(":")
+        ):
+            j = i + 1
+            block_lines: list[str] = []
+            has_continuation = False
+            local_changed = False
+            while j < len(lines):
+                nxt = lines[j]
+                if not nxt:
+                    break
+                stripped = nxt.lstrip(" ")
+                indent = len(nxt) - len(stripped)
+                if stripped.startswith("- ") or stripped == "-":
+                    if indent != 2:
+                        local_changed = True
+                    block_lines.append("  " + stripped)
+                    j += 1
+                    continue
+                if indent > 0 and not stripped.startswith("-"):
+                    has_continuation = True
+                    break
+                break
+            if block_lines and not has_continuation:
+                out.append(line)
+                out.extend(block_lines)
+                if local_changed:
+                    changed = True
+                i = j
+                continue
+        out.append(line)
+        i += 1
+    return "\n".join(out), changed
+
+
+def repair_tag_indent(wiki_root: Path, apply: bool = False) -> RepairReport:
+    """Normalize tag-list (and other top-level block-list) indentation.
+
+    See module docstring for the corruption shape. Idempotent: files
+    already at 2-space indent are left untouched.
+    """
+    report = RepairReport()
+    if not wiki_root.is_dir():
+        report.errors.append((wiki_root, "wiki root not found"))
+        return report
+
+    for path in _iter_wiki_files(wiki_root):
+        report.files_scanned += 1
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            report.errors.append((path, f"read_error: {exc}"))
+            continue
+        parts = _split_frontmatter(text)
+        if parts is None:
+            continue
+        fm, body = parts
+        new_fm, changed = _normalize_block_lists(fm)
+        if not changed:
+            continue
+        # Validate the rewrite parses before recording / writing
+        try:
+            meta = yaml.safe_load(new_fm)
+        except yaml.YAMLError as exc:
+            report.errors.append((path, f"still_broken: {str(exc)[:80]}"))
+            continue
+        if not isinstance(meta, dict):
+            report.errors.append((path, "not_dict_after_parse"))
+            continue
+        report.files_changed += 1
+        report.changes.append((path, "tag-indent normalized to 2-space"))
+        if apply:
+            try:
+                path.write_text("---\n" + new_fm + "\n---\n" + body, encoding="utf-8")
+            except OSError as exc:
+                report.errors.append((path, f"write_error: {exc}"))
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# 2. Value-quoting repair
+
+# Match keys (with optional dash prefix for list items) where value either:
+#  (a) starts with `[` (looks like flow-sequence to YAML)
+#  (b) is a bare `-` (treated as block-sequence start)
+#  (c) starts with `- ` followed by content
+_VALUE_QUOTING_RE = re.compile(
+    r"^(\s*-?\s*)(title|organization_name|apollo_headline|current_title|current_company): "
+    r"(\[[^\n]*\][^\n]*|- ?[^\n]*)$",
+    re.MULTILINE,
+)
+
+
+def _yaml_parses(fm: str) -> bool:
+    try:
+        yaml.safe_load(fm)
+        return True
+    except yaml.YAMLError:
+        return False
+
+
+def _quote_subst(m: re.Match) -> str:
+    indent, key, val = m.group(1), m.group(2), m.group(3)
+    if val.strip() in {"-", ""}:
+        return f"{indent}{key}: ''"
+    esc = val.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{indent}{key}: "{esc}"'
+
+
+def repair_value_quoting(wiki_root: Path, apply: bool = False) -> RepairReport:
+    """Quote unquoted YAML values that break ``safe_load``.
+
+    Only rewrites a file if the original frontmatter fails to parse AND
+    the rewrite parses cleanly. Idempotent on already-clean trees.
+    """
+    report = RepairReport()
+    if not wiki_root.is_dir():
+        report.errors.append((wiki_root, "wiki root not found"))
+        return report
+
+    for path in _iter_wiki_files(wiki_root):
+        report.files_scanned += 1
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            report.errors.append((path, f"read_error: {exc}"))
+            continue
+        parts = _split_frontmatter(text)
+        if parts is None:
+            continue
+        fm, body = parts
+        if _yaml_parses(fm):
+            continue
+        new_fm = _VALUE_QUOTING_RE.sub(_quote_subst, fm)
+        if new_fm == fm:
+            continue
+        if not _yaml_parses(new_fm):
+            continue
+        report.files_changed += 1
+        report.changes.append((path, "value-quoting repaired"))
+        if apply:
+            try:
+                path.write_text("---\n" + new_fm + "\n---\n" + body, encoding="utf-8")
+            except OSError as exc:
+                report.errors.append((path, f"write_error: {exc}"))
+
+    return report

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -239,3 +239,102 @@ def test_cli_mutex_flags_rejected(tmp_path: Path, capsys) -> None:
 def test_cli_missing_wiki_returns_1(tmp_path: Path) -> None:
     rc = cli.main(["repair", "--tag-indent", "--wiki-root", str(tmp_path / "nope")])
     assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Pass isolation + errors path
+
+# A file whose tag-indent rewrite still fails to parse — used to drive the
+# tag-indent "still_broken" error branch. Mixed indent + a stray unquoted
+# bracket value that survives the indent normalization and keeps YAML broken.
+TAG_INDENT_UNREPAIRABLE = """\
+---
+uid: person:eve
+type: person
+name: Eve Test
+tags:
+- person
+  - apollo:enriched
+current_title: [Founder] CEO
+---
+
+Body.
+"""
+
+
+def test_pass2_runs_after_pass1_errors_on_other_file(tmp_path: Path) -> None:
+    """`repair --all` keeps running pass 2 on remaining files when pass 1
+    logs an error on a malformed-beyond-repair file."""
+    wiki = _make_wiki(
+        tmp_path,
+        {
+            # pass 1 (tag-indent) will log an error on this one — its
+            # post-rewrite frontmatter still fails yaml.safe_load because
+            # of the unquoted `[Founder] CEO` value.
+            "eve.md": TAG_INDENT_UNREPAIRABLE,
+            # pass 2 (value-quoting) must still fix this one.
+            "carol.md": VALUE_QUOTING_BROKEN,
+        },
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main(["repair", "--all", "--apply", "--wiki-root", str(wiki)])
+
+    # Errors present from pass 1 → exit 1
+    assert rc == 1
+    out = buf.getvalue()
+    assert "tag-indent" in out
+    assert "value-quoting" in out
+    # carol.md got repaired by pass 2 despite pass 1's error
+    text = (wiki / "carol.md").read_text()
+    end = text.find("\n---\n", 4)
+    meta = yaml.safe_load(text[4:end])
+    assert meta["current_title"] == "[Founder] CEO"
+
+
+# Truly unparseable YAML — unterminated double-quote inside frontmatter.
+# Neither pass can repair this; both should populate `report.errors` for
+# tag-indent's "still_broken" branch (no, actually only if a rewrite is
+# attempted). For value-quoting we need a parse failure that the regex
+# does not match, so the rewrite is a no-op and the file is just skipped.
+# To force the errors-path test, we use a file that pass 1 will rewrite
+# (mixed indent) but where the rewrite still fails to parse.
+UNPARSEABLE_FRONTMATTER = """\
+---
+uid: person:frank
+type: person
+name: Frank Test
+tags:
+- person
+  - apollo:enriched
+title: "unterminated quote
+---
+
+Body.
+"""
+
+
+def test_unparseable_yaml_populates_errors_and_cli_exits_1(tmp_path: Path) -> None:
+    """File with unterminated quote: tag-indent rewrites the indent but the
+    result still fails ``yaml.safe_load`` → ``report.errors`` populated and
+    CLI returns exit code 1."""
+    wiki = _make_wiki(tmp_path, {"frank.md": UNPARSEABLE_FRONTMATTER})
+
+    report = repair_tag_indent(wiki, apply=False)
+    assert len(report.errors) == 1
+    path, msg = report.errors[0]
+    assert path.name == "frank.md"
+    assert "still_broken" in msg
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main(["repair", "--tag-indent", "--wiki-root", str(wiki)])
+    assert rc == 1
+
+
+def test_atomic_write_no_tmp_left_behind(tmp_path: Path) -> None:
+    """Apply pass leaves no ``*.tmp`` debris on disk."""
+    wiki = _make_wiki(tmp_path, {"bob.md": TAG_INDENT_BROKEN})
+    repair_tag_indent(wiki, apply=True)
+    leftovers = list(wiki.glob("*.tmp")) + list(wiki.glob("*.md.tmp"))
+    assert leftovers == []

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for athenaeum.repair (tag-indent + value-quoting passes)."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import yaml
+
+from athenaeum import cli
+from athenaeum.repair import repair_tag_indent, repair_value_quoting
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+
+
+# A wiki where Apollo enricher spliced "  - apollo:enriched" into a 0-space
+# tag block — fails yaml.safe_load until tag-indent normalization runs.
+TAG_INDENT_BROKEN = """\
+---
+uid: person:bob
+type: person
+name: Bob Test
+tags:
+- person
+  - apollo:enriched
+- warm
+emails:
+- bob@example.com
+- bob@other.com
+---
+
+# Bob Test
+
+Body content.
+"""
+
+# Already-clean wiki with 2-space tag indent — must be a no-op.
+TAG_INDENT_CLEAN = """\
+---
+uid: person:alice
+type: person
+name: Alice Test
+tags:
+  - person
+  - warm
+---
+
+Body.
+"""
+
+# A wiki where current_title is unquoted and starts with "[" — breaks YAML.
+VALUE_QUOTING_BROKEN = """\
+---
+uid: person:carol
+type: person
+name: Carol Test
+current_title: [Founder] CEO
+current_company: Acme
+---
+
+Body.
+"""
+
+# Already-clean — must be a no-op.
+VALUE_QUOTING_CLEAN = """\
+---
+uid: person:dan
+type: person
+name: Dan Test
+current_title: "VP Engineering"
+---
+
+Body.
+"""
+
+
+def _make_wiki(tmp_path: Path, files: dict[str, str]) -> Path:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    for name, content in files.items():
+        (wiki / name).write_text(content, encoding="utf-8")
+    return wiki
+
+
+# ---------------------------------------------------------------------------
+# repair_tag_indent
+
+
+def test_tag_indent_dry_run_does_not_write(tmp_path: Path) -> None:
+    wiki = _make_wiki(
+        tmp_path, {"bob.md": TAG_INDENT_BROKEN, "alice.md": TAG_INDENT_CLEAN}
+    )
+    before = (wiki / "bob.md").read_text()
+
+    report = repair_tag_indent(wiki, apply=False)
+
+    assert report.files_scanned == 2
+    assert report.files_changed == 1
+    assert (wiki / "bob.md").read_text() == before  # untouched
+    assert any("bob.md" == p.name for p, _ in report.changes)
+
+
+def test_tag_indent_apply_writes_and_parses(tmp_path: Path) -> None:
+    wiki = _make_wiki(tmp_path, {"bob.md": TAG_INDENT_BROKEN})
+
+    report = repair_tag_indent(wiki, apply=True)
+
+    assert report.files_changed == 1
+    text = (wiki / "bob.md").read_text()
+    # Frontmatter parses cleanly now
+    assert text.startswith("---\n")
+    end = text.find("\n---\n", 4)
+    fm = text[4:end]
+    meta = yaml.safe_load(fm)
+    assert meta["tags"] == ["person", "apollo:enriched", "warm"]
+    assert meta["emails"] == ["bob@example.com", "bob@other.com"]
+
+
+def test_tag_indent_idempotent(tmp_path: Path) -> None:
+    wiki = _make_wiki(tmp_path, {"bob.md": TAG_INDENT_BROKEN})
+    repair_tag_indent(wiki, apply=True)
+    after_first = (wiki / "bob.md").read_text()
+
+    report2 = repair_tag_indent(wiki, apply=True)
+
+    assert report2.files_changed == 0
+    assert (wiki / "bob.md").read_text() == after_first
+
+
+def test_tag_indent_skips_underscore_files(tmp_path: Path) -> None:
+    wiki = _make_wiki(tmp_path, {"_pending_questions.md": TAG_INDENT_BROKEN})
+    report = repair_tag_indent(wiki, apply=False)
+    assert report.files_scanned == 0
+
+
+# ---------------------------------------------------------------------------
+# repair_value_quoting
+
+
+def test_value_quoting_dry_run(tmp_path: Path) -> None:
+    wiki = _make_wiki(
+        tmp_path,
+        {"carol.md": VALUE_QUOTING_BROKEN, "dan.md": VALUE_QUOTING_CLEAN},
+    )
+    before = (wiki / "carol.md").read_text()
+
+    report = repair_value_quoting(wiki, apply=False)
+
+    assert report.files_scanned == 2
+    assert report.files_changed == 1
+    assert (wiki / "carol.md").read_text() == before
+
+
+def test_value_quoting_apply_writes_and_parses(tmp_path: Path) -> None:
+    wiki = _make_wiki(tmp_path, {"carol.md": VALUE_QUOTING_BROKEN})
+
+    report = repair_value_quoting(wiki, apply=True)
+
+    assert report.files_changed == 1
+    text = (wiki / "carol.md").read_text()
+    end = text.find("\n---\n", 4)
+    meta = yaml.safe_load(text[4:end])
+    assert meta["current_title"] == "[Founder] CEO"
+    assert meta["current_company"] == "Acme"
+
+
+def test_value_quoting_idempotent(tmp_path: Path) -> None:
+    wiki = _make_wiki(tmp_path, {"carol.md": VALUE_QUOTING_BROKEN})
+    repair_value_quoting(wiki, apply=True)
+    after_first = (wiki / "carol.md").read_text()
+
+    report2 = repair_value_quoting(wiki, apply=True)
+    assert report2.files_changed == 0
+    assert (wiki / "carol.md").read_text() == after_first
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+
+
+def test_cli_dry_run_returns_2_when_fixes_pending(tmp_path: Path) -> None:
+    wiki = _make_wiki(tmp_path, {"bob.md": TAG_INDENT_BROKEN})
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main(["repair", "--tag-indent", "--wiki-root", str(wiki)])
+    assert rc == 2
+    out = buf.getvalue()
+    assert "tag-indent" in out
+    assert "DRY RUN" in out
+    assert "files_changed: 1" in out
+    # File untouched
+    assert (wiki / "bob.md").read_text() == TAG_INDENT_BROKEN
+
+
+def test_cli_apply_returns_0(tmp_path: Path) -> None:
+    wiki = _make_wiki(tmp_path, {"bob.md": TAG_INDENT_BROKEN})
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main(["repair", "--tag-indent", "--apply", "--wiki-root", str(wiki)])
+    assert rc == 0
+    assert "APPLY" in buf.getvalue()
+
+
+def test_cli_clean_tree_returns_0(tmp_path: Path) -> None:
+    wiki = _make_wiki(tmp_path, {"alice.md": TAG_INDENT_CLEAN})
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main(["repair", "--tag-indent", "--wiki-root", str(wiki)])
+    assert rc == 0
+
+
+def test_cli_all_runs_both_passes(tmp_path: Path) -> None:
+    wiki = _make_wiki(
+        tmp_path,
+        {"bob.md": TAG_INDENT_BROKEN, "carol.md": VALUE_QUOTING_BROKEN},
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli.main(["repair", "--all", "--apply", "--wiki-root", str(wiki)])
+    assert rc == 0
+    out = buf.getvalue()
+    assert "tag-indent" in out
+    assert "value-quoting" in out
+
+
+def test_cli_mutex_flags_rejected(tmp_path: Path, capsys) -> None:
+    wiki = _make_wiki(tmp_path, {})
+    try:
+        cli.main(["repair", "--tag-indent", "--all", "--wiki-root", str(wiki)])
+    except SystemExit as e:
+        assert e.code == 2
+    else:
+        raise AssertionError("expected SystemExit from mutex flag conflict")
+
+
+def test_cli_missing_wiki_returns_1(tmp_path: Path) -> None:
+    rc = cli.main(["repair", "--tag-indent", "--wiki-root", str(tmp_path / "nope")])
+    assert rc == 1


### PR DESCRIPTION
## Summary

Adds the `athenaeum repair` subcommand for fixing YAML-frontmatter corruption in wiki files. Two repair passes:

- `--tag-indent` — normalizes top-level block-list indentation to uniform 2-space, fixing the Apollo-enricher splice bug that broke `yaml.safe_load` on 3,341 wikis.
- `--value-quoting` — quotes unquoted YAML values starting with `-` or `[` for keys like `current_title` / `organization_name`.
- `--all` — runs both passes in sequence.

Default mode is dry-run; pass `--apply` to write fixes. Exit codes: `0` clean, `1` errors, `2` dry-run found fixes (CI gate signal). Idempotent on already-clean trees.

## Ported from

- `cwc/scripts/knowledge-librarian/repair_tag_indent.py`
- `cwc/scripts/knowledge-librarian/repair_yaml_value_quoting.py`

Behavior preserved for the corruption shapes the originals targeted; new module `src/athenaeum/repair.py` exposes `repair_tag_indent()` and `repair_value_quoting()` returning a `RepairReport` dataclass for programmatic callers.

## Test plan

- [x] pytest tests/test_repair.py — 13 tests covering dry-run, apply, idempotence, CLI exit codes, mutex flags, missing-wiki errors
- [x] ruff check src/ tests/ clean
- [x] Existing test_cli.py and test_smoke.py still pass
- [ ] CI green on PR

Closes #86
