### PR TITLE
feat(init): scaffold entity-author markdown templates (#89)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ packages = ["src/athenaeum"]
 include = [
     "src/athenaeum/py.typed",
     "src/athenaeum/schema/**/*.md",
+    "src/athenaeum/templates/**/*.md",
 ]
 
 [tool.ruff]

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -12,16 +12,39 @@ def main(argv: list[str] | None = None) -> int:
         prog="athenaeum",
         description="Knowledge management pipeline — append-only intake, tiered compilation",
     )
-    parser.add_argument("--version", action="version", version=f"%(prog)s {_get_version()}")
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {_get_version()}"
+    )
     subparsers = parser.add_subparsers(dest="command")
 
     # init command
-    init_parser = subparsers.add_parser("init", help="Initialize a new knowledge directory")
+    init_parser = subparsers.add_parser(
+        "init", help="Initialize a new knowledge directory"
+    )
     init_parser.add_argument(
         "--path",
         type=Path,
         default=Path("~/knowledge"),
         help="Target directory (default: ~/knowledge)",
+    )
+    init_parser.add_argument(
+        "--with-templates",
+        action="store_true",
+        help="Also copy bundled entity-author templates "
+        "(person/company/project/concept/source) into <path>/templates/.",
+    )
+    init_parser.add_argument(
+        "--templates-dest",
+        type=Path,
+        default=None,
+        help="Override the templates destination directory "
+        "(default: <path>/templates).",
+    )
+    init_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing template files at the destination "
+        "(only applies with --with-templates).",
     )
 
     # status command
@@ -45,44 +68,59 @@ def main(argv: list[str] | None = None) -> int:
     # run command — execute the librarian pipeline
     run_parser = subparsers.add_parser("run", help="Run the librarian pipeline")
     run_parser.add_argument(
-        "--raw-root", type=Path, default=None,
+        "--raw-root",
+        type=Path,
+        default=None,
         help="Raw intake directory (default: ~/knowledge/raw)",
     )
     run_parser.add_argument(
-        "--wiki-root", type=Path, default=None,
+        "--wiki-root",
+        type=Path,
+        default=None,
         help="Wiki output directory (default: ~/knowledge/wiki)",
     )
     run_parser.add_argument(
-        "--knowledge-root", type=Path, default=None,
+        "--knowledge-root",
+        type=Path,
+        default=None,
         help="Knowledge git repo root (default: ~/knowledge)",
     )
     run_parser.add_argument(
-        "--dry-run", action="store_true",
+        "--dry-run",
+        action="store_true",
         help="Run pipeline without writing files or committing",
     )
     run_parser.add_argument(
-        "--max-files", type=int, default=50,
+        "--max-files",
+        type=int,
+        default=50,
         help="Stop after processing this many raw files (default: 50)",
     )
     run_parser.add_argument(
-        "--max-api-calls", type=int, default=200,
+        "--max-api-calls",
+        type=int,
+        default=200,
         help="Maximum estimated API calls per run (default: 200)",
     )
     run_parser.add_argument(
-        "--verbose", "-v", action="store_true",
+        "--verbose",
+        "-v",
+        action="store_true",
         help="Enable debug logging",
     )
     run_parser.add_argument(
-        "--cluster-only", action="store_true",
+        "--cluster-only",
+        action="store_true",
         help="Only run C2 auto-memory discovery + clustering — skip the "
-             "entity tier pipeline. Writes the cluster JSONL report and "
-             "exits. Useful for validating the cluster output before C3.",
+        "entity tier pipeline. Writes the cluster JSONL report and "
+        "exits. Useful for validating the cluster output before C3.",
     )
     run_parser.add_argument(
-        "--merge-only", action="store_true",
+        "--merge-only",
+        action="store_true",
         help="Only run C3 cluster merge — read the canonical cluster "
-             "JSONL from the last C2 run and emit wiki/auto-*.md entries. "
-             "Skips discovery, clustering, and the entity tier pipeline.",
+        "JSONL from the last C2 run and emit wiki/auto-*.md entries. "
+        "Skips discovery, clustering, and the entity tier pipeline.",
     )
 
     # test-mcp command — smoke-test the MCP memory setup without a session
@@ -91,7 +129,8 @@ def main(argv: list[str] | None = None) -> int:
         help="Smoke-test MCP remember/recall against a synthetic knowledge dir",
     )
     test_mcp_parser.add_argument(
-        "--keep", action="store_true",
+        "--keep",
+        action="store_true",
         help="Don't delete the temp knowledge dir on exit (for debugging)",
     )
 
@@ -99,52 +138,69 @@ def main(argv: list[str] | None = None) -> int:
     people_parser = subparsers.add_parser(
         "people",
         help="List type:person wikis filtered by frontmatter (company / tag / tier / score). "
-             "No LLM, no embeddings — deterministic over the wiki tree.",
+        "No LLM, no embeddings — deterministic over the wiki tree.",
     )
     people_parser.add_argument(
-        "--path", type=Path, default=Path("~/knowledge"),
+        "--path",
+        type=Path,
+        default=Path("~/knowledge"),
         help="Knowledge directory (default: ~/knowledge)",
     )
     people_parser.add_argument(
-        "--company", action="append", default=[],
+        "--company",
+        action="append",
+        default=[],
         help=(
             "Match current_company OR linkedin_company_at_connect "
             "(case-insensitive substring). Repeat to AND."
         ),
     )
     people_parser.add_argument(
-        "--tag", action="append", default=[],
+        "--tag",
+        action="append",
+        default=[],
         help="Require this exact tag (repeat to AND).",
     )
     people_parser.add_argument(
-        "--tier", default="",
+        "--tier",
+        default="",
         help="Shorthand for --tag tier:<value> (warm-a / warm-b / warm-c / extended / active).",
     )
     people_parser.add_argument(
-        "--title-regex", action="append", default=[],
+        "--title-regex",
+        action="append",
+        default=[],
         help=(
             "Match current_title OR linkedin_position_at_connect against this "
             "regex (case-insensitive). Repeat to AND multiple patterns."
         ),
     )
     people_parser.add_argument(
-        "--company-regex", action="append", default=[],
+        "--company-regex",
+        action="append",
+        default=[],
         help=(
             "Match current_company OR linkedin_company_at_connect against this "
             "regex (case-insensitive). Repeat to AND multiple patterns."
         ),
     )
     people_parser.add_argument(
-        "--top-touch", type=int, default=0,
+        "--top-touch",
+        type=int,
+        default=0,
         help="Sort by recent-touch signal (meeting+sent counts) and return top N. "
-             "Default sort is by warm_score desc.",
+        "Default sort is by warm_score desc.",
     )
     people_parser.add_argument(
-        "--limit", type=int, default=50,
+        "--limit",
+        type=int,
+        default=50,
         help="Max rows to print (default: 50; 0 = unlimited)",
     )
     people_parser.add_argument(
-        "--format", choices=["table", "tsv"], default="table",
+        "--format",
+        choices=["table", "tsv"],
+        default="table",
         help="Output shape (default: table).",
     )
 
@@ -152,16 +208,19 @@ def main(argv: list[str] | None = None) -> int:
     query_topics_parser = subparsers.add_parser(
         "query-topics",
         help="Extract substantive search topics from a prompt (Haiku). "
-             "Used by the UserPromptSubmit hook to rewrite queries before "
-             "FTS5/vector search. Prints one topic per line to stdout; "
-             "empty output means fall back to the caller's built-in extractor.",
+        "Used by the UserPromptSubmit hook to rewrite queries before "
+        "FTS5/vector search. Prints one topic per line to stdout; "
+        "empty output means fall back to the caller's built-in extractor.",
     )
     query_topics_parser.add_argument(
-        "prompt", type=str,
+        "prompt",
+        type=str,
         help="The user's raw message.",
     )
     query_topics_parser.add_argument(
-        "--timeout", type=float, default=3.0,
+        "--timeout",
+        type=float,
+        default=3.0,
         help="Seconds to wait for the LLM before giving up (default: 3.0)",
     )
 
@@ -169,8 +228,8 @@ def main(argv: list[str] | None = None) -> int:
     subparsers.add_parser(
         "stopwords",
         help="Print the stopword list (one word per line). "
-             "Used by the example UserPromptSubmit hook's regex fallback "
-             "to stay in sync with the FTS5 query filter.",
+        "Used by the example UserPromptSubmit hook's regex fallback "
+        "to stay in sync with the FTS5 query filter.",
     )
 
     # ingest-answers command — convert resolved `[x]` blocks in
@@ -181,7 +240,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Ingest answered pending questions from _pending_questions.md",
     )
     ingest_answers_parser.add_argument(
-        "--path", type=Path, default=Path("~/knowledge"),
+        "--path",
+        type=Path,
+        default=Path("~/knowledge"),
         help="Knowledge directory (default: ~/knowledge)",
     )
 
@@ -194,22 +255,32 @@ def main(argv: list[str] | None = None) -> int:
         help="Search the wiki from the shell (one tab-separated hit per line)",
     )
     recall_parser.add_argument(
-        "query", type=str, help="Search query string",
+        "query",
+        type=str,
+        help="Search query string",
     )
     recall_parser.add_argument(
-        "--top-k", type=int, default=5,
+        "--top-k",
+        type=int,
+        default=5,
         help="Maximum results to return (default: 5)",
     )
     recall_parser.add_argument(
-        "--path", type=Path, default=Path("~/knowledge"),
+        "--path",
+        type=Path,
+        default=Path("~/knowledge"),
         help="Knowledge directory (default: ~/knowledge)",
     )
     recall_parser.add_argument(
-        "--cache-dir", type=Path, default=None,
+        "--cache-dir",
+        type=Path,
+        default=None,
         help="Cache directory (default: ~/.cache/athenaeum)",
     )
     recall_parser.add_argument(
-        "--backend", choices=["keyword", "fts5", "vector"], default=None,
+        "--backend",
+        choices=["keyword", "fts5", "vector"],
+        default=None,
         help="Override configured backend (default: read from athenaeum.yaml)",
     )
 
@@ -219,15 +290,21 @@ def main(argv: list[str] | None = None) -> int:
         help="Rebuild the search index (FTS5 or vector, per config)",
     )
     rebuild_parser.add_argument(
-        "--path", type=Path, default=Path("~/knowledge"),
+        "--path",
+        type=Path,
+        default=Path("~/knowledge"),
         help="Knowledge directory (default: ~/knowledge)",
     )
     rebuild_parser.add_argument(
-        "--cache-dir", type=Path, default=None,
+        "--cache-dir",
+        type=Path,
+        default=None,
         help="Cache directory (default: ~/.cache/athenaeum)",
     )
     rebuild_parser.add_argument(
-        "--backend", choices=["fts5", "vector"], default=None,
+        "--backend",
+        choices=["fts5", "vector"],
+        default=None,
         help="Override configured backend (default: read from athenaeum.yaml)",
     )
 
@@ -274,10 +351,19 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _cmd_init(args: argparse.Namespace) -> int:
-    from athenaeum.init import init_knowledge_dir
+    from athenaeum.init import copy_templates, init_knowledge_dir
 
     target = init_knowledge_dir(args.path)
     print(f"Initialized knowledge directory at {target}")
+
+    if getattr(args, "with_templates", False):
+        dest = args.templates_dest if args.templates_dest else target / "templates"
+        dest = dest.expanduser().resolve()
+        written, skipped = copy_templates(dest, force=args.force)
+        for fname in written:
+            print(f"  wrote   {dest / fname}")
+        for fname in skipped:
+            print(f"  skipped {dest / fname} (exists; pass --force to overwrite)")
     return 0
 
 
@@ -452,7 +538,9 @@ def _cmd_rebuild_index(args: argparse.Namespace) -> int:
     if backend == "vector":
         try:
             count = build_vector_index(
-                wiki_root, cache_dir, extra_roots=extra_roots,
+                wiki_root,
+                cache_dir,
+                extra_roots=extra_roots,
             )
         except ImportError as exc:
             print(f"Vector backend unavailable: {exc}", file=sys.stderr)
@@ -466,7 +554,9 @@ def _cmd_rebuild_index(args: argparse.Namespace) -> int:
 
     if backend == "fts5":
         count = build_fts5_index(
-            wiki_root, cache_dir, extra_roots=extra_roots,
+            wiki_root,
+            cache_dir,
+            extra_roots=extra_roots,
         )
         print(
             f"FTS5 index rebuilt: {count} pages "
@@ -513,7 +603,10 @@ def _cmd_recall(args: argparse.Namespace) -> int:
 
     try:
         hits = backend.query(
-            args.query, cache_dir, n=args.top_k, wiki_root=wiki_root,
+            args.query,
+            cache_dir,
+            n=args.top_k,
+            wiki_root=wiki_root,
         )
     except NotImplementedError as exc:
         print(f"Error: {exc}", file=sys.stderr)
@@ -560,8 +653,12 @@ def _cmd_people(args: argparse.Namespace) -> int:
     if args.tier:
         required_tags.append(f"tier:{args.tier}")
 
-    title_regexes = [re.compile(p, re.IGNORECASE) for p in (args.title_regex or []) if p]
-    company_regexes = [re.compile(p, re.IGNORECASE) for p in (args.company_regex or []) if p]
+    title_regexes = [
+        re.compile(p, re.IGNORECASE) for p in (args.title_regex or []) if p
+    ]
+    company_regexes = [
+        re.compile(p, re.IGNORECASE) for p in (args.company_regex or []) if p
+    ]
 
     rows: list[dict] = []
     for path in sorted(wiki_root.glob("*.md")):
@@ -616,27 +713,25 @@ def _cmd_people(args: argparse.Namespace) -> int:
             sent_count = 0
 
         title = (
-            meta.get("current_title")
-            or meta.get("linkedin_position_at_connect")
-            or ""
+            meta.get("current_title") or meta.get("linkedin_position_at_connect") or ""
         )
         company = (
-            meta.get("current_company")
-            or meta.get("linkedin_company_at_connect")
-            or ""
+            meta.get("current_company") or meta.get("linkedin_company_at_connect") or ""
         )
-        rows.append({
-            "name": str(meta.get("name") or ""),
-            "current_title": str(title),
-            "current_company": str(company),
-            "warm_score": warm_score,
-            "meeting_count_24mo": meeting_count,
-            "sent_count_24mo": sent_count,
-            "touch_score": meeting_count * 3 + sent_count,
-            "last_touch": str(meta.get("last_touch") or ""),
-            "uid": str(meta.get("uid") or ""),
-            "path": path.name,
-        })
+        rows.append(
+            {
+                "name": str(meta.get("name") or ""),
+                "current_title": str(title),
+                "current_company": str(company),
+                "warm_score": warm_score,
+                "meeting_count_24mo": meeting_count,
+                "sent_count_24mo": sent_count,
+                "touch_score": meeting_count * 3 + sent_count,
+                "last_touch": str(meta.get("last_touch") or ""),
+                "uid": str(meta.get("uid") or ""),
+                "path": path.name,
+            }
+        )
 
     if args.top_touch:
         rows.sort(key=lambda r: -r["touch_score"])
@@ -648,11 +743,22 @@ def _cmd_people(args: argparse.Namespace) -> int:
 
     if args.format == "tsv":
         for r in rows:
-            print("\t".join(str(r[k]) for k in (
-                "name", "current_title", "current_company",
-                "warm_score", "meeting_count_24mo", "sent_count_24mo",
-                "last_touch", "uid", "path",
-            )))
+            print(
+                "\t".join(
+                    str(r[k])
+                    for k in (
+                        "name",
+                        "current_title",
+                        "current_company",
+                        "warm_score",
+                        "meeting_count_24mo",
+                        "sent_count_24mo",
+                        "last_touch",
+                        "uid",
+                        "path",
+                    )
+                )
+            )
         return 0
 
     if not rows:
@@ -766,7 +872,8 @@ def _cmd_test_mcp(args: argparse.Namespace) -> int:
             _record("create_server (FastMCP)", ok, "factory returned unusable object")
         except ImportError as exc:
             _record(
-                "create_server (FastMCP)", False,
+                "create_server (FastMCP)",
+                False,
                 f"FastMCP not installed: {exc}. Install with: pip install athenaeum[mcp]",
             )
     finally:

--- a/src/athenaeum/init.py
+++ b/src/athenaeum/init.py
@@ -16,6 +16,19 @@ _SCHEMA_FILES = [
     "types.md",
 ]
 
+# Entity-author templates shipped with the wheel. Copied into
+# `<knowledge_root>/templates/` only when the user passes
+# `athenaeum init --with-templates`. These are user-facing scaffolds
+# (one per common entity type) — distinct from the LLM-tier `schema/`
+# files above, which describe the wiki contract for compilation.
+_TEMPLATE_FILES = [
+    "person.md",
+    "company.md",
+    "project.md",
+    "concept.md",
+    "source.md",
+]
+
 # Standard subdirectories created during init
 _SUBDIRS = [
     "raw",
@@ -64,6 +77,7 @@ def init_knowledge_dir(path: Path) -> Path:
 
     # 4. Create default config (skip if already present)
     from athenaeum.config import write_default_config
+
     write_default_config(path)
 
     # 5. Initialize git repo and create initial commit
@@ -79,7 +93,11 @@ def init_knowledge_dir(path: Path) -> Path:
                 capture_output=True,
             )
         except subprocess.CalledProcessError as exc:
-            stderr = exc.stderr.decode() if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+            stderr = (
+                exc.stderr.decode()
+                if isinstance(exc.stderr, bytes)
+                else (exc.stderr or "")
+            )
             if "user.name" in stderr or "user.email" in stderr or exc.returncode == 128:
                 raise SystemExit(
                     "Git identity not configured. Please run:\n"
@@ -90,3 +108,26 @@ def init_knowledge_dir(path: Path) -> Path:
             raise
 
     return path
+
+
+def copy_templates(dest: Path, *, force: bool = False) -> tuple[list[str], list[str]]:
+    """Copy bundled entity templates into *dest*.
+
+    Returns ``(written, skipped)`` lists of filenames. Without ``force``,
+    pre-existing destination files are skipped (not overwritten). With
+    ``force``, existing files are overwritten.
+    """
+    dest = dest.expanduser().resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+    template_pkg = importlib.resources.files("athenaeum.templates")
+    written: list[str] = []
+    skipped: list[str] = []
+    for fname in _TEMPLATE_FILES:
+        target = dest / fname
+        if target.exists() and not force:
+            skipped.append(fname)
+            continue
+        source = template_pkg / fname
+        target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+        written.append(fname)
+    return written, skipped

--- a/src/athenaeum/templates/__init__.py
+++ b/src/athenaeum/templates/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Markdown templates copied into the user's knowledge dir by `athenaeum init --with-templates`."""

--- a/src/athenaeum/templates/company.md
+++ b/src/athenaeum/templates/company.md
@@ -1,0 +1,38 @@
+---
+uid: company-REPLACE-ME
+type: company
+name: REPLACE ME
+hq_location: ""
+industry: ""
+website: ""
+linkedin_url: ""
+employee_count: 0
+tags: []
+# `source:` records where THIS wiki page came from. Scalar form is
+# `<type>:<ref>` (e.g. `manual:tristan` or `apollo:org-enrich-2026-05`).
+# Structured form lets you attach more provenance metadata:
+#   source:
+#     type: apollo
+#     ref: org-enrich-2026-05
+#     captured_at: 2026-05-08
+source: manual:user
+# `field_sources:` records per-field origin when fields come from
+# different places. Keys are field names; values follow the same
+# scalar/structured forms as `source:`.
+#   field_sources:
+#     industry: apollo:org-enrich-2026-05
+#     employee_count:
+#       type: linkedin
+#       ref: scrape-2026-04
+field_sources: {}
+---
+
+# REPLACE ME
+
+## What this is
+
+Brief description of the company and why it matters to you.
+
+## Notes
+
+- Observations, contacts, deal history, etc.

--- a/src/athenaeum/templates/concept.md
+++ b/src/athenaeum/templates/concept.md
@@ -1,0 +1,33 @@
+---
+uid: concept-REPLACE-ME
+type: concept
+name: REPLACE ME
+aliases: []
+tags: []
+# `source:` records where THIS wiki page came from. Scalar form is
+# `<type>:<ref>` (e.g. `manual:tristan` or `book:lean-startup-ch3`).
+# Structured form:
+#   source:
+#     type: book
+#     ref: lean-startup-ch3
+#     captured_at: 2026-05-08
+source: manual:user
+# `field_sources:` records per-field origin. Keys are field names;
+# values follow the same scalar/structured forms as `source:`.
+#   field_sources:
+#     aliases:
+#       type: manual
+#       ref: tristan
+field_sources: {}
+---
+
+# REPLACE ME
+
+## What this is
+
+One-paragraph definition of the concept in your own words.
+
+## Why it matters
+
+- When you'd reach for it.
+- Adjacent concepts.

--- a/src/athenaeum/templates/person.md
+++ b/src/athenaeum/templates/person.md
@@ -1,0 +1,39 @@
+---
+uid: person-REPLACE-ME
+type: person
+name: REPLACE ME
+emails: []
+phones: []
+current_title: ""
+current_company: ""
+linkedin_url: ""
+tags: []
+# `source:` records where THIS wiki page came from. Scalar form is
+# `<type>:<ref>` (e.g. `manual:tristan` or `linkedin:export-2026-04`).
+# Structured form lets you attach more provenance metadata:
+#   source:
+#     type: manual
+#     ref: tristan
+#     captured_at: 2026-05-08
+source: manual:user
+# `field_sources:` records where each FIELD on this page came from when
+# different fields have different origins (LLM enrichment vs manual edit
+# vs an external import). Keys are field names; values follow the same
+# scalar/structured forms as `source:`.
+#   field_sources:
+#     emails: linkedin:export-2026-04
+#     current_title:
+#       type: apollo
+#       ref: bulk-enrich-2026-05
+field_sources: {}
+---
+
+# REPLACE ME
+
+## What this is
+
+Brief one-sentence description of who this person is and why you're tracking them.
+
+## Notes
+
+- Add observations here. Keep them dated.

--- a/src/athenaeum/templates/project.md
+++ b/src/athenaeum/templates/project.md
@@ -1,0 +1,37 @@
+---
+uid: project-REPLACE-ME
+type: project
+name: REPLACE ME
+status: active
+start_date: ""
+end_date: ""
+owner: ""
+repo_url: ""
+tags: []
+# `source:` records where THIS wiki page came from. Scalar form is
+# `<type>:<ref>` (e.g. `manual:tristan`). Structured form:
+#   source:
+#     type: manual
+#     ref: tristan
+#     captured_at: 2026-05-08
+source: manual:user
+# `field_sources:` records per-field origin. Keys are field names;
+# values follow the same scalar/structured forms as `source:`.
+#   field_sources:
+#     status: manual:tristan
+#     repo_url:
+#       type: github
+#       ref: api-fetch-2026-05
+field_sources: {}
+---
+
+# REPLACE ME
+
+## What this is
+
+Brief description of the project — goal, scope, current phase.
+
+## Milestones
+
+- [ ] First milestone
+- [ ] Next milestone

--- a/src/athenaeum/templates/source.md
+++ b/src/athenaeum/templates/source.md
@@ -1,0 +1,36 @@
+---
+uid: source-REPLACE-ME
+type: source
+name: REPLACE ME
+url: ""
+author: ""
+published_at: ""
+medium: ""
+tags: []
+# `source:` records where THIS wiki page came from. For a `type: source`
+# entity this is usually `manual:user` (you decided to record this
+# reference). Scalar form is `<type>:<ref>`. Structured form:
+#   source:
+#     type: manual
+#     ref: tristan
+#     captured_at: 2026-05-08
+source: manual:user
+# `field_sources:` records per-field origin. Useful when the URL came
+# from one place but the author or published_at came from another.
+#   field_sources:
+#     author: manual:tristan
+#     published_at:
+#       type: web-fetch
+#       ref: meta-tag-2026-05
+field_sources: {}
+---
+
+# REPLACE ME
+
+## What this is
+
+A reference (article, book, podcast, talk, paper). One-sentence summary.
+
+## Key takeaways
+
+- Bullet the things you'd want to recall later.

--- a/tests/test_init_templates.py
+++ b/tests/test_init_templates.py
@@ -1,0 +1,127 @@
+"""Tests for `athenaeum init --with-templates` (issue #89)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from athenaeum.cli import main
+from athenaeum.init import _TEMPLATE_FILES, copy_templates
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    assert text.startswith("---\n"), "missing frontmatter"
+    rest = text[4:]
+    end = rest.index("\n---")
+    return rest[:end], rest[end + 4 :]
+
+
+def test_with_templates_creates_five_files(tmp_path: Path) -> None:
+    target = tmp_path / "knowledge"
+    exit_code = main(["init", "--path", str(target), "--with-templates"])
+    assert exit_code == 0
+    dest = target / "templates"
+    for fname in _TEMPLATE_FILES:
+        assert (dest / fname).is_file(), f"missing template: {fname}"
+    assert len(list(dest.glob("*.md"))) == 5
+
+
+def test_each_template_parses_yaml(tmp_path: Path) -> None:
+    dest = tmp_path / "templates"
+    copy_templates(dest)
+    for fname in _TEMPLATE_FILES:
+        text = (dest / fname).read_text(encoding="utf-8")
+        fm, _ = _split_frontmatter(text)
+        # yaml.safe_load must accept the frontmatter without error.
+        meta = yaml.safe_load(fm)
+        assert isinstance(meta, dict), f"frontmatter not a dict: {fname}"
+
+
+def test_template_type_matches_basename(tmp_path: Path) -> None:
+    dest = tmp_path / "templates"
+    copy_templates(dest)
+    for fname in _TEMPLATE_FILES:
+        expected_type = fname[:-3]  # strip ".md"
+        text = (dest / fname).read_text(encoding="utf-8")
+        fm, _ = _split_frontmatter(text)
+        meta = yaml.safe_load(fm)
+        assert (
+            meta.get("type") == expected_type
+        ), f"{fname}: type={meta.get('type')!r} != {expected_type!r}"
+
+
+def test_template_includes_source_and_field_sources_with_comments(
+    tmp_path: Path,
+) -> None:
+    dest = tmp_path / "templates"
+    copy_templates(dest)
+    for fname in _TEMPLATE_FILES:
+        raw = (dest / fname).read_text(encoding="utf-8")
+        assert "source:" in raw, f"{fname}: no source: key"
+        assert "field_sources:" in raw, f"{fname}: no field_sources: key"
+        # Explanatory comments preserved (string-contains).
+        assert "# `source:`" in raw, f"{fname}: missing source: comment"
+        assert "# `field_sources:`" in raw, f"{fname}: missing field_sources: comment"
+        # Both scalar and structured forms documented.
+        assert "<type>:<ref>" in raw, f"{fname}: scalar form not documented"
+        assert (
+            "type:" in raw and "ref:" in raw
+        ), f"{fname}: structured form not documented"
+
+
+def test_rerun_without_force_is_idempotent(tmp_path: Path) -> None:
+    dest = tmp_path / "templates"
+    written1, skipped1 = copy_templates(dest)
+    assert sorted(written1) == sorted(_TEMPLATE_FILES)
+    assert skipped1 == []
+
+    # User edits a template.
+    user_edit = "---\nuid: my-edit\n---\n\nuser content\n"
+    (dest / "person.md").write_text(user_edit, encoding="utf-8")
+
+    written2, skipped2 = copy_templates(dest)
+    assert written2 == []
+    assert sorted(skipped2) == sorted(_TEMPLATE_FILES)
+    assert (dest / "person.md").read_text(encoding="utf-8") == user_edit
+
+
+def test_force_overwrites_cleanly(tmp_path: Path) -> None:
+    dest = tmp_path / "templates"
+    copy_templates(dest)
+
+    (dest / "person.md").write_text("custom\n", encoding="utf-8")
+    written, skipped = copy_templates(dest, force=True)
+    assert sorted(written) == sorted(_TEMPLATE_FILES)
+    assert skipped == []
+    # Restored to bundled content.
+    text = (dest / "person.md").read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert "type: person" in text
+
+
+def test_cli_templates_dest_override(tmp_path: Path) -> None:
+    target = tmp_path / "knowledge"
+    custom_dest = tmp_path / "elsewhere" / "tpls"
+    exit_code = main(
+        [
+            "init",
+            "--path",
+            str(target),
+            "--with-templates",
+            "--templates-dest",
+            str(custom_dest),
+        ]
+    )
+    assert exit_code == 0
+    for fname in _TEMPLATE_FILES:
+        assert (custom_dest / fname).is_file()
+    # Default location not used.
+    assert not (target / "templates").exists()
+
+
+def test_init_without_flag_does_not_copy_templates(tmp_path: Path) -> None:
+    target = tmp_path / "knowledge"
+    exit_code = main(["init", "--path", str(target)])
+    assert exit_code == 0
+    assert not (target / "templates").exists()


### PR DESCRIPTION
## Summary

Adds five bundled entity-author markdown templates and wires them through `athenaeum init --with-templates`.

- New `src/athenaeum/templates/` directory shipping `person.md`, `company.md`, `project.md`, `concept.md`, `source.md`.
- `pyproject.toml` includes `src/athenaeum/templates/**/*.md` in the wheel (mirrors the existing `schema/**/*.md` pattern).
- `init` subparser gains `--with-templates`, `--templates-dest`, and `--force`. Default destination is `<knowledge_root>/templates/`. Without `--force`, pre-existing files are skipped with a clear message.
- Each template carries `source:` and `field_sources:` frontmatter with inline comments showing both scalar (`<type>:<ref>`) and structured forms required by Lane B / #90.

## Distinct from existing `src/athenaeum/schema/**/*.md`

Reviewers: these are NOT the same as the existing schema files.

- `src/athenaeum/schema/*.md` (`types.md`, `tags.md`, `access-levels.md`, `observation-filter.md`, `_entity-template.md`) — LLM-tier wiki contract; copied into `wiki/_schema/` on every `init`; describes how the compilation pipeline reads/writes wiki entries.
- `src/athenaeum/templates/*.md` (this PR) — user-facing entity scaffolds; copied into `<knowledge_root>/templates/` only when `--with-templates` is passed; intended as starting points the human (or an agent) duplicates when authoring a new entity.

## Sample template (`person.md`)

```markdown
---
uid: person-REPLACE-ME
type: person
name: REPLACE ME
emails: []
phones: []
current_title: ""
current_company: ""
linkedin_url: ""
tags: []
# `source:` records where THIS wiki page came from. Scalar form is
# `<type>:<ref>` (e.g. `manual:tristan` or `linkedin:export-2026-04`).
# Structured form lets you attach more provenance metadata:
#   source:
#     type: manual
#     ref: tristan
#     captured_at: 2026-05-08
source: manual:user
# `field_sources:` records where each FIELD on this page came from when
# different fields have different origins (LLM enrichment vs manual edit
# vs an external import). Keys are field names; values follow the same
# scalar/structured forms as `source:`.
#   field_sources:
#     emails: linkedin:export-2026-04
#     current_title:
#       type: apollo
#       ref: bulk-enrich-2026-05
field_sources: {}
---

# REPLACE ME

## What this is

Brief one-sentence description of who this person is and why you're tracking them.

## Notes

- Add observations here. Keep them dated.
```

## Test plan

- [x] `pytest tests/test_init_templates.py` (8 tests, all green)
- [x] `pytest tests/test_init.py tests/test_cli.py` (existing tests unaffected)
- [x] `python -c "import importlib.resources; print(list(importlib.resources.files('athenaeum.templates').iterdir()))"` lists the five `.md` files
- [ ] CI green on this PR

Closes #89
