### PR TITLE
feat(dedupe): port person dedup from cwc scripts (#85)

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -285,6 +285,48 @@ def main(argv: list[str] | None = None) -> int:
         help="Override configured backend (default: read from athenaeum.yaml)",
     )
 
+    # dedupe command — find / merge duplicate person wikis
+    dedupe_parser = subparsers.add_parser(
+        "dedupe",
+        help="Find or merge duplicate wiki entries.",
+    )
+    dedupe_sub = dedupe_parser.add_subparsers(dest="dedupe_target")
+    dedupe_persons = dedupe_sub.add_parser(
+        "persons",
+        help="Person-wiki dedupe (HIGH-confidence apollo_id / linkedin / "
+        "exact-name match). Default --find prints a YAML report; "
+        "--apply consumes the report and merges.",
+    )
+    dedupe_persons.add_argument(
+        "--find",
+        action="store_true",
+        help="Discover duplicate pairs and write a YAML report.",
+    )
+    dedupe_persons.add_argument(
+        "--apply",
+        action="store_true",
+        help="Read a report and perform the merge (idempotent).",
+    )
+    dedupe_persons.add_argument(
+        "--wiki-root",
+        type=Path,
+        default=None,
+        help="Wiki directory (default: ~/knowledge/wiki).",
+    )
+    dedupe_persons.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Path to write the YAML report (default: stdout). --find only.",
+    )
+    dedupe_persons.add_argument(
+        "--from",
+        dest="from_path",
+        type=Path,
+        default=None,
+        help="Path to the YAML report to apply (default: stdin). --apply only.",
+    )
+
     # repair command — frontmatter YAML repair tools (tag-indent, value-quoting)
     repair_parser = subparsers.add_parser(
         "repair",
@@ -384,10 +426,69 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "stopwords":
         return _cmd_stopwords(args)
 
+    if args.command == "dedupe":
+        return _cmd_dedupe(args)
+
     if args.command == "repair":
         return _cmd_repair(args)
 
     return 0
+
+
+def _cmd_dedupe(args: argparse.Namespace) -> int:
+    """Dispatch ``athenaeum dedupe persons --find|--apply``."""
+    from athenaeum.dedupe import (
+        find_duplicate_persons,
+        merge_duplicate_persons,
+        pairs_from_yaml,
+        pairs_to_yaml,
+    )
+
+    target = getattr(args, "dedupe_target", None)
+    if target != "persons":
+        print("usage: athenaeum dedupe persons [--find | --apply] ...", file=sys.stderr)
+        return 2
+
+    wiki_root = (args.wiki_root or Path("~/knowledge/wiki")).expanduser().resolve()
+
+    if args.find and args.apply:
+        print("error: pass either --find or --apply, not both", file=sys.stderr)
+        return 2
+    if not args.find and not args.apply:
+        print("error: pass --find or --apply", file=sys.stderr)
+        return 2
+
+    if args.find:
+        if not wiki_root.is_dir():
+            print(f"Wiki root not found: {wiki_root}", file=sys.stderr)
+            return 1
+        pairs = find_duplicate_persons(wiki_root)
+        report = pairs_to_yaml(pairs)
+        if args.out:
+            args.out.parent.mkdir(parents=True, exist_ok=True)
+            args.out.write_text(report, encoding="utf-8")
+            print(f"Wrote {len(pairs)} pair(s) → {args.out}", file=sys.stderr)
+        else:
+            sys.stdout.write(report)
+        return 0
+
+    # --apply
+    if args.from_path:
+        text = args.from_path.read_text(encoding="utf-8")
+    else:
+        text = sys.stdin.read()
+    pairs = pairs_from_yaml(text)
+    merge_report = merge_duplicate_persons(pairs, apply=True, wiki_root=wiki_root)
+    print(
+        f"merged={merge_report.merged} "
+        f"already_merged={merge_report.already_merged} "
+        f"missing_canonical={merge_report.missing_canonical} "
+        f"skipped_parse={merge_report.skipped_parse} "
+        f"errors={len(merge_report.errors)}"
+    )
+    for err in merge_report.errors:
+        print(f"  ERROR: {err}", file=sys.stderr)
+    return 0 if not merge_report.errors else 1
 
 
 def _cmd_init(args: argparse.Namespace) -> int:

--- a/src/athenaeum/dedupe.py
+++ b/src/athenaeum/dedupe.py
@@ -1,0 +1,556 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Person-wiki dedupe — find HIGH-confidence duplicate pairs and merge them.
+
+Ported from the cwc-side scripts ``find_duplicate_persons.py`` and
+``merge_duplicate_persons.py``. Behavior preserved for the HIGH-confidence
+tier (apollo_id / linkedin_url / exact normalized name); MEDIUM-tier
+fuzzy-name matching is intentionally dropped from the public API surface
+because it requires human triage and the CSV worksheet round-trip — that
+workflow stays in the cwc scripts.
+
+Per-claim provenance preservation (issue #90):
+
+- Scalar fields: canonical wins; canonical's ``field_sources.<field>``
+  is preserved verbatim.
+- List fields (emails, tags, aliases, …): the union of values is taken
+  with canonical-first ordering. When the absorbed wiki carried a
+  ``field_sources.<list_field>`` for a list whose values came from it,
+  that attribution survives in the merged ``field_sources`` map: the
+  canonical's entry wins on the key (matches the canonical-first list
+  ordering) but if canonical had no entry, the absorbed entry is kept.
+- Wiki-level ``source``: canonical wins. The absorbed wiki's
+  ``source`` is recorded in a merge audit trail under
+  ``merged_from_sources: {<absorbed_uid>: <absorbed_source>}`` so
+  attribution is recoverable without resurrecting the absorbed file.
+
+Idempotence: ``merge_duplicate_persons(..., apply=True)`` is a no-op on
+already-merged pairs (absorbed file missing → ``already_merged`` count).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+from athenaeum.models import parse_frontmatter, render_frontmatter
+
+# Honorifics + suffixes to drop before name matching.
+_HONORIFICS = {
+    "dr",
+    "dr.",
+    "mr",
+    "mr.",
+    "mrs",
+    "mrs.",
+    "ms",
+    "ms.",
+    "prof",
+    "prof.",
+    "professor",
+    "sir",
+    "hon",
+    "hon.",
+}
+_SUFFIXES = {"jr", "jr.", "sr", "sr.", "ii", "iii", "iv", "phd", "md", "esq"}
+
+# Frontmatter keys merged with MAX semantics.
+_MAX_KEYS_NUMERIC = {"warm_score", "meeting_count_24mo", "sent_count_24mo"}
+_MAX_KEYS_DATE = {"last_touch", "updated", "apollo_enriched_on"}
+
+# Apollo / LinkedIn / Google namespaces — coalesce (canonical wins).
+_APOLLO_KEYS = {
+    "apollo_id",
+    "apollo_headline",
+    "apollo_location",
+    "apollo_employment_history",
+    "current_title",
+    "current_company",
+}
+_LINKEDIN_KEYS = {
+    "linkedin_url",
+    "linkedin_position_at_connect",
+    "linkedin_company_at_connect",
+    "linkedin_connected_on",
+}
+_GOOGLE_KEYS = {
+    "google_contact",
+    "google_contact_kromatic",
+    "google_contact_tristankromer",
+}
+
+# Fields where "list union with canonical-first order" is the merge rule.
+_LIST_UNION_KEYS = {"emails", "tags", "aliases"}
+
+
+# --- Public types ---
+
+
+@dataclass
+class DuplicatePair:
+    """A HIGH-confidence duplicate-person pair.
+
+    Attributes:
+        canonical_uid: uid of the wiki that wins the merge.
+        absorbed_uid: uid of the wiki to be absorbed (deleted on apply).
+        match_signal: one of ``"apollo_id"``, ``"linkedin_url"``,
+            ``"name_exact"``.
+        confidence: always ``"HIGH"`` for pairs returned by
+            :func:`find_duplicate_persons` — kept on the dataclass for
+            JSONL/YAML round-trip compatibility with the cwc worksheet.
+        canonical_path: absolute path to the canonical wiki file.
+        absorbed_path: absolute path to the absorbed wiki file.
+    """
+
+    canonical_uid: str
+    absorbed_uid: str
+    match_signal: str
+    confidence: str = "HIGH"
+    canonical_path: str = ""
+    absorbed_path: str = ""
+
+
+@dataclass
+class MergeReport:
+    """Outcome of a merge run."""
+
+    merged: int = 0
+    already_merged: int = 0
+    missing_canonical: int = 0
+    missing_absorbed: int = 0
+    skipped_parse: int = 0
+    errors: list[str] = field(default_factory=list)
+    dry_run: bool = False
+
+
+# --- Name / URL normalization ---
+
+
+def _normalize_name(name: str) -> str:
+    s = name.lower().strip()
+    s = re.sub(r"\([^)]*\)", " ", s)
+    s = re.sub(r"\b(dr|mr|mrs|ms|prof|hon|sir)\.(\S)", r"\1. \2", s)
+    s = re.sub(r"[^\w\s.\-']", " ", s, flags=re.UNICODE)
+    tokens = [
+        t.strip(".")
+        for t in s.split()
+        if t.strip(".")
+        and t not in _HONORIFICS
+        and t.strip(".") not in _HONORIFICS
+        and t not in _SUFFIXES
+        and t.strip(".") not in _SUFFIXES
+    ]
+    return " ".join(tokens)
+
+
+def _canonical_linkedin(url: str) -> str:
+    if not url:
+        return ""
+    u = url.strip().lower()
+    u = re.sub(r"^https?://(www\.)?", "", u)
+    u = u.rstrip("/")
+    u = u.split("?")[0]
+    return u
+
+
+# --- Wiki loading ---
+
+
+def _load_persons(wiki_root: Path) -> list[dict[str, Any]]:
+    persons: list[dict[str, Any]] = []
+    for path in sorted(wiki_root.glob("*.md")):
+        if path.name.startswith("_"):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        meta, _body = parse_frontmatter(text)
+        if not meta or meta.get("type") != "person":
+            continue
+        name = str(meta.get("name") or "")
+        uid = str(meta.get("uid") or "")
+        if not name or not uid:
+            continue
+        emails = meta.get("emails") or []
+        if not isinstance(emails, list):
+            emails = []
+        persons.append(
+            {
+                "path": path,
+                "uid": uid,
+                "name": name,
+                "normalized": _normalize_name(name),
+                "emails": [str(e).lower() for e in emails],
+                "linkedin": _canonical_linkedin(str(meta.get("linkedin_url") or "")),
+                "apollo_id": str(meta.get("apollo_id") or ""),
+                "warm_score": meta.get("warm_score"),
+                "updated": str(meta.get("updated") or ""),
+            }
+        )
+    return persons
+
+
+# --- Discovery ---
+
+
+def _pair_key(uid_a: str, uid_b: str) -> tuple[str, str]:
+    return (uid_a, uid_b) if uid_a < uid_b else (uid_b, uid_a)
+
+
+def _pick_canonical(
+    a: dict[str, Any], b: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Apollo-enriched > higher warm_score > more emails > recently updated."""
+
+    def score(p: dict[str, Any]) -> tuple[int, float, int, str]:
+        try:
+            ws = float(p["warm_score"] or 0)
+        except (ValueError, TypeError):
+            ws = 0.0
+        return (1 if p["apollo_id"] else 0, ws, len(p["emails"]), p["updated"])
+
+    return (a, b) if score(a) >= score(b) else (b, a)
+
+
+def find_duplicate_persons(wiki_root: Path) -> list[DuplicatePair]:
+    """Surface HIGH-confidence duplicate-person pairs.
+
+    HIGH-confidence signals (preserved from the cwc-side script):
+
+    - shared ``apollo_id``
+    - shared canonicalized ``linkedin_url``
+    - exact-match normalized ``name`` (group size 2 or 3 — name buckets
+      with 4+ wikis are dropped here as common-name false-positives,
+      matching the script's MEDIUM downgrade)
+
+    The MEDIUM tier (fuzzy-name token Jaccard ≥ 0.8) is intentionally
+    not surfaced through this API — that path requires human triage via
+    the CSV worksheet workflow which lives in the cwc scripts.
+    """
+    persons = _load_persons(wiki_root)
+    seen: dict[tuple[str, str], DuplicatePair] = {}
+
+    def record(a: dict[str, Any], b: dict[str, Any], signal: str) -> None:
+        if a["uid"] == b["uid"]:
+            return
+        key = _pair_key(a["uid"], b["uid"])
+        if key in seen:
+            return  # first signal wins (apollo > linkedin > name_exact)
+        canonical, absorbed = _pick_canonical(a, b)
+        seen[key] = DuplicatePair(
+            canonical_uid=canonical["uid"],
+            absorbed_uid=absorbed["uid"],
+            match_signal=signal,
+            confidence="HIGH",
+            canonical_path=str(canonical["path"]),
+            absorbed_path=str(absorbed["path"]),
+        )
+
+    by_apollo: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for p in persons:
+        if p["apollo_id"]:
+            by_apollo[p["apollo_id"]].append(p)
+    for group in by_apollo.values():
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                record(group[i], group[j], "apollo_id")
+
+    by_linkedin: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for p in persons:
+        if p["linkedin"]:
+            by_linkedin[p["linkedin"]].append(p)
+    for group in by_linkedin.values():
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                record(group[i], group[j], "linkedin_url")
+
+    by_name: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for p in persons:
+        if p["normalized"]:
+            by_name[p["normalized"]].append(p)
+    for group in by_name.values():
+        # 2-3 wikis with the same normalized name = HIGH; 4+ = ambiguous
+        # common name (the cwc script flags those MEDIUM and routes to
+        # the CSV; here we drop them since this API is HIGH-only).
+        if len(group) < 2 or len(group) > 3:
+            continue
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                record(group[i], group[j], "name_exact")
+
+    return list(seen.values())
+
+
+# --- Merge primitives (provenance-aware) ---
+
+
+def _union_list(a: list | None, b: list | None) -> list:
+    out: list = []
+    seen_keys: set = set()
+    for item in (a or []) + (b or []):
+        key = repr(item) if isinstance(item, (dict, list)) else item
+        if key not in seen_keys:
+            seen_keys.add(key)
+            out.append(item)
+    return out
+
+
+def _coalesce(a: Any, b: Any) -> Any:
+    return a if a else b
+
+
+def _max_numeric(a: Any, b: Any) -> Any:
+    def f(x: Any) -> float:
+        try:
+            return float(x)
+        except (TypeError, ValueError):
+            return float("-inf")
+
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if f(a) >= f(b) else b
+
+
+def _max_date(a: Any, b: Any) -> Any:
+    if not a:
+        return b
+    if not b:
+        return a
+    return a if str(a) >= str(b) else b
+
+
+def _merge_field_sources(
+    canonical_meta: dict[str, Any],
+    absorbed_meta: dict[str, Any],
+    merged_meta: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Build the merged ``field_sources`` map.
+
+    Rules (per #90):
+
+    - Canonical's ``field_sources.<key>`` always wins.
+    - For keys that exist on absorbed's ``field_sources`` but not
+      canonical's, the absorbed entry is carried forward — this is how
+      per-value attribution survives for list fields whose values came
+      from the absorbed wiki only.
+    - Keys whose merged value is absent from the merged frontmatter are
+      pruned (don't keep dangling attributions).
+    """
+    cfs = canonical_meta.get("field_sources") or {}
+    afs = absorbed_meta.get("field_sources") or {}
+    if not isinstance(cfs, dict):
+        cfs = {}
+    if not isinstance(afs, dict):
+        afs = {}
+    if not cfs and not afs:
+        return None
+    merged: dict[str, Any] = {}
+    for k, v in afs.items():
+        if k in merged_meta:
+            merged[k] = v
+    for k, v in cfs.items():
+        if k in merged_meta:
+            merged[k] = v  # canonical overrides
+    return merged or None
+
+
+def _merge_meta(
+    canonical: dict[str, Any], absorbed: dict[str, Any], absorbed_uid: str
+) -> dict[str, Any]:
+    out = dict(canonical)
+
+    # List unions
+    for k in _LIST_UNION_KEYS:
+        merged = _union_list(canonical.get(k), absorbed.get(k))
+        if merged:
+            out[k] = merged
+    if absorbed.get("name") and absorbed["name"] != canonical.get("name"):
+        out["aliases"] = _union_list(out.get("aliases"), [absorbed["name"]])
+
+    # Google fields
+    for k in _GOOGLE_KEYS:
+        merged_v = _coalesce(canonical.get(k), absorbed.get(k))
+        if merged_v:
+            out[k] = merged_v
+    if (
+        canonical.get("google_contact")
+        and absorbed.get("google_contact")
+        and canonical["google_contact"] != absorbed["google_contact"]
+    ):
+        for kspec in ("google_contact_kromatic", "google_contact_tristankromer"):
+            if absorbed.get(kspec) and not canonical.get(kspec):
+                out[kspec] = absorbed[kspec]
+
+    # Apollo + LinkedIn coalesce
+    for k in _APOLLO_KEYS | _LINKEDIN_KEYS:
+        merged_v = _coalesce(canonical.get(k), absorbed.get(k))
+        if merged_v is not None:
+            out[k] = merged_v
+
+    # MAX-merge numeric/date fields
+    for k in _MAX_KEYS_NUMERIC:
+        merged_v = _max_numeric(canonical.get(k), absorbed.get(k))
+        if merged_v is not None and merged_v != float("-inf"):
+            out[k] = merged_v
+    for k in _MAX_KEYS_DATE:
+        merged_v = _max_date(canonical.get(k), absorbed.get(k))
+        if merged_v:
+            out[k] = merged_v
+
+    # Stamp updated + audit trail
+    out["updated"] = date.today().isoformat()
+    merged_from = list(out.get("merged_from") or [])
+    if absorbed_uid not in merged_from:
+        merged_from.append(absorbed_uid)
+    out["merged_from"] = merged_from
+
+    # Wiki-level source: canonical wins; absorbed source archived.
+    absorbed_source = absorbed.get("source")
+    if absorbed_source is not None:
+        mfs = dict(out.get("merged_from_sources") or {})
+        mfs[absorbed_uid] = absorbed_source
+        out["merged_from_sources"] = mfs
+
+    # Per-claim field_sources merge
+    new_fs = _merge_field_sources(canonical, absorbed, out)
+    if new_fs is not None:
+        out["field_sources"] = new_fs
+    elif "field_sources" in out:
+        del out["field_sources"]
+
+    return out
+
+
+def _merge_body(canonical_body: str, absorbed_body: str, absorbed_uid: str) -> str:
+    absorbed_stripped = (absorbed_body or "").strip()
+    if not absorbed_stripped:
+        return canonical_body
+    canonical_stripped = (canonical_body or "").strip()
+    if not canonical_stripped:
+        return absorbed_body
+    if absorbed_stripped in canonical_stripped:
+        return canonical_body
+    return (
+        canonical_body.rstrip()
+        + "\n\n"
+        + f"## Merged from {absorbed_uid}\n\n"
+        + absorbed_stripped
+        + "\n"
+    )
+
+
+def _perform_merge(canonical_path: Path, absorbed_path: Path, dry_run: bool) -> str:
+    canonical_text = canonical_path.read_text(encoding="utf-8")
+    absorbed_text = absorbed_path.read_text(encoding="utf-8")
+    cmeta, cbody = parse_frontmatter(canonical_text)
+    ameta, abody = parse_frontmatter(absorbed_text)
+    if not cmeta or not ameta:
+        return f"SKIP_PARSE:{canonical_path.name}|{absorbed_path.name}"
+    canonical_uid = str(cmeta.get("uid") or "")
+    absorbed_uid = str(ameta.get("uid") or "")
+    if not canonical_uid or not absorbed_uid:
+        return f"SKIP_NO_UID:{absorbed_path.name}"
+
+    new_meta = _merge_meta(cmeta, ameta, absorbed_uid)
+    new_body = _merge_body(cbody, abody, absorbed_uid)
+    new_text = render_frontmatter(new_meta) + "\n" + new_body
+
+    if dry_run:
+        return f"WOULD_MERGE:{absorbed_uid}->{canonical_uid}"
+
+    canonical_path.write_text(new_text, encoding="utf-8")
+    absorbed_path.unlink()
+    return f"MERGED:{absorbed_uid}->{canonical_uid}"
+
+
+def merge_duplicate_persons(
+    pairs: Iterable[DuplicatePair],
+    apply: bool = False,
+    wiki_root: Path | None = None,
+) -> MergeReport:
+    """Merge a list of duplicate pairs.
+
+    Idempotent: pairs whose absorbed file is already gone are counted
+    under ``already_merged`` and skipped. Defaults to dry-run; pass
+    ``apply=True`` to write changes.
+
+    ``wiki_root`` is used only to resolve relative paths recorded on
+    :class:`DuplicatePair` — absolute paths bypass it.
+    """
+    report = MergeReport(dry_run=not apply)
+    for pair in pairs:
+        cpath = Path(pair.canonical_path)
+        apath = Path(pair.absorbed_path)
+        if not cpath.is_absolute() and wiki_root is not None:
+            cpath = wiki_root / cpath
+        if not apath.is_absolute() and wiki_root is not None:
+            apath = wiki_root / apath
+        if not cpath.exists():
+            report.missing_canonical += 1
+            continue
+        if not apath.exists():
+            report.already_merged += 1
+            continue
+        try:
+            outcome = _perform_merge(cpath, apath, dry_run=not apply)
+        except (OSError, UnicodeDecodeError) as exc:
+            report.errors.append(f"{pair.absorbed_uid}: {exc}")
+            continue
+        if outcome.startswith("SKIP_PARSE"):
+            report.skipped_parse += 1
+        elif outcome.startswith("MERGED") or outcome.startswith("WOULD_MERGE"):
+            report.merged += 1
+    return report
+
+
+# --- Report I/O for CLI plumbing ---
+
+
+def pairs_to_yaml(pairs: list[DuplicatePair]) -> str:
+    """Serialize pairs as a YAML document (list of dicts)."""
+    return yaml.safe_dump(
+        [asdict(p) for p in pairs],
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+
+
+def pairs_from_yaml(text: str) -> list[DuplicatePair]:
+    """Parse pairs back from YAML produced by :func:`pairs_to_yaml`."""
+    raw = yaml.safe_load(text) or []
+    if not isinstance(raw, list):
+        raise ValueError("dedupe report must be a YAML list")
+    out: list[DuplicatePair] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError(f"dedupe entry must be a dict, got {type(item).__name__}")
+        out.append(
+            DuplicatePair(
+                canonical_uid=str(item["canonical_uid"]),
+                absorbed_uid=str(item["absorbed_uid"]),
+                match_signal=str(item["match_signal"]),
+                confidence=str(item.get("confidence", "HIGH")),
+                canonical_path=str(item.get("canonical_path", "")),
+                absorbed_path=str(item.get("absorbed_path", "")),
+            )
+        )
+    return out
+
+
+__all__ = [
+    "DuplicatePair",
+    "MergeReport",
+    "find_duplicate_persons",
+    "merge_duplicate_persons",
+    "pairs_to_yaml",
+    "pairs_from_yaml",
+]

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``athenaeum.dedupe`` — HIGH-confidence person dedupe + merge.
+
+Covers the four cwc-script signals (apollo_id / linkedin / name_exact),
+the per-claim ``field_sources`` preservation contract from #90, and
+idempotency of repeated ``--apply`` runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athenaeum.dedupe import (
+    DuplicatePair,
+    find_duplicate_persons,
+    merge_duplicate_persons,
+    pairs_from_yaml,
+    pairs_to_yaml,
+)
+from athenaeum.models import parse_frontmatter
+
+
+def _write_person(
+    wiki_root: Path,
+    *,
+    uid: str,
+    name: str,
+    apollo_id: str = "",
+    linkedin_url: str = "",
+    emails: list[str] | None = None,
+    source: str | None = None,
+    field_sources: dict | None = None,
+    extra: dict | None = None,
+) -> Path:
+    lines = ["---", f"uid: {uid}", "type: person", f"name: {name}"]
+    if apollo_id:
+        lines.append(f"apollo_id: {apollo_id}")
+    if linkedin_url:
+        lines.append(f"linkedin_url: {linkedin_url}")
+    if emails:
+        lines.append("emails:")
+        for e in emails:
+            lines.append(f"  - {e}")
+    if source is not None:
+        lines.append(f"source: {source}")
+    if field_sources is not None:
+        import yaml as _yaml
+
+        lines.append("field_sources:")
+        for k, v in field_sources.items():
+            # render as nested map
+            lines.append(f"  {k}: {_yaml.safe_dump(v).strip()}")
+    if extra:
+        for k, v in extra.items():
+            lines.append(f"{k}: {v}")
+    lines.append("---")
+    lines.append("")
+    lines.append(f"Body for {name}.")
+    path = wiki_root / f"{uid}-{name.lower().replace(' ', '-')}.md"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def wiki_root(tmp_path: Path) -> Path:
+    root = tmp_path / "wiki"
+    root.mkdir()
+    return root
+
+
+class TestFindDuplicatePersons:
+    def test_apollo_id_match(self, wiki_root: Path) -> None:
+        _write_person(wiki_root, uid="aaaa1111", name="Alice Smith", apollo_id="apo-1")
+        _write_person(wiki_root, uid="aaaa2222", name="Alice S.", apollo_id="apo-1")
+        pairs = find_duplicate_persons(wiki_root)
+        assert len(pairs) == 1
+        assert pairs[0].match_signal == "apollo_id"
+        assert pairs[0].confidence == "HIGH"
+        assert {pairs[0].canonical_uid, pairs[0].absorbed_uid} == {
+            "aaaa1111",
+            "aaaa2222",
+        }
+
+    def test_linkedin_match(self, wiki_root: Path) -> None:
+        _write_person(
+            wiki_root,
+            uid="bbbb1111",
+            name="Bob Jones",
+            linkedin_url="https://www.linkedin.com/in/bobjones/",
+        )
+        _write_person(
+            wiki_root,
+            uid="bbbb2222",
+            name="Robert Jones",
+            linkedin_url="https://linkedin.com/in/bobjones",
+        )
+        pairs = find_duplicate_persons(wiki_root)
+        assert len(pairs) == 1
+        assert pairs[0].match_signal == "linkedin_url"
+
+    def test_name_exact_match(self, wiki_root: Path) -> None:
+        _write_person(wiki_root, uid="cccc1111", name="Carol Diaz")
+        _write_person(wiki_root, uid="cccc2222", name="Dr. Carol Diaz")
+        pairs = find_duplicate_persons(wiki_root)
+        assert len(pairs) == 1
+        assert pairs[0].match_signal == "name_exact"
+
+    def test_no_duplicates(self, wiki_root: Path) -> None:
+        _write_person(wiki_root, uid="dddd1111", name="Eve Adams")
+        _write_person(wiki_root, uid="dddd2222", name="Frank Brown")
+        assert find_duplicate_persons(wiki_root) == []
+
+    def test_common_name_4plus_dropped(self, wiki_root: Path) -> None:
+        # 4 wikis with the same normalized name → ambiguous, dropped from
+        # the HIGH-only public API.
+        for i in range(4):
+            _write_person(wiki_root, uid=f"eeee000{i}", name="John Smith")
+        assert find_duplicate_persons(wiki_root) == []
+
+
+class TestMergePreservesFieldSources:
+    def test_list_union_preserves_per_value_attribution(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="11111111",
+            name="Alice Canon",
+            apollo_id="apo-x",
+            emails=["alice@canonical.com"],
+            field_sources={"emails": "google:contact-1"},
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="22222222",
+            name="Alice Absorb",
+            apollo_id="apo-x",
+            emails=["alice@absorbed.com"],
+            field_sources={"emails": "linkedin:profile-2"},
+        )
+        # Force canonical = 11111111 by giving it more emails / apollo
+        pair = DuplicatePair(
+            canonical_uid="11111111",
+            absorbed_uid="22222222",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        report = merge_duplicate_persons([pair], apply=True)
+        assert report.merged == 1
+        meta, _body = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        # Union of emails preserved
+        assert "alice@canonical.com" in meta["emails"]
+        assert "alice@absorbed.com" in meta["emails"]
+        # Canonical's field_sources entry wins on the key (canonical-first
+        # ordering matches scalar-source semantics; per-value attribution
+        # is documented as the canonical-first list rule).
+        assert meta["field_sources"]["emails"] == "google:contact-1"
+
+    def test_absorbed_only_field_sources_carries_forward(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="33333333",
+            name="Bob Canon",
+            apollo_id="apo-y",
+            emails=["bob@canonical.com"],
+            source="claude:session-canon",
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="44444444",
+            name="Bob Absorb",
+            apollo_id="apo-y",
+            emails=["bob@absorbed.com"],
+            source="apollo:export-2026",
+            field_sources={"emails": "apollo:export-2026"},
+        )
+        pair = DuplicatePair(
+            canonical_uid="33333333",
+            absorbed_uid="44444444",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        # Absorbed-only emails attribution carried forward
+        assert meta["field_sources"]["emails"] == "apollo:export-2026"
+        # Wiki-level source: canonical wins
+        assert meta["source"] == "claude:session-canon"
+        # Absorbed source archived in audit trail
+        assert meta["merged_from_sources"]["44444444"] == "apollo:export-2026"
+        # Audit trail uid recorded
+        assert "44444444" in meta["merged_from"]
+
+
+class TestIdempotency:
+    def test_apply_twice_is_noop(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="55555555",
+            name="Carol Canon",
+            apollo_id="apo-z",
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="66666666",
+            name="Carol Absorb",
+            apollo_id="apo-z",
+        )
+        pair = DuplicatePair(
+            canonical_uid="55555555",
+            absorbed_uid="66666666",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        r1 = merge_duplicate_persons([pair], apply=True)
+        assert r1.merged == 1
+        assert not apath.exists()
+        # Second run: absorbed is gone → already_merged path.
+        r2 = merge_duplicate_persons([pair], apply=True)
+        assert r2.merged == 0
+        assert r2.already_merged == 1
+
+
+class TestReportRoundtrip:
+    def test_yaml_roundtrip(self, wiki_root: Path) -> None:
+        _write_person(wiki_root, uid="77777777", name="Dee", apollo_id="apo-q")
+        _write_person(wiki_root, uid="88888888", name="Dee", apollo_id="apo-q")
+        pairs = find_duplicate_persons(wiki_root)
+        text = pairs_to_yaml(pairs)
+        roundtripped = pairs_from_yaml(text)
+        assert len(roundtripped) == 1
+        assert roundtripped[0].canonical_uid == pairs[0].canonical_uid
+        assert roundtripped[0].absorbed_uid == pairs[0].absorbed_uid
+        assert roundtripped[0].match_signal == pairs[0].match_signal
+
+
+class TestDryRun:
+    def test_dry_run_does_not_modify(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="99999999",
+            name="Ed",
+            apollo_id="apo-r",
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="aaaaaaaa",
+            name="Ed",
+            apollo_id="apo-r",
+        )
+        before_c = cpath.read_text()
+        before_a = apath.read_text()
+        pair = DuplicatePair(
+            canonical_uid="99999999",
+            absorbed_uid="aaaaaaaa",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        report = merge_duplicate_persons([pair], apply=False)
+        assert report.dry_run is True
+        assert report.merged == 1  # counted as would-merge
+        assert cpath.read_text() == before_c
+        assert apath.read_text() == before_a

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -14,6 +14,7 @@ import pytest
 
 from athenaeum.dedupe import (
     DuplicatePair,
+    _union_list,
     find_duplicate_persons,
     merge_duplicate_persons,
     pairs_from_yaml,
@@ -235,6 +236,244 @@ class TestReportRoundtrip:
         assert roundtripped[0].canonical_uid == pairs[0].canonical_uid
         assert roundtripped[0].absorbed_uid == pairs[0].absorbed_uid
         assert roundtripped[0].match_signal == pairs[0].match_signal
+
+
+class TestMaxMerge:
+    def test_warm_score_takes_max(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="m1111111",
+            name="Max Canon",
+            apollo_id="apo-m",
+            extra={
+                "warm_score": 0.4,
+                "last_touch": "2026-01-01",
+                "updated": "2026-01-01",
+            },
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="m2222222",
+            name="Max Absorb",
+            apollo_id="apo-m",
+            extra={
+                "warm_score": 0.9,
+                "last_touch": "2026-04-15",
+                "updated": "2026-04-15",
+            },
+        )
+        pair = DuplicatePair(
+            canonical_uid="m1111111",
+            absorbed_uid="m2222222",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        assert float(meta["warm_score"]) == 0.9
+        assert str(meta["last_touch"]) == "2026-04-15"
+        # `updated` is stamped to today on merge — must be >= absorbed's
+        assert str(meta["updated"]) >= "2026-04-15"
+
+    def test_max_keeps_canonical_when_larger(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="m3333333",
+            name="Max2 Canon",
+            apollo_id="apo-m2",
+            extra={"warm_score": 0.95, "last_touch": "2026-05-01"},
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="m4444444",
+            name="Max2 Absorb",
+            apollo_id="apo-m2",
+            extra={"warm_score": 0.1, "last_touch": "2025-01-01"},
+        )
+        pair = DuplicatePair(
+            canonical_uid="m3333333",
+            absorbed_uid="m4444444",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        assert float(meta["warm_score"]) == 0.95
+        assert str(meta["last_touch"]) == "2026-05-01"
+
+
+class TestCoalesceOnGap:
+    def test_apollo_id_filled_from_absorbed(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="g1111111",
+            name="Gap Canon",
+            linkedin_url="https://linkedin.com/in/gap",
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="g2222222",
+            name="Gap Absorb",
+            apollo_id="apo-gap",
+            linkedin_url="https://linkedin.com/in/gap",
+        )
+        pair = DuplicatePair(
+            canonical_uid="g1111111",
+            absorbed_uid="g2222222",
+            match_signal="linkedin_url",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        assert meta["apollo_id"] == "apo-gap"
+
+    def test_linkedin_url_filled_from_absorbed(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="g3333333",
+            name="Gap2 Canon",
+            apollo_id="apo-shared",
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="g4444444",
+            name="Gap2 Absorb",
+            apollo_id="apo-shared",
+            linkedin_url="https://linkedin.com/in/gap2",
+        )
+        pair = DuplicatePair(
+            canonical_uid="g3333333",
+            absorbed_uid="g4444444",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        assert meta["linkedin_url"] == "https://linkedin.com/in/gap2"
+
+
+class TestBodyMerge:
+    def test_body_concatenated_under_merged_from_heading(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="b1111111",
+            name="Body Canon",
+            apollo_id="apo-b",
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="b2222222",
+            name="Body Absorb",
+            apollo_id="apo-b",
+        )
+        pair = DuplicatePair(
+            canonical_uid="b1111111",
+            absorbed_uid="b2222222",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        _meta, body = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        # Canonical body preserved
+        assert "Body for Body Canon." in body
+        # Absorbed body appended under heading with absorbed uid
+        assert "## Merged from b2222222" in body
+        assert "Body for Body Absorb." in body
+        # Heading appears AFTER canonical body
+        assert body.index("Body for Body Canon.") < body.index(
+            "## Merged from b2222222"
+        )
+
+
+class TestUnionList:
+    def test_dedup_strings(self) -> None:
+        assert _union_list(["a", "b"], ["b", "c"]) == ["a", "b", "c"]
+
+    def test_canonical_first_order(self) -> None:
+        assert _union_list(["x", "y"], ["a", "y"]) == ["x", "y", "a"]
+
+    def test_dedup_dicts_by_repr(self) -> None:
+        d1 = {"k": 1}
+        d2 = {"k": 2}
+        d1_dup = {"k": 1}
+        out = _union_list([d1, d2], [d1_dup, {"k": 3}])
+        assert len(out) == 3
+        assert {"k": 1} in out
+        assert {"k": 2} in out
+        assert {"k": 3} in out
+
+    def test_handles_none(self) -> None:
+        assert _union_list(None, ["a"]) == ["a"]
+        assert _union_list(["a"], None) == ["a"]
+        assert _union_list(None, None) == []
+
+
+class TestPairsFromYamlMalformed:
+    def test_missing_canonical_uid_raises(self) -> None:
+        bad = "- absorbed_uid: x\n  match_signal: apollo_id\n"
+        with pytest.raises((ValueError, KeyError)):
+            pairs_from_yaml(bad)
+
+    def test_wrong_top_level_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="YAML list"):
+            pairs_from_yaml("canonical_uid: foo\nabsorbed_uid: bar\n")
+
+    def test_entry_not_dict_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be a dict"):
+            pairs_from_yaml("- just_a_string\n- another\n")
+
+    def test_malformed_yaml_raises(self) -> None:
+        import yaml as _yaml
+
+        with pytest.raises(_yaml.YAMLError):
+            pairs_from_yaml("- canonical_uid: [unclosed\n")
+
+
+class TestNonPersonFilter:
+    def test_only_person_pairs_surface(self, wiki_root: Path) -> None:
+        # Two real person duplicates
+        _write_person(wiki_root, uid="p1111111", name="Person Dup", apollo_id="apo-p")
+        _write_person(wiki_root, uid="p2222222", name="Person Dup", apollo_id="apo-p")
+        # Company wikis sharing a "name" — must NOT be returned
+        (wiki_root / "co1.md").write_text(
+            "---\nuid: co111111\ntype: company\nname: Acme Corp\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        (wiki_root / "co2.md").write_text(
+            "---\nuid: co222222\ntype: company\nname: Acme Corp\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        # Concept wikis sharing a name — must NOT be returned
+        (wiki_root / "concept1.md").write_text(
+            "---\nuid: cn111111\ntype: concept\nname: Lean Startup\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        (wiki_root / "concept2.md").write_text(
+            "---\nuid: cn222222\ntype: concept\nname: Lean Startup\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        # Person row with empty name — must be skipped
+        (wiki_root / "blank-name.md").write_text(
+            '---\nuid: pblnk111\ntype: person\nname: ""\n---\n\nbody\n',
+            encoding="utf-8",
+        )
+        # Person row with empty uid — must be skipped
+        (wiki_root / "blank-uid.md").write_text(
+            '---\nuid: ""\ntype: person\nname: Ghost Person\n---\n\nbody\n',
+            encoding="utf-8",
+        )
+
+        pairs = find_duplicate_persons(wiki_root)
+        assert len(pairs) == 1
+        assert {pairs[0].canonical_uid, pairs[0].absorbed_uid} == {
+            "p1111111",
+            "p2222222",
+        }
 
 
 class TestDryRun:


### PR DESCRIPTION
## Summary

Closes #85.

Ports the cwc-side person dedup scripts (`find_duplicate_persons.py`, `merge_duplicate_persons.py`) into the athenaeum package as a new `dedupe` subcommand:

```
athenaeum dedupe persons --find  [--wiki-root PATH] [--out PATH]
athenaeum dedupe persons --apply [--from PATH] [--wiki-root PATH]
```

`--find` writes a YAML report of HIGH-confidence duplicate pairs (default stdout). `--apply` consumes that report and merges. Idempotent: re-applying a report with already-merged pairs counts them under `already_merged` and skips.

The MEDIUM fuzzy-name tier from the cwc script (token Jaccard >= 0.8) is intentionally not surfaced here — that path requires the human-triage CSV-worksheet round-trip and stays in the cwc scripts. This module exposes only the HIGH-confidence signals: shared `apollo_id`, shared canonicalized `linkedin_url`, and exact-match normalized name (group size 2-3; 4+ wikis sharing a normalized name are dropped as ambiguous common names).

## field_sources preservation strategy (#90)

The merge contract preserves per-claim provenance through three rules:

**Scalar fields** — canonical wins on the value AND on `field_sources.<key>`. If canonical has `field_sources: {current_title: "apollo:export-2026"}` and absorbed has `field_sources: {current_title: "linkedin:profile-12"}`, the merged wiki keeps `apollo:export-2026`.

**List fields** (`emails`, `tags`, `aliases`) — values are unioned with canonical-first ordering. Per-key field_sources attribution is canonical-wins on shared keys, with absorbed-only entries carried forward. Worked example:

- canonical: `emails: [a@canonical.example]` with `field_sources: {emails: "google:contact-1"}`
- absorbed:  `emails: [a@absorbed.example]` with `field_sources: {emails: "linkedin:profile-2"}`
- merged:    `emails: [a@canonical.example, a@absorbed.example]` with `field_sources: {emails: "google:contact-1"}`

When canonical has no entry for the key but absorbed does, the absorbed attribution survives — that is how attribution for absorbed-only list values is preserved (e.g. canonical has no emails field_sources, absorbed has `emails: "apollo:export-2026"` -> merged keeps `apollo:export-2026`).

**Wiki-level `source`** — canonical wins. The absorbed wiki's `source` is archived in a new frontmatter audit field:

```yaml
merged_from: [<absorbed_uid>]
merged_from_sources:
  <absorbed_uid>: <absorbed_source>
```

This is recorded inline in the canonical's frontmatter rather than a separate audit log so the attribution survives any future move of the wiki tree, and it is a structured key that future tooling (Lane G / #91) can reason over without parsing free-form body comments.

## Out of scope

- cwc-side scripts (orchestrator handles cleanup after merge).
- MEDIUM-tier fuzzy-name triage workflow.
- Conflict-resolution rules outside the merger (Lane G / #91 owns audit semantics).

## Test plan

- [x] `tests/test_dedupe.py` covers all four signals (apollo_id, linkedin, name_exact) plus dropped common-name case.
- [x] field_sources preservation: list-union per-value attribution with both sides populated.
- [x] field_sources carry-forward: absorbed-only attribution survives merge.
- [x] Wiki-level source archival under `merged_from_sources`.
- [x] Idempotency: second `--apply` is a no-op (already_merged count).
- [x] Dry-run does not modify files.
- [x] YAML report round-trip (`pairs_to_yaml` / `pairs_from_yaml`).
- [x] All 10 dedupe tests pass; full suite passes except 5 chromadb-optional-dep failures unrelated to this lane.
