### PR TITLE
feat(connectors): Apollo people-enrichment + athenaeum enrich subcommand

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -3,6 +3,7 @@
 
 import argparse
 import logging
+import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -363,6 +364,43 @@ def main(argv: list[str] | None = None) -> int:
         help="Wiki directory (default: ~/knowledge/wiki)",
     )
 
+    # enrich command — call external connectors against wiki entities (#87)
+    enrich_parser = subparsers.add_parser(
+        "enrich",
+        help=(
+            "Enrich wiki entities via external connectors. "
+            "Currently supports --persons (Apollo people-match)."
+        ),
+    )
+    enrich_parser.add_argument(
+        "--persons",
+        action="store_true",
+        help="Enrich type:person wikis via the Apollo connector.",
+    )
+    enrich_parser.add_argument(
+        "--wiki-root",
+        type=Path,
+        default=None,
+        help="Wiki directory (default: ~/knowledge/wiki).",
+    )
+    enrich_parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Cap to first N candidates (default: no cap).",
+    )
+    enrich_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write changes. Default is dry-run (no writes).",
+    )
+    enrich_parser.add_argument(
+        "--skip-recent-days",
+        type=int,
+        default=30,
+        help="Skip wikis with apollo_enriched_on within N days (default 30; 0=no skip).",
+    )
+
     # rebuild-index command — rebuild the search index out-of-band
     rebuild_parser = subparsers.add_parser(
         "rebuild-index",
@@ -431,6 +469,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "repair":
         return _cmd_repair(args)
+
+    if args.command == "enrich":
+        return _cmd_enrich(args)
 
     return 0
 
@@ -1079,6 +1120,116 @@ def _cmd_repair(args: argparse.Namespace) -> int:
         return 1
     if not args.apply and total_changed > 0:
         return 2
+    return 0
+
+
+def _cmd_enrich(args: argparse.Namespace) -> int:
+    """Enrich wiki entities via external connectors.
+
+    Currently supports ``--persons`` only — calls the Apollo connector
+    against ``type:person`` wikis under ``--wiki-root`` (default
+    ``~/knowledge/wiki``). Filters to wikis that need enrichment
+    (missing ``apollo_id`` AND have at least one of ``emails`` or
+    ``linkedin_url``). Calls :func:`athenaeum.connectors.apollo.enrich_person`
+    and merges the result into frontmatter via
+    :func:`athenaeum.models.render_frontmatter` — this is the
+    YAML-corruption-safe write path.
+
+    Default is dry-run; ``--apply`` writes.
+    """
+    from datetime import date
+
+    from athenaeum.connectors.apollo import ApolloClient, enrich_person
+    from athenaeum.models import parse_frontmatter, render_frontmatter
+
+    if not args.persons:
+        print("enrich: pass --persons (no other connectors yet)", file=sys.stderr)
+        return 1
+
+    wiki_root = (args.wiki_root or Path("~/knowledge/wiki")).expanduser().resolve()
+    if not wiki_root.is_dir():
+        print(f"Wiki root not found: {wiki_root}", file=sys.stderr)
+        return 1
+
+    today = date.today()
+
+    candidates: list[tuple[Path, dict, str]] = []
+    for path in sorted(wiki_root.glob("*.md")):
+        if path.name.startswith("_"):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        meta, body = parse_frontmatter(text)
+        if not meta or meta.get("type") != "person":
+            continue
+        if meta.get("apollo_id"):
+            # Skip-recent guard for already-enriched wikis.
+            if args.skip_recent_days > 0:
+                last = str(meta.get("apollo_enriched_on") or "")
+                if last:
+                    try:
+                        d = date.fromisoformat(last[:10])
+                        if (today - d).days < args.skip_recent_days:
+                            continue
+                    except ValueError:
+                        pass
+            else:
+                continue
+        emails = meta.get("emails") or []
+        linkedin = str(meta.get("linkedin_url") or "").strip()
+        if not (emails or linkedin):
+            continue
+        candidates.append((path, meta, body))
+
+    if args.limit > 0:
+        candidates = candidates[: args.limit]
+
+    print(
+        f"enrich --persons: {len(candidates)} candidate(s) "
+        f"({'APPLY' if args.apply else 'DRY-RUN'})"
+    )
+
+    client = ApolloClient() if args.apply or os.environ.get("APOLLO_API_KEY") else None
+    if client is None:
+        # Dry-run without an API key — show candidate list and exit.
+        for path, meta, _body in candidates[:20]:
+            print(f"  would enrich: {meta.get('name')!r}  ({path.name})")
+        if len(candidates) > 20:
+            print(f"  ... and {len(candidates) - 20} more")
+        return 0
+
+    matched = 0
+    no_match = 0
+    written = 0
+    for path, meta, body in candidates:
+        result = enrich_person(meta, client)
+        if not result.matched:
+            no_match += 1
+            continue
+        matched += 1
+        if not args.apply:
+            print(
+                f"  would update: {meta.get('name')!r}  "
+                f"+{len(result.fields)} field(s)"
+            )
+            continue
+
+        new_meta = dict(meta)
+        new_meta.update(result.fields)
+        # Merge field_sources without clobbering existing entries.
+        existing_fs = dict(new_meta.get("field_sources") or {})
+        existing_fs.update(result.field_sources)
+        new_meta["field_sources"] = existing_fs
+        new_text = render_frontmatter(new_meta) + body
+        path.write_text(new_text, encoding="utf-8")
+        written += 1
+
+    print(
+        f"enrich --persons summary: matched={matched} no_match={no_match} "
+        f"written={written}"
+    )
     return 0
 
 

--- a/src/athenaeum/connectors/__init__.py
+++ b/src/athenaeum/connectors/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""External-data connectors that enrich wiki entities.
+
+Each connector is a thin client around a third-party API plus an
+``enrich_<type>`` function that returns the fields a wiki should be
+updated with — never writing the wiki itself. Composition (merge into
+frontmatter, attach ``field_sources``, persist) is the caller's job so
+the connectors stay testable and composable.
+"""

--- a/src/athenaeum/connectors/apollo.py
+++ b/src/athenaeum/connectors/apollo.py
@@ -1,0 +1,481 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Apollo.io connector — people enrichment for type:person wikis.
+
+Two surfaces:
+
+- :class:`ApolloClient` — generic REST wrapper around the Apollo API.
+  Supports ``people_match`` (single-call, recommended) and
+  ``people_bulk_match`` (opt-in, **not recommended** — see warning below).
+- :func:`enrich_person` — given a person wiki frontmatter dict, build the
+  Apollo request, call the API, and return an :class:`EnrichResult` with
+  the fields that should be written and the matching ``field_sources``
+  entries (``api:apollo:<YYYY-MM-DD>``). Caller composes the write.
+
+Known bug — bulk_match silently drops valid matches
+---------------------------------------------------
+Apollo's ``/people/bulk_match`` endpoint silently returns ~70% fewer
+matches than the identical request shape sent to ``/people/match`` one
+record at a time. Verified 2026-05-08 by replaying ten "no_match" rows:
+bulk returned 3/10, single returned 10/10. The default for any caller
+in this module (including :func:`enrich_person`) is **single-call**.
+:meth:`ApolloClient.people_bulk_match` is preserved as opt-in only and
+emits a :class:`UserWarning` so opt-in callers are reminded of the cost.
+Do not change the default.
+
+Provenance (#90)
+----------------
+Every field returned in :class:`EnrichResult` carries a corresponding
+entry in ``field_sources`` of the canonical form
+``api:apollo:<YYYY-MM-DD>`` (UTC date of the enrichment call). Callers
+merge ``fields`` into wiki frontmatter and ``field_sources`` into the
+wiki's ``field_sources`` map.
+
+YAML round-trip
+---------------
+This connector returns plain Python dicts/lists. Persistence uses
+:func:`athenaeum.models.render_frontmatter` (PyYAML ``safe_dump`` with
+``sort_keys=False``), which produces YAML that round-trips cleanly
+through ``yaml.safe_load``. The connector does NOT splice raw lines
+into existing frontmatter text — that legacy path (the cwc-side
+``apollo_enrich_warm_tier.py``) is the source of the
+indent-corruption bug tracked in
+``reference_apollo_enricher_yaml_corruption``. Lane E uses dict
+composition + ``render_frontmatter`` instead.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import warnings
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+APOLLO_BASE = "https://api.apollo.io/api/v1"
+DEFAULT_USER_AGENT = "athenaeum/0.x (apollo-enrichment)"
+# Apollo's edge (Cloudflare) blocks the default Python urllib UA with a
+# 1010 challenge. A normal-looking UA bypasses it.
+
+# 1Password lookup defaults — used only if APOLLO_API_KEY env-var is
+# unset. Keeps parity with the cwc-side wrapper so existing operators
+# don't need to re-stash the key.
+OP_VAULT_DEFAULT = "Agent Tools"
+OP_ITEM_DEFAULT = "Apollo API Key"
+OP_FIELD_DEFAULT = "credential"
+
+
+class ApolloError(RuntimeError):
+    """Raised when the Apollo API returns an unrecoverable error."""
+
+
+def _resolve_api_key(
+    explicit: str | None = None,
+    *,
+    op_vault: str | None = None,
+    op_item: str | None = None,
+    op_field: str | None = None,
+) -> str:
+    """Resolve the Apollo API key.
+
+    Order: explicit arg → ``APOLLO_API_KEY`` env var → 1Password (``op``).
+    Raises :class:`ApolloError` if no key can be obtained.
+    """
+    if explicit:
+        return explicit.strip()
+    env = os.environ.get("APOLLO_API_KEY")
+    if env:
+        return env.strip()
+    vault = op_vault or os.environ.get("APOLLO_1PASSWORD_VAULT", OP_VAULT_DEFAULT)
+    item = op_item or os.environ.get("APOLLO_1PASSWORD_ITEM", OP_ITEM_DEFAULT)
+    field_name = op_field or os.environ.get("APOLLO_1PASSWORD_FIELD", OP_FIELD_DEFAULT)
+    try:
+        out = subprocess.check_output(
+            ["op", "read", f"op://{vault}/{item}/{field_name}"],
+            text=True,
+            stderr=subprocess.PIPE,
+        ).strip()
+    except FileNotFoundError as exc:
+        raise ApolloError(
+            "Apollo API key not found: pass api_key=, set APOLLO_API_KEY, "
+            "or install the `op` CLI for 1Password lookup."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise ApolloError(
+            f"Apollo API key lookup via 1Password failed: {exc.stderr.strip()}"
+        ) from exc
+    if not out:
+        raise ApolloError("Apollo API key resolved but is empty.")
+    return out
+
+
+def _apollo_source(date_str: str | None = None) -> str:
+    """Return the canonical provenance source string for an Apollo claim.
+
+    Form: ``api:apollo:<YYYY-MM-DD>``. ``date_str`` may be supplied for
+    determinism in tests; otherwise UTC ``today`` is used.
+    """
+    if date_str is None:
+        date_str = datetime.now(tz=timezone.utc).date().isoformat()
+    return f"api:apollo:{date_str}"
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class ApolloClient:
+    """Minimal Apollo.io REST client.
+
+    Parameters
+    ----------
+    api_key:
+        Explicit key. If omitted, falls back to ``APOLLO_API_KEY`` env
+        then 1Password ``op``.
+    base_url:
+        Apollo API base. Override only for tests / mock servers.
+    user_agent:
+        Sent as ``User-Agent``. Default identifies this client; override
+        only when the caller wants its own attribution.
+    transport:
+        Optional callable ``(method, url, headers, body) -> dict`` for
+        injecting a fake transport in tests. When set, no network I/O is
+        attempted.
+    retries:
+        Number of additional attempts after the first failed call.
+        Retried on HTTP 429 + 5xx + transient network errors with
+        exponential backoff (``2 ** attempt`` seconds).
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        base_url: str = APOLLO_BASE,
+        user_agent: str = DEFAULT_USER_AGENT,
+        transport: Any = None,
+        retries: int = 2,
+    ) -> None:
+        self._api_key = (
+            _resolve_api_key(api_key) if transport is None else (api_key or "test")
+        )
+        self._base_url = base_url.rstrip("/")
+        self._user_agent = user_agent
+        self._transport = transport
+        self._retries = max(0, int(retries))
+
+    # -- low-level ---------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: dict | None = None,
+        params: dict | None = None,
+    ) -> dict:
+        url = f"{self._base_url}{path}"
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+        headers = {
+            "Cache-Control": "no-cache",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-Api-Key": self._api_key,
+            "User-Agent": self._user_agent,
+        }
+        body = json.dumps(payload).encode() if payload is not None else None
+
+        if self._transport is not None:
+            return self._transport(method, url, headers, body)
+
+        last_err: str | None = None
+        for attempt in range(self._retries + 1):
+            req = urllib.request.Request(url, data=body, method=method, headers=headers)
+            try:
+                with urllib.request.urlopen(req, timeout=60) as resp:
+                    raw = resp.read().decode()
+                    return json.loads(raw) if raw else {}
+            except urllib.error.HTTPError as exc:
+                err_body = exc.read().decode(errors="replace")
+                last_err = f"{exc.code} {err_body[:200]}"
+                retryable = exc.code == 429 or exc.code >= 500
+                if retryable and attempt < self._retries:
+                    time.sleep(2**attempt)
+                    continue
+                raise ApolloError(f"Apollo API error: {last_err}") from exc
+            except (urllib.error.URLError, TimeoutError) as exc:
+                last_err = str(exc)
+                if attempt < self._retries:
+                    time.sleep(1)
+                    continue
+                raise ApolloError(f"Apollo network error: {last_err}") from exc
+        raise ApolloError(f"Apollo retries exhausted: {last_err}")
+
+    # -- people/match (single, recommended) --------------------------------
+
+    def people_match(
+        self,
+        *,
+        email: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        name: str | None = None,
+        organization_name: str | None = None,
+        domain: str | None = None,
+        linkedin_url: str | None = None,
+        reveal_personal_emails: bool = False,
+    ) -> dict | None:
+        """Single-call match. Returns the matched person dict or None."""
+        payload: dict = {}
+        if email:
+            payload["email"] = email
+        if first_name:
+            payload["first_name"] = first_name
+        if last_name:
+            payload["last_name"] = last_name
+        if name:
+            payload["name"] = name
+        if organization_name:
+            payload["organization_name"] = organization_name
+        if domain:
+            payload["domain"] = domain
+        if linkedin_url:
+            payload["linkedin_url"] = linkedin_url
+        if reveal_personal_emails:
+            payload["reveal_personal_emails"] = True
+
+        if not payload:
+            return None
+
+        resp = self._request("POST", "/people/match", payload=payload)
+        person = resp.get("person")
+        return person or None
+
+    # -- people/bulk_match (opt-in, NOT recommended) -----------------------
+
+    def people_bulk_match(self, records: list[dict]) -> list[dict | None]:
+        """Bulk match — **not recommended**.
+
+        Apollo's ``/people/bulk_match`` silently drops ~70% of valid
+        matches that ``/people/match`` accepts with the identical
+        per-record payload. Verified 2026-05-08. Use
+        :meth:`people_match` in a loop instead. Preserved here for
+        callers that have explicitly accepted the trade-off (e.g.
+        replays where partial coverage is acceptable).
+        """
+        if not records:
+            return []
+        if len(records) > 10:
+            raise ValueError("Apollo bulk_match accepts at most 10 records per call")
+        warnings.warn(
+            "Apollo /people/bulk_match silently drops ~70% of valid matches "
+            "vs single-call /people/match. Use ApolloClient.people_match in "
+            "a loop instead. See "
+            "athenaeum.connectors.apollo for details.",
+            UserWarning,
+            stacklevel=2,
+        )
+        payload = {"details": records}
+        resp = self._request("POST", "/people/bulk_match", payload=payload)
+        matches = resp.get("matches") or []
+        out: list[dict | None] = []
+        for m in matches:
+            if m and m.get("id"):
+                out.append(m)
+            else:
+                out.append(None)
+        while len(out) < len(records):
+            out.append(None)
+        return out[: len(records)]
+
+
+# ---------------------------------------------------------------------------
+# Enrichment surface
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EnrichResult:
+    """Output of :func:`enrich_person`.
+
+    ``fields`` maps frontmatter keys to values to write. ``field_sources``
+    is the matching per-claim provenance map keyed by the same field
+    names; merging it into the wiki's existing ``field_sources`` is the
+    caller's responsibility.
+
+    ``matched`` is True iff Apollo returned a person record. When False,
+    ``fields`` and ``field_sources`` are empty.
+    """
+
+    matched: bool
+    fields: dict[str, Any] = field(default_factory=dict)
+    field_sources: dict[str, str] = field(default_factory=dict)
+    raw: dict | None = None
+
+
+def _split_name(full: str) -> tuple[str, str]:
+    parts = (full or "").strip().split()
+    if not parts:
+        return "", ""
+    if len(parts) == 1:
+        return parts[0], ""
+    return parts[0], " ".join(parts[1:])
+
+
+def _derive_current_org(person: dict) -> str:
+    history = person.get("employment_history") or []
+    for h in history:
+        if h.get("current") and (h.get("organization_name") or "").strip():
+            return h["organization_name"].strip()
+    org = person.get("organization") or {}
+    if org.get("name"):
+        return str(org["name"]).strip()
+    return ""
+
+
+def _derive_location(person: dict) -> str:
+    parts = []
+    for k in ("city", "state", "country"):
+        v = (person.get(k) or "").strip()
+        if v:
+            parts.append(v)
+    return ", ".join(parts)
+
+
+def _short_employment_history(person: dict, n: int = 5) -> list[dict]:
+    history = person.get("employment_history") or []
+    out: list[dict] = []
+    for h in history[:n]:
+        entry = {
+            "title": (h.get("title") or "").strip(),
+            "organization_name": (h.get("organization_name") or "").strip(),
+            "current": bool(h.get("current")),
+        }
+        if h.get("start_date"):
+            entry["start_date"] = str(h["start_date"])
+        if h.get("end_date"):
+            entry["end_date"] = str(h["end_date"])
+        out.append(entry)
+    return out
+
+
+def build_match_request(meta: dict) -> dict | None:
+    """Build an Apollo ``people_match`` kwargs dict from a person wiki dict.
+
+    Returns ``None`` if there is not enough identifying data (no email,
+    no LinkedIn URL, no last name).
+    """
+    name = str(meta.get("name") or "").strip()
+    if not name or name in ("(unknown)", "(no name)"):
+        return None
+    first, last = _split_name(name)
+    req: dict = {}
+    emails = meta.get("emails") or []
+    if isinstance(emails, list) and emails:
+        req["email"] = str(emails[0]).strip().lower()
+    elif isinstance(meta.get("email"), str) and meta["email"]:
+        req["email"] = str(meta["email"]).strip().lower()
+    if first:
+        req["first_name"] = first
+    if last:
+        req["last_name"] = last
+    linkedin = str(meta.get("linkedin_url") or "").strip()
+    if linkedin:
+        req["linkedin_url"] = linkedin
+    if not (req.get("email") or req.get("linkedin_url") or req.get("last_name")):
+        return None
+    return req
+
+
+def enrich_person(
+    meta: dict,
+    client: ApolloClient,
+    *,
+    today: str | None = None,
+) -> EnrichResult:
+    """Enrich a person wiki frontmatter dict via Apollo.
+
+    Returns an :class:`EnrichResult` with the fields to write plus a
+    per-field provenance map. Caller composes the write — this function
+    is pure aside from the Apollo API call.
+
+    ``today`` overrides the date stamp embedded in ``field_sources``
+    (useful for deterministic tests). Defaults to UTC today.
+    """
+    request = build_match_request(meta)
+    if request is None:
+        return EnrichResult(matched=False)
+
+    person = client.people_match(**request)
+    if not person:
+        return EnrichResult(matched=False)
+
+    src = _apollo_source(today)
+    fields: dict[str, Any] = {}
+    field_sources: dict[str, str] = {}
+
+    def set_field(key: str, value: Any) -> None:
+        if value in (None, "", [], {}):
+            return
+        fields[key] = value
+        field_sources[key] = src
+
+    apollo_id = (person.get("id") or "").strip()
+    set_field("apollo_id", apollo_id)
+
+    title = (person.get("title") or "").strip()
+    set_field("current_title", title)
+
+    company = _derive_current_org(person)
+    set_field("current_company", company)
+
+    headline = (person.get("headline") or "").strip()
+    set_field("apollo_headline", headline)
+
+    location = _derive_location(person)
+    set_field("apollo_location", location)
+
+    # Fill linkedin_url ONLY if missing on input — do not clobber
+    # operator-curated values. Same pattern for twitter / github.
+    if not str(meta.get("linkedin_url") or "").strip():
+        set_field("linkedin_url", (person.get("linkedin_url") or "").strip())
+    if not str(meta.get("twitter_url") or "").strip():
+        set_field("twitter_url", (person.get("twitter_url") or "").strip())
+    if not str(meta.get("github_url") or "").strip():
+        set_field("github_url", (person.get("github_url") or "").strip())
+
+    history = _short_employment_history(person, n=5)
+    if history:
+        set_field("apollo_employment_history", history)
+
+    # Stamp the enrichment date on its own field so downstream "skip
+    # recently enriched" logic works without parsing field_sources.
+    if today is None:
+        today = datetime.now(tz=timezone.utc).date().isoformat()
+    set_field("apollo_enriched_on", today)
+
+    return EnrichResult(
+        matched=True,
+        fields=fields,
+        field_sources=field_sources,
+        raw=person,
+    )
+
+
+__all__ = [
+    "ApolloClient",
+    "ApolloError",
+    "EnrichResult",
+    "_apollo_source",
+    "build_match_request",
+    "enrich_person",
+]

--- a/tests/test_apollo_connector.py
+++ b/tests/test_apollo_connector.py
@@ -197,6 +197,18 @@ def test_bulk_match_emits_warning():
     assert any(issubclass(x.category, UserWarning) for x in w)
     assert result[0] == {"id": "p-1"}
     assert result[1] is None
+    # Endpoint discrimination: bulk_match path hits /people/bulk_match
+    # exactly once and never falls through to /people/match. Guards
+    # against a regression where a future refactor routes bulk callers
+    # back to the single-call endpoint (or vice versa).
+    assert sum("/people/bulk_match" in c[1] for c in transport.calls) == 1
+    assert (
+        sum(
+            "/people/match" in c[1] and "/people/bulk_match" not in c[1]
+            for c in transport.calls
+        )
+        == 0
+    )
 
 
 def test_default_path_uses_people_match_not_bulk():
@@ -342,4 +354,105 @@ def test_cli_enrich_apply_writes_with_field_sources(tmp_path, monkeypatch):
     assert fs["apollo_id"].startswith("api:apollo:")
     assert fs["current_title"].startswith("api:apollo:")
     # YAML re-parses cleanly (regression guard)
+    yaml.safe_load(new_text.split("---\n", 2)[1])
+    # CLI default --apply path MUST NOT touch /people/bulk_match.
+    # Apollo's bulk endpoint silently drops ~70% of valid matches; the
+    # CLI must always route through single-call /people/match.
+    assert all("/bulk_match" not in c[1] for c in transport.calls)
+    assert any(c[1].endswith("/people/match") for c in transport.calls)
+
+
+# ---------------------------------------------------------------------------
+# UTC-date determinism in _apollo_source
+# ---------------------------------------------------------------------------
+
+
+def test_apollo_source_uses_utc_date_under_non_utc_local_zone(monkeypatch):
+    """``_apollo_source(None)`` must stamp UTC date, not local-zone date.
+
+    Pick a moment 30 minutes after UTC midnight on 2026-05-08. In a
+    Pacific (UTC-7/8) zone, the local wall-clock date is still
+    2026-05-07. The provenance string must reflect UTC (2026-05-08).
+    """
+    from datetime import timedelta as real_timedelta
+    from datetime import timezone as real_timezone
+
+    from athenaeum.connectors import apollo as apollo_mod
+
+    real_datetime = apollo_mod.datetime
+    fixed_utc = real_datetime(2026, 5, 8, 0, 30, tzinfo=real_timezone.utc)
+    pacific = real_timezone(real_timedelta(hours=-7))
+
+    class _FakeDateTime(real_datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                # Local wall-clock would be 2026-05-07 17:30 (Pacific),
+                # naive — i.e. local-zone date is 2026-05-07.
+                return fixed_utc.astimezone(pacific).replace(tzinfo=None)
+            return fixed_utc.astimezone(tz)
+
+    monkeypatch.setattr(apollo_mod, "datetime", _FakeDateTime)
+
+    out = apollo_mod._apollo_source()
+    assert out == "api:apollo:2026-05-08", out
+
+
+# ---------------------------------------------------------------------------
+# Legacy 2-space-tag frontmatter ingest (cwc-bug regression)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_enrich_apply_handles_legacy_2space_tag_block(tmp_path, monkeypatch):
+    """Pre-existing wiki with cwc-bug-shaped 2-space-indented tags block.
+
+    The legacy ``apollo_enrich_warm_tier.py`` (cwc-side) wrote tag
+    blocks with 2-space indentation, which broke yaml.safe_load when
+    spliced into a 0-space block. The Lane E enricher uses dict
+    composition + ``render_frontmatter``, so any pre-existing 2-space
+    block on disk should round-trip through ``parse_frontmatter`` ->
+    enrich -> ``render_frontmatter`` cleanly.
+    """
+    from athenaeum.cli import main
+    from athenaeum.connectors import apollo as apollo_mod
+
+    wiki_root = tmp_path / "wiki"
+    wiki_root.mkdir()
+    path = wiki_root / "abc12345-jane-doe.md"
+    # 2-space-indented tag entries — the cwc-bug shape.
+    path.write_text(
+        "---\n"
+        "uid: abc12345\n"
+        "type: person\n"
+        "name: Jane Doe\n"
+        "emails:\n"
+        "- jane@example.com\n"
+        "tags:\n"
+        "  - tier:warm-a\n"
+        "  - warm:network\n"
+        "---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    transport = FakeTransport(person=make_person_payload())
+
+    class _PatchedClient(ApolloClient):
+        def __init__(self):
+            super().__init__(api_key="test", transport=transport)
+
+    monkeypatch.setattr(apollo_mod, "ApolloClient", _PatchedClient)
+    monkeypatch.setenv("APOLLO_API_KEY", "test")
+
+    rc = main(["enrich", "--persons", "--apply", "--wiki-root", str(wiki_root)])
+    assert rc == 0
+
+    new_text = path.read_text(encoding="utf-8")
+    # Re-parses cleanly — no indent-splice corruption.
+    parsed_meta, _body = parse_frontmatter(new_text)
+    # Tags survived intact (regardless of original indent shape).
+    assert parsed_meta["tags"] == ["tier:warm-a", "warm:network"]
+    # Apollo fields landed.
+    assert parsed_meta["apollo_id"] == "apollo-123"
+    assert parsed_meta["field_sources"]["apollo_id"].startswith("api:apollo:")
+    # Direct yaml.safe_load also clean.
     yaml.safe_load(new_text.split("---\n", 2)[1])

--- a/tests/test_apollo_connector.py
+++ b/tests/test_apollo_connector.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for athenaeum.connectors.apollo.
+
+Covers:
+- canonical ``api:apollo:<YYYY-MM-DD>`` provenance string.
+- ``enrich_person`` returns ``field_sources`` for every field it sets.
+- ``people_match`` is the default path (per the bulk-match bug).
+- ``people_bulk_match`` is opt-in and emits a UserWarning.
+- YAML round-trip of an enriched wiki: ``render_frontmatter`` of the
+  merged dict re-loads cleanly through ``yaml.safe_load`` (regression
+  for the indent-corruption bug in the cwc-side enricher).
+- CLI ``enrich --persons`` dry-run produces no writes; ``--apply``
+  produces correct writes.
+"""
+from __future__ import annotations
+
+import json
+import warnings
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+from athenaeum.connectors.apollo import (
+    ApolloClient,
+    EnrichResult,
+    _apollo_source,
+    build_match_request,
+    enrich_person,
+)
+from athenaeum.models import parse_frontmatter, render_frontmatter
+
+# ---------------------------------------------------------------------------
+# Fake transport
+# ---------------------------------------------------------------------------
+
+
+def make_person_payload(**overrides) -> dict:
+    base = {
+        "id": "apollo-123",
+        "title": "VP Engineering",
+        "headline": "Builder of platforms",
+        "linkedin_url": "https://linkedin.com/in/jane-doe",
+        "twitter_url": "",
+        "github_url": "",
+        "city": "San Francisco",
+        "state": "CA",
+        "country": "United States",
+        "employment_history": [
+            {
+                "title": "VP Engineering",
+                "organization_name": "Acme Corp",
+                "current": True,
+                "start_date": "2024-01-01",
+                "end_date": "",
+            },
+            {
+                "title": "Director",
+                "organization_name": "Old Co",
+                "current": False,
+                "start_date": "2020-01-01",
+                "end_date": "2023-12-31",
+            },
+        ],
+        "organization": {"name": "Acme Corp"},
+    }
+    base.update(overrides)
+    return base
+
+
+class FakeTransport:
+    """Records calls and returns canned responses keyed by URL path."""
+
+    def __init__(self, person: dict | None = None, *, bulk: list | None = None) -> None:
+        self.person = person
+        self.bulk = bulk or []
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+    def __call__(self, method, url, headers, body):
+        payload = json.loads(body) if body else None
+        self.calls.append((method, url, payload))
+        if "/people/match" in url and "bulk" not in url:
+            return {"person": self.person}
+        if "/people/bulk_match" in url:
+            return {"matches": self.bulk}
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Provenance source string
+# ---------------------------------------------------------------------------
+
+
+def test_apollo_source_canonical_form():
+    assert _apollo_source("2026-05-08") == "api:apollo:2026-05-08"
+
+
+def test_apollo_source_default_is_today_utc():
+    out = _apollo_source()
+    # api:apollo:YYYY-MM-DD
+    assert out.startswith("api:apollo:")
+    date.fromisoformat(out.split(":", 2)[2])  # must parse
+
+
+# ---------------------------------------------------------------------------
+# build_match_request
+# ---------------------------------------------------------------------------
+
+
+def test_build_match_request_with_email_and_name():
+    req = build_match_request({"name": "Jane Doe", "emails": ["jane@example.com"]})
+    assert req == {
+        "email": "jane@example.com",
+        "first_name": "Jane",
+        "last_name": "Doe",
+    }
+
+
+def test_build_match_request_skips_unknown_name():
+    assert build_match_request({"name": "(unknown)"}) is None
+
+
+def test_build_match_request_requires_identifier():
+    # First-name only with no email/linkedin/last-name = not enough.
+    assert build_match_request({"name": "Cher"}) is None
+
+
+# ---------------------------------------------------------------------------
+# enrich_person
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_person_returns_field_sources_for_every_field():
+    transport = FakeTransport(person=make_person_payload())
+    client = ApolloClient(api_key="test", transport=transport)
+    meta = {
+        "uid": "abc12345",
+        "type": "person",
+        "name": "Jane Doe",
+        "emails": ["jane@example.com"],
+    }
+    result = enrich_person(meta, client, today="2026-05-08")
+    assert isinstance(result, EnrichResult)
+    assert result.matched is True
+    # Every field set must have a field_sources entry.
+    assert set(result.field_sources.keys()) == set(result.fields.keys())
+    expected_src = "api:apollo:2026-05-08"
+    for src in result.field_sources.values():
+        assert src == expected_src
+    # Spot-check a few fields landed.
+    assert result.fields["apollo_id"] == "apollo-123"
+    assert result.fields["current_title"] == "VP Engineering"
+    assert result.fields["current_company"] == "Acme Corp"
+    assert result.fields["apollo_enriched_on"] == "2026-05-08"
+
+
+def test_enrich_person_no_match_returns_empty_result():
+    transport = FakeTransport(person=None)
+    client = ApolloClient(api_key="test", transport=transport)
+    result = enrich_person(
+        {"uid": "x", "type": "person", "name": "Nobody", "emails": ["x@y.z"]},
+        client,
+        today="2026-05-08",
+    )
+    assert result.matched is False
+    assert result.fields == {}
+    assert result.field_sources == {}
+
+
+def test_enrich_person_does_not_clobber_existing_linkedin():
+    transport = FakeTransport(person=make_person_payload())
+    client = ApolloClient(api_key="test", transport=transport)
+    meta = {
+        "uid": "abc12345",
+        "type": "person",
+        "name": "Jane Doe",
+        "emails": ["jane@example.com"],
+        "linkedin_url": "https://linkedin.com/in/operator-curated",
+    }
+    result = enrich_person(meta, client, today="2026-05-08")
+    # linkedin_url already present on input -> connector must not return it.
+    assert "linkedin_url" not in result.fields
+    assert "linkedin_url" not in result.field_sources
+
+
+# ---------------------------------------------------------------------------
+# bulk_match opt-in + warning
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_match_emits_warning():
+    transport = FakeTransport(bulk=[{"id": "p-1"}, None])
+    client = ApolloClient(api_key="test", transport=transport)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = client.people_bulk_match([{"email": "a@x"}, {"email": "b@x"}])
+    assert any(issubclass(x.category, UserWarning) for x in w)
+    assert result[0] == {"id": "p-1"}
+    assert result[1] is None
+
+
+def test_default_path_uses_people_match_not_bulk():
+    transport = FakeTransport(person=make_person_payload())
+    client = ApolloClient(api_key="test", transport=transport)
+    enrich_person(
+        {
+            "uid": "u",
+            "type": "person",
+            "name": "Jane Doe",
+            "emails": ["jane@example.com"],
+        },
+        client,
+        today="2026-05-08",
+    )
+    # Exactly one call, to /people/match (not /people/bulk_match).
+    assert len(transport.calls) == 1
+    method, url, _payload = transport.calls[0]
+    assert method == "POST"
+    assert url.endswith("/people/match")
+    assert "/bulk_match" not in url
+
+
+# ---------------------------------------------------------------------------
+# YAML round-trip regression
+# ---------------------------------------------------------------------------
+
+
+def test_enriched_frontmatter_yaml_roundtrips():
+    """Regression for the cwc-side indent-corruption bug.
+
+    Compose enrichment output into a wiki dict, render via
+    ``render_frontmatter``, and assert the output reloads cleanly via
+    ``yaml.safe_load`` AND survives a second render with the same bytes.
+    """
+    transport = FakeTransport(person=make_person_payload())
+    client = ApolloClient(api_key="test", transport=transport)
+    meta = {
+        "uid": "abc12345",
+        "type": "person",
+        "name": "Jane Doe",
+        "emails": ["jane@example.com"],
+        "tags": ["tier:warm-a", "warm:network"],
+    }
+    result = enrich_person(meta, client, today="2026-05-08")
+
+    new_meta = dict(meta)
+    new_meta.update(result.fields)
+    new_meta["field_sources"] = dict(result.field_sources)
+
+    rendered = render_frontmatter(new_meta) + "\nBody.\n"
+
+    # 1) Reloads clean via yaml.safe_load
+    parsed_meta, body = parse_frontmatter(rendered)
+    assert parsed_meta["apollo_id"] == "apollo-123"
+    assert parsed_meta["field_sources"]["apollo_id"] == "api:apollo:2026-05-08"
+    # employment history is a list of dicts — survived the round-trip.
+    assert isinstance(parsed_meta["apollo_employment_history"], list)
+    assert (
+        parsed_meta["apollo_employment_history"][0]["organization_name"] == "Acme Corp"
+    )
+    # tags survived intact (no indent splice)
+    assert parsed_meta["tags"] == ["tier:warm-a", "warm:network"]
+    assert body.strip() == "Body."
+
+    # 2) Idempotent re-render
+    rendered2 = render_frontmatter(parsed_meta) + "\n" + body
+    yaml.safe_load(rendered2.split("---\n", 2)[1])  # no exception
+
+
+# ---------------------------------------------------------------------------
+# CLI: dry-run vs --apply
+# ---------------------------------------------------------------------------
+
+
+def _seed_person_wiki(wiki_root: Path, name: str = "Jane Doe") -> Path:
+    path = wiki_root / "abc12345-jane-doe.md"
+    path.write_text(
+        "---\n"
+        "uid: abc12345\n"
+        "type: person\n"
+        f"name: {name}\n"
+        "emails:\n"
+        "- jane@example.com\n"
+        "tags:\n"
+        "- tier:warm-a\n"
+        "---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_cli_enrich_dry_run_does_not_write(tmp_path, monkeypatch):
+    """Dry-run must not modify the wiki file on disk."""
+    from athenaeum.cli import main
+
+    wiki_root = tmp_path / "wiki"
+    wiki_root.mkdir()
+    path = _seed_person_wiki(wiki_root)
+    original = path.read_text(encoding="utf-8")
+
+    # Stub the Apollo client + enrich_person so the dry-run path doesn't
+    # need network OR a real API key. We exercise the candidate-listing
+    # branch, which is the dry-run-without-key path.
+    monkeypatch.delenv("APOLLO_API_KEY", raising=False)
+
+    rc = main(["enrich", "--persons", "--wiki-root", str(wiki_root)])
+    assert rc == 0
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_cli_enrich_apply_writes_with_field_sources(tmp_path, monkeypatch):
+    """``--apply`` writes enriched fields with provenance entries."""
+    from athenaeum.cli import main
+    from athenaeum.connectors import apollo as apollo_mod
+
+    wiki_root = tmp_path / "wiki"
+    wiki_root.mkdir()
+    path = _seed_person_wiki(wiki_root)
+
+    # Patch ApolloClient construction to inject a fake transport. The
+    # CLI's `_cmd_enrich` calls ApolloClient() with no args; substituting
+    # a factory keeps the production call site unmodified.
+    transport = FakeTransport(person=make_person_payload())
+
+    class _PatchedClient(ApolloClient):
+        def __init__(self):
+            super().__init__(api_key="test", transport=transport)
+
+    monkeypatch.setattr(apollo_mod, "ApolloClient", _PatchedClient)
+    # Force the apply branch (which would otherwise also try to build a
+    # real client) by giving _cmd_enrich a non-empty APOLLO_API_KEY env.
+    monkeypatch.setenv("APOLLO_API_KEY", "test")
+
+    rc = main(["enrich", "--persons", "--apply", "--wiki-root", str(wiki_root)])
+    assert rc == 0
+
+    new_text = path.read_text(encoding="utf-8")
+    new_meta, _body = parse_frontmatter(new_text)
+    assert new_meta["apollo_id"] == "apollo-123"
+    assert new_meta["current_title"] == "VP Engineering"
+    fs = new_meta["field_sources"]
+    assert fs["apollo_id"].startswith("api:apollo:")
+    assert fs["current_title"].startswith("api:apollo:")
+    # YAML re-parses cleanly (regression guard)
+    yaml.safe_load(new_text.split("---\n", 2)[1])


### PR DESCRIPTION
## Summary

Lane E of the foundation refactor. Ports the cwc-side `apollo_wrapper.py` + `apollo_enrich_warm_tier.py` into the `athenaeum` package as a generic connector + CLI subcommand.

- `src/athenaeum/connectors/apollo.py` — new module with `ApolloClient` (people_match, people_bulk_match) and `enrich_person(meta, client) -> EnrichResult`.
- `athenaeum enrich --persons [--wiki-root PATH] [--limit N] [--apply]` — new CLI, dry-run by default.
- `tests/test_apollo_connector.py` — 13 tests, no live API calls.

Closes #87.

## bulk_match vs match — default decision

Apollo's `/people/bulk_match` endpoint silently drops ~70% of valid matches that `/people/match` accepts with the identical per-record payload (verified 2026-05-08; ten "no_match" rows replayed: bulk returned 3/10, single returned 10/10).

Decision: **single-call is the default** everywhere — connector method, `enrich_person`, and the `enrich --persons` CLI. `ApolloClient.people_bulk_match` is preserved as opt-in only and emits a `UserWarning`. Test `test_bulk_match_emits_warning` enforces the warning; test `test_default_path_uses_people_match_not_bulk` asserts `enrich_person` makes exactly one POST and that it goes to `/people/match`, not `/people/bulk_match`.

## Provenance — `api:apollo:<YYYY-MM-DD>`

Every field that `enrich_person` returns carries a matching entry in `EnrichResult.field_sources`. The canonical source string is built by `_apollo_source(date_str=None)` and has the form `api:apollo:<YYYY-MM-DD>` using UTC today. The CLI merges `field_sources` into the wiki's existing `field_sources` map without clobbering pre-existing entries. `test_enrich_person_returns_field_sources_for_every_field` asserts coverage parity (every key in `fields` also appears in `field_sources`) and that every value matches the expected `api:apollo:2026-05-08` form.

## YAML-corruption regression — guarded

The cwc-side `apollo_enrich_warm_tier.py` line-splicing writer splices 2-space-indented tag entries into 0-space-indented blocks, breaking `yaml.safe_load` on 3,341 live wikis. This connector does NOT splice raw lines. The CLI composes writes via `athenaeum.models.render_frontmatter` — PyYAML `safe_dump(..., sort_keys=False)`, which produces YAML that round-trips cleanly through `yaml.safe_load`. Test `test_enriched_frontmatter_yaml_roundtrips` enriches a person, renders via `render_frontmatter`, asserts `parse_frontmatter` reloads a clean dict (employment history + tags survive intact), and a second render-then-parse round-trip is a no-op. Test `test_cli_enrich_apply_writes_with_field_sources` end-to-ends on-disk through the CLI and re-runs `yaml.safe_load` on the output as a final regression guard.

## Test plan

- [ ] CI green
- [x] `pytest tests/test_apollo_connector.py` — 13 passed locally
- [x] `pytest` — 463 passed, 1 skipped locally (no regressions)
- [x] `ruff check` clean on new code

## Out of scope (orchestrator handles after merge)

- Reducing `cwc/scripts/knowledge-librarian/apollo_enrich_warm_tier.py` to a thin wrapper around the new CLI.
- Deleting `cwc/scripts/knowledge-librarian/apollo_wrapper.py`.

🧙 Built with [WOZCODE](https://wozcode.com)
