### PR TITLE
docs(branch-flow): switch to develop-default; document trunk-style branch model

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/athenaeum.svg)](https://pypi.org/project/athenaeum/)
 [![Python versions](https://img.shields.io/pypi/pyversions/athenaeum.svg)](https://pypi.org/project/athenaeum/)
-[![License](https://img.shields.io/pypi/l/athenaeum.svg)](https://github.com/Kromatic-Innovation/athenaeum/blob/main/LICENSE)
+[![License](https://img.shields.io/pypi/l/athenaeum.svg)](https://github.com/Kromatic-Innovation/athenaeum/blob/develop/LICENSE)
 
 **Production-grade agentic memory for teams deploying multiple AI agents.**
+Athenaeum follows trunk-style development with `develop` as the active branch
+and `main` as the released-revision pointer.
 Append-only intake, a tiered librarian that compiles raw observations into a
 trustworthy wiki, and a sidecar that makes recall happen passively on every
 turn.
@@ -182,7 +184,7 @@ This gives you:
 - **Context checkpointing** — observations are saved before context-window compaction.
 
 Full setup guide, smoke test, and environment-variable reference:
-[`examples/claude-code/README.md`](https://github.com/Kromatic-Innovation/athenaeum/blob/main/examples/claude-code/README.md).
+[`examples/claude-code/README.md`](https://github.com/Kromatic-Innovation/athenaeum/blob/develop/examples/claude-code/README.md).
 
 ## Integrations
 
@@ -315,6 +317,27 @@ pytest tests/ -v
 ruff check src/ tests/
 ```
 
+## Branch flow
+
+Athenaeum uses a trunk-style branch model:
+
+- **`develop`** is the active development branch and the GitHub default. All
+  pull requests target `develop`.
+- **`main`** carries the most recent released revision. Release tags
+  (`vX.Y.Z`) live on `main` and trigger the PyPI release workflow.
+
+Most users should install via `pip install athenaeum` (above). To work from
+source against the latest released revision instead of the active branch,
+clone and check out the latest tag:
+
+```bash
+git clone https://github.com/Kromatic-Innovation/athenaeum.git
+cd athenaeum
+git checkout "$(git describe --tags --abbrev=0)"
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full promotion flow.
+
 ## Getting help
 
 Rolling this out on a team? Open an
@@ -324,4 +347,4 @@ agent-memory rollouts often and are happy to point at whatever's useful.
 
 ## License
 
-Apache 2.0 — see [LICENSE](https://github.com/Kromatic-Innovation/athenaeum/blob/main/LICENSE).
+Apache 2.0 — see [LICENSE](https://github.com/Kromatic-Innovation/athenaeum/blob/develop/LICENSE).


### PR DESCRIPTION
## Summary

- GitHub default branch was flipped from `main` to `develop` on 2026-05-09. This PR aligns the user-facing docs with the new default while keeping the released-revision pointer (`main`) accurate.
- Adds an explicit **Branch flow** section to `README.md` documenting the trunk-style model: `develop` is active, `main` carries the released revision and the PyPI release tags.
- Repoints `/blob/main/` deep links in `README.md` (LICENSE, `examples/claude-code/README.md`) to `/blob/develop/` so they resolve against the active branch.

## Changes

- `README.md`
  - One-line trunk-style positioning note near the header.
  - New "Branch flow" section between Development and Getting help, with a `git checkout "$(git describe --tags --abbrev=0)"` recipe for users who want the latest released revision from source.
  - Three blob URLs repointed `main` → `develop` (license badge, example README link, license footer).

## Not changed (verified correct)

- `CONTRIBUTING.md` — already describes the develop-first flow and the `Promote Main` fast-forward promotion correctly.
- `SECURITY.md` — already states fixes land on `develop` first and promote to `main`.
- `pyproject.toml` URLs — branch-agnostic.
- `.github/workflows/*.yml` — branch logic in CI/promotion is correct as written; intentionally untouched (infra change, not docs).

## Test plan

- [ ] CI green on `chore/develop-default-doc-updates`
- [ ] Rendered README on the PR shows the new "Branch flow" section and the trunk-style note
- [ ] Repointed `/blob/develop/` links resolve to live files
