### PR TITLE
fix(dedupe): coalesce twitter_url + github_url on merge (#106)

### DIFF
--- a/src/athenaeum/dedupe.py
+++ b/src/athenaeum/dedupe.py
@@ -83,6 +83,10 @@ _GOOGLE_KEYS = {
     "google_contact_kromatic",
     "google_contact_tristankromer",
 }
+_SOCIAL_KEYS = {
+    "twitter_url",
+    "github_url",
+}
 
 # Fields where "list union with canonical-first order" is the merge rule.
 _LIST_UNION_KEYS = {"emails", "tags", "aliases"}
@@ -389,8 +393,8 @@ def _merge_meta(
             if absorbed.get(kspec) and not canonical.get(kspec):
                 out[kspec] = absorbed[kspec]
 
-    # Apollo + LinkedIn coalesce
-    for k in _APOLLO_KEYS | _LINKEDIN_KEYS:
+    # Apollo + LinkedIn + social URL coalesce
+    for k in _APOLLO_KEYS | _LINKEDIN_KEYS | _SOCIAL_KEYS:
         merged_v = _coalesce(canonical.get(k), absorbed.get(k))
         if merged_v is not None:
             out[k] = merged_v

--- a/tests/test_conflict_resolution.py
+++ b/tests/test_conflict_resolution.py
@@ -619,10 +619,9 @@ class TestDedupePerformMerge:
         # Apollo namespace + current_title: canonical wins (both truthy).
         assert meta["apollo_id"] == "apollo-123"
         assert meta["current_title"] == "VP"
-        # NOTE: twitter_url is NOT in dedupe.py's coalesce sets (_LINKEDIN_KEYS
-        # covers linkedin_* only). The absorbed-only twitter_url is therefore
-        # DROPPED on merge. Documented bug — see PR body for the filed issue.
-        assert "twitter_url" not in meta
+        # twitter_url is now in _SOCIAL_KEYS coalesce set (#106) — absorbed-only
+        # value carries forward to the canonical merged wiki.
+        assert meta["twitter_url"] == "https://twitter.com/alice"
 
     def test_perform_merge_max_numeric_higher_wins(self, tmp_path: Path) -> None:
         cpath, apath = self._setup_pair(tmp_path)

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -195,6 +195,72 @@ class TestMergePreservesFieldSources:
         assert "44444444" in meta["merged_from"]
 
 
+class TestSocialUrlCoalesce:
+    """Regression for #106 — twitter_url / github_url were silently dropped."""
+
+    def test_absorbed_only_social_urls_carry_forward(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="s1111111",
+            name="Social Canon",
+            apollo_id="apo-soc",
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="s2222222",
+            name="Social Absorb",
+            apollo_id="apo-soc",
+            extra={
+                "twitter_url": "https://twitter.com/socialabsorb",
+                "github_url": "https://github.com/socialabsorb",
+            },
+        )
+        pair = DuplicatePair(
+            canonical_uid="s1111111",
+            absorbed_uid="s2222222",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        assert meta["twitter_url"] == "https://twitter.com/socialabsorb"
+        assert meta["github_url"] == "https://github.com/socialabsorb"
+
+    def test_canonical_social_urls_win(self, wiki_root: Path) -> None:
+        cpath = _write_person(
+            wiki_root,
+            uid="s3333333",
+            name="Social Canon2",
+            apollo_id="apo-soc2",
+            extra={
+                "twitter_url": "https://twitter.com/canonical",
+                "github_url": "https://github.com/canonical",
+            },
+        )
+        apath = _write_person(
+            wiki_root,
+            uid="s4444444",
+            name="Social Absorb2",
+            apollo_id="apo-soc2",
+            extra={
+                "twitter_url": "https://twitter.com/absorbed",
+                "github_url": "https://github.com/absorbed",
+            },
+        )
+        pair = DuplicatePair(
+            canonical_uid="s3333333",
+            absorbed_uid="s4444444",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        assert meta["twitter_url"] == "https://twitter.com/canonical"
+        assert meta["github_url"] == "https://github.com/canonical"
+
+
 class TestIdempotency:
     def test_apply_twice_is_noop(self, wiki_root: Path) -> None:
         cpath = _write_person(


### PR DESCRIPTION
## Context

`src/athenaeum/dedupe.py::_merge_meta` coalesces `apollo_id`, `linkedin_url`, Apollo namespace keys, and Google contact keys from absorbed onto canonical when the canonical value is empty. `twitter_url` and `github_url` were missing from these coalesce sets, so an absorbed wiki carrying social URLs would silently lose them on merge.

## Change

- Add `_SOCIAL_KEYS = {"twitter_url", "github_url"}` to `dedupe.py`.
- Include it in the existing `_APOLLO_KEYS | _LINKEDIN_KEYS` coalesce loop. Same canonical-wins-when-truthy semantics as the surrounding namespaces.

## Tests

- New `TestSocialUrlCoalesce` class in `tests/test_dedupe.py`:
  - absorbed-only `twitter_url` + `github_url` carry forward to canonical
  - canonical's `twitter_url` + `github_url` win when both sides have values
- Updated `tests/test_conflict_resolution.py::test_perform_merge_coalesce_canonical_wins_when_truthy` — that test previously documented the bug (`assert "twitter_url" not in meta`); it now asserts the absorbed value carries forward.

Closes #106
