### PR TITLE
chore(init): polish init UX (#105)

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -44,8 +44,8 @@ def main(argv: list[str] | None = None) -> int:
     init_parser.add_argument(
         "--force",
         action="store_true",
-        help="Overwrite existing template files at the destination "
-        "(only applies with --with-templates).",
+        help="Overwrite existing template files at the destination; "
+        "no backup is created (only applies with --with-templates).",
     )
 
     # status command
@@ -505,6 +505,12 @@ def _cmd_init(args: argparse.Namespace) -> int:
             print(f"  wrote   {dest / fname}")
         for fname in skipped:
             print(f"  skipped {dest / fname} (exists; pass --force to overwrite)")
+    elif args.templates_dest is not None:
+        print(
+            "warning: --templates-dest is ignored without --with-templates; "
+            "no templates were copied.",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/src/athenaeum/templates/company.md
+++ b/src/athenaeum/templates/company.md
@@ -1,4 +1,5 @@
 ---
+# Scaffold template — copied by `athenaeum init --with-templates` for users to edit (not an LLM-tier schema).
 uid: company-REPLACE-ME
 type: company
 name: REPLACE ME

--- a/src/athenaeum/templates/concept.md
+++ b/src/athenaeum/templates/concept.md
@@ -1,4 +1,5 @@
 ---
+# Scaffold template — copied by `athenaeum init --with-templates` for users to edit (not an LLM-tier schema).
 uid: concept-REPLACE-ME
 type: concept
 name: REPLACE ME

--- a/src/athenaeum/templates/person.md
+++ b/src/athenaeum/templates/person.md
@@ -1,4 +1,5 @@
 ---
+# Scaffold template — copied by `athenaeum init --with-templates` for users to edit (not an LLM-tier schema).
 uid: person-REPLACE-ME
 type: person
 name: REPLACE ME

--- a/src/athenaeum/templates/project.md
+++ b/src/athenaeum/templates/project.md
@@ -1,4 +1,5 @@
 ---
+# Scaffold template — copied by `athenaeum init --with-templates` for users to edit (not an LLM-tier schema).
 uid: project-REPLACE-ME
 type: project
 name: REPLACE ME

--- a/src/athenaeum/templates/source.md
+++ b/src/athenaeum/templates/source.md
@@ -1,4 +1,5 @@
 ---
+# Scaffold template — copied by `athenaeum init --with-templates` for users to edit (not an LLM-tier schema).
 uid: source-REPLACE-ME
 type: source
 name: REPLACE ME

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -69,7 +69,9 @@ def test_idempotent_preserves_content(tmp_path: Path) -> None:
     (target / "wiki" / "_index.md").write_text(custom_index, encoding="utf-8")
 
     custom_schema = "# Custom types\n"
-    (target / "wiki" / "_schema" / "types.md").write_text(custom_schema, encoding="utf-8")
+    (target / "wiki" / "_schema" / "types.md").write_text(
+        custom_schema, encoding="utf-8"
+    )
 
     # Add a user file in raw/
     (target / "raw" / "my-notes.md").write_text("my notes\n", encoding="utf-8")
@@ -79,7 +81,9 @@ def test_idempotent_preserves_content(tmp_path: Path) -> None:
 
     # Verify nothing was overwritten
     assert (target / "wiki" / "_index.md").read_text(encoding="utf-8") == custom_index
-    assert (target / "wiki" / "_schema" / "types.md").read_text(encoding="utf-8") == custom_schema
+    assert (target / "wiki" / "_schema" / "types.md").read_text(
+        encoding="utf-8"
+    ) == custom_schema
     assert (target / "raw" / "my-notes.md").read_text(encoding="utf-8") == "my notes\n"
 
 
@@ -105,7 +109,8 @@ def test_cli_init_default(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_git_identity_error_gives_helpful_message(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Issue #10: When git identity is not configured, init should raise
     SystemExit with a helpful message instead of a raw CalledProcessError."""
@@ -120,7 +125,8 @@ def test_git_identity_error_gives_helpful_message(
         # Let git init and git add succeed; fail on git commit (3rd call)
         if call_count == 3:
             raise subprocess.CalledProcessError(
-                128, cmd,
+                128,
+                cmd,
                 stderr=b"Author identity unknown\n"
                 b"*** Please tell me who you are.\n"
                 b"  git config --global user.name ...\n"
@@ -134,6 +140,45 @@ def test_git_identity_error_gives_helpful_message(
 
     with pytest.raises(SystemExit, match="Git identity not configured"):
         init_knowledge_dir(target)
+
+
+def test_force_help_mentions_no_backup(capsys: pytest.CaptureFixture[str]) -> None:
+    """`--force` help text should warn that no backup is created (#105)."""
+    from athenaeum.cli import main
+
+    with pytest.raises(SystemExit):
+        main(["init", "--help"])
+    captured = capsys.readouterr()
+    assert "backup" in captured.out.lower()
+
+
+def test_templates_dest_without_with_templates_warns(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--templates-dest` without `--with-templates` must emit a stderr
+    warning so the user notices the flag was silently ignored (#105)."""
+    from athenaeum.cli import main
+
+    target = tmp_path / "knowledge"
+    custom_dest = tmp_path / "elsewhere"
+    exit_code = main(
+        [
+            "init",
+            "--path",
+            str(target),
+            "--templates-dest",
+            str(custom_dest),
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower()
+    assert "--templates-dest" in captured.err
+    assert "--with-templates" in captured.err
+    # Templates were not actually copied.
+    assert not custom_dest.exists()
 
 
 def test_schema_files_match_bundled(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Three taste-level fixes to `athenaeum init` UX:

- `--force` help text now mentions that no backup is created (previously silent on what it actually does to existing files).
- `--templates-dest` without `--with-templates` was silently ignored. Now emits a `warning:` line to stderr; exit code unchanged.
- Each scaffold template under `src/athenaeum/templates/` gains a one-line header comment (inside the YAML frontmatter, `# Scaffold template — ...`) distinguishing them from LLM-tier schema files.

No behavior change beyond the new stderr warning. Tests added covering the help-text contains-`backup` and the stderr-warning paths.

Closes #105
