### PR TITLE
feat(provenance): tier3 emits source/field_sources + KNOWN_TYPES allowlist (#95, #93)

### DIFF
--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -156,6 +156,11 @@ class WikiEntity:
     created: str = ""
     updated: str = ""
     body: str = ""
+    # Per-claim provenance (issue #90 / #95). Optional so old wikis
+    # without provenance still round-trip cleanly. ``source`` is the
+    # wiki-level default; ``field_sources`` overrides per field.
+    source: str | dict | None = None
+    field_sources: dict[str, str | dict] | None = None
 
     @property
     def filename(self) -> str:
@@ -179,6 +184,10 @@ class WikiEntity:
             meta["created"] = self.created
         if self.updated:
             meta["updated"] = self.updated
+        if self.source is not None:
+            meta["source"] = self.source
+        if self.field_sources:
+            meta["field_sources"] = self.field_sources
         return render_frontmatter(meta) + "\n" + self.body
 
 

--- a/src/athenaeum/schemas.py
+++ b/src/athenaeum/schemas.py
@@ -27,6 +27,7 @@ Out of scope here (Lane B / #90, Lane G / #91):
 """
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, field_validator
@@ -141,6 +142,28 @@ _BY_TYPE: dict[str, type[WikiBase]] = {
     "source": SourceWiki,
 }
 
+# Types that are not in ``_BY_TYPE`` but are present in the live wiki
+# tree as of 2026-05-09 (issue #93 audit). These fall through to
+# :class:`WikiBase` for validation; the allowlist exists so unknown
+# types (typos, drift) emit a warning instead of being silently
+# accepted. See issue #93.
+FALLBACK_TYPES: frozenset[str] = frozenset(
+    {
+        "auto-memory",
+        "tool",
+        "reference",
+        "principle",
+        "feedback",
+        "preference",
+        "user",
+    }
+)
+
+#: All wiki ``type`` values currently recognized — concrete schemas
+#: plus the live-tree fallback set. Anything outside this set triggers
+#: a :class:`UserWarning` from :func:`validate_wiki_meta`.
+KNOWN_TYPES: frozenset[str] = frozenset(_BY_TYPE) | FALLBACK_TYPES
+
 
 def validate_wiki_meta(meta: dict[str, Any]) -> WikiBase:
     """Validate a frontmatter dict against the appropriate schema.
@@ -148,8 +171,18 @@ def validate_wiki_meta(meta: dict[str, Any]) -> WikiBase:
     Dispatches by ``meta["type"]``. Unknown types fall through to
     :class:`WikiBase` (still enforces uid/type/name). Raises
     :class:`pydantic.ValidationError` on malformed input.
+
+    Issue #93: emits a :class:`UserWarning` (NOT an exception) when
+    ``meta["type"]`` is outside :data:`KNOWN_TYPES`. Recoverable —
+    strict mode is out of scope.
     """
     etype = meta.get("type", "")
+    if etype and etype not in KNOWN_TYPES:
+        warnings.warn(
+            f"unknown wiki type: {etype!r} (not in KNOWN_TYPES)",
+            UserWarning,
+            stacklevel=2,
+        )
     model_cls = _BY_TYPE.get(etype, WikiBase)
     return model_cls.model_validate(meta)
 
@@ -161,5 +194,7 @@ __all__ = [
     "ProjectWiki",
     "ConceptWiki",
     "SourceWiki",
+    "FALLBACK_TYPES",
+    "KNOWN_TYPES",
     "validate_wiki_meta",
 ]

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -47,7 +47,8 @@ def _get_write_model() -> str:
 
 
 def _record_usage(
-    response: anthropic.types.Message, usage: TokenUsage | None,
+    response: anthropic.types.Message,
+    usage: TokenUsage | None,
 ) -> None:
     """Record token usage from an API response if tracking is enabled."""
     if usage is not None and hasattr(response, "usage"):
@@ -71,6 +72,7 @@ def _load_schema_text(wiki_root: Path, filename: str) -> str:
 # ---------------------------------------------------------------------------
 # Tier 1 — Programmatic matching
 # ---------------------------------------------------------------------------
+
 
 def tier1_programmatic_match(
     raw: RawFile,
@@ -179,10 +181,7 @@ def tier2_classify(
     if wiki_root:
         obs_text = _load_schema_text(wiki_root, "observation-filter.md")
         if obs_text:
-            obs_filter = (
-                "\n## Observation filter (what to capture)\n"
-                f"{obs_text}\n"
-            )
+            obs_filter = "\n## Observation filter (what to capture)\n" f"{obs_text}\n"
 
     user_msg = CLASSIFY_USER_TEMPLATE.format(
         content=raw.content[:4000],
@@ -211,7 +210,9 @@ def tier2_classify(
     try:
         items = json.loads(json_match.group())
     except json.JSONDecodeError:
-        log.warning("Classification returned invalid JSON for %s: %s", raw.ref, text[:200])
+        log.warning(
+            "Classification returned invalid JSON for %s: %s", raw.ref, text[:200]
+        )
         return []
 
     results: list[ClassifiedEntity] = []
@@ -226,14 +227,16 @@ def tier2_classify(
             access = "internal"
         tags = [t for t in item.get("tags", []) if t in valid_tags]
 
-        results.append(ClassifiedEntity(
-            name=item["name"],
-            entity_type=entity_type,
-            tags=tags,
-            access=access,
-            is_new=True,
-            observations=item.get("observations", ""),
-        ))
+        results.append(
+            ClassifiedEntity(
+                name=item["name"],
+                entity_type=entity_type,
+                tags=tags,
+                access=access,
+                is_new=True,
+                observations=item.get("observations", ""),
+            )
+        )
 
     return results
 
@@ -315,8 +318,7 @@ def tier3_create(
         tmpl_text = _load_schema_text(wiki_root, "_entity-template.md")
         if tmpl_text:
             tmpl_section = (
-                "\n## Entity template (follow this structure)\n"
-                f"{tmpl_text}\n"
+                "\n## Entity template (follow this structure)\n" f"{tmpl_text}\n"
             )
 
     user_msg = CREATE_TEMPLATE.format(
@@ -340,6 +342,13 @@ def tier3_create(
     body = response.content[0].text.strip()
     today = date.today().isoformat()
 
+    # Issue #95: stamp authoritative provenance at construction time.
+    # Format: ``claude:tier3-create:<model>:<YYYY-MM-DD>``. The model
+    # name is read live from the same env-driven setting used for the
+    # API call so the source matches the model that actually wrote.
+    model = _get_write_model() or "unknown"
+    source = f"claude:tier3-create:{model}:{today}"
+
     return WikiEntity(
         uid=generate_uid(),
         type=action.entity_type,
@@ -350,6 +359,7 @@ def tier3_create(
         created=today,
         updated=today,
         body=body,
+        source=source,
     )
 
 
@@ -422,8 +432,11 @@ def tier3_write(
         if action.kind == "create":
             new_entities.append(
                 tier3_create(
-                    action, raw.ref, client,
-                    wiki_root=wiki_root, usage=usage,
+                    action,
+                    raw.ref,
+                    client,
+                    wiki_root=wiki_root,
+                    usage=usage,
                 )
             )
 
@@ -431,23 +444,50 @@ def tier3_write(
             existing_path = index.get_by_uid(action.existing_uid)
 
             if not existing_path or not existing_path.exists():
-                log.warning("Could not find existing page for uid %s", action.existing_uid)
+                log.warning(
+                    "Could not find existing page for uid %s", action.existing_uid
+                )
                 continue
 
             text = existing_path.read_text(encoding="utf-8")
             meta, existing_body = parse_frontmatter(text)
 
             updated_body, esc = tier3_merge(
-                action, existing_body, raw.ref, client, usage=usage,
+                action,
+                existing_body,
+                raw.ref,
+                client,
+                usage=usage,
             )
             if esc:
                 escalations.append(esc)
             if updated_body:
-                meta["updated"] = date.today().isoformat()
-                pending_updates.append((
-                    existing_path,
-                    render_frontmatter(meta) + "\n" + updated_body,
-                ))
+                today_iso = date.today().isoformat()
+                meta["updated"] = today_iso
+
+                # Issue #95: per-claim provenance on merge. The
+                # incoming source wins for fields the merge actually
+                # overwrote (Wikipedia rule: incoming wins for that
+                # field, so its source wins for that field). Preserve
+                # canonical's existing field_sources for non-touched
+                # fields.
+                model = _get_write_model() or "unknown"
+                merge_source = f"claude:tier3-merge:{model}:{today_iso}"
+                fs = meta.get("field_sources")
+                if not isinstance(fs, dict):
+                    fs = {}
+                # tier3_merge currently overwrites only ``body`` and
+                # ``updated`` from the LLM call; attribute both to the
+                # merge source. Other fields keep their prior source.
+                fs["body"] = merge_source
+                fs["updated"] = merge_source
+                meta["field_sources"] = fs
+                pending_updates.append(
+                    (
+                        existing_path,
+                        render_frontmatter(meta) + "\n" + updated_body,
+                    )
+                )
                 updated_uids.append(action.existing_uid)
 
     # All LLM calls succeeded — apply updates atomically
@@ -461,7 +501,10 @@ def tier3_write(
 # Tier 4 — Human escalation
 # ---------------------------------------------------------------------------
 
-def _question_from_description(description: str, entity_name: str, conflict_type: str) -> str:
+
+def _question_from_description(
+    description: str, entity_name: str, conflict_type: str
+) -> str:
     """Derive a one-line question for the checkbox row.
 
     Uses the first non-empty line of the description, trimmed to a single
@@ -497,9 +540,9 @@ def tier4_escalate(items: list[EscalationItem], pending_path: Path) -> None:
         # double quotes round-trip cleanly. raw_ref is NOT escaped: paths
         # should survive in storage untouched; the parser anchors to the
         # final ")\n" to tolerate parens inside refs.
-        escaped_entity = item.entity_name.replace("\\", "\\\\").replace("\"", "\\\"")
+        escaped_entity = item.entity_name.replace("\\", "\\\\").replace('"', '\\"')
         sections.append(
-            f"## [{today}] Entity: \"{escaped_entity}\" (from {item.raw_ref})\n"
+            f'## [{today}] Entity: "{escaped_entity}" (from {item.raw_ref})\n'
             f"- [ ] {question}\n\n"
             f"**Conflict type**: {item.conflict_type}\n"
             f"**Description**: {item.description}\n"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -21,6 +21,8 @@ from pydantic import ValidationError
 
 from athenaeum.models import parse_frontmatter
 from athenaeum.schemas import (
+    FALLBACK_TYPES,
+    KNOWN_TYPES,
     CompanyWiki,
     ConceptWiki,
     PersonWiki,
@@ -339,3 +341,48 @@ class TestProvenanceFields:
         m = validate_wiki_meta(meta)
         assert m.source == "api:apollo:2026-05-07"
         assert m.field_sources == {"emails": "api:apollo:2026-05-07"}
+
+
+# --- KNOWN_TYPES allowlist (issue #93) ---
+
+
+class TestKnownTypes:
+    """Issue #93: validate_wiki_meta warns on unknown types but does not raise."""
+
+    def test_known_types_includes_concrete_schemas(self) -> None:
+        for t in ("person", "company", "project", "concept", "source"):
+            assert t in KNOWN_TYPES
+
+    def test_known_types_includes_fallback_set(self) -> None:
+        for t in (
+            "auto-memory",
+            "tool",
+            "reference",
+            "principle",
+            "feedback",
+            "preference",
+            "user",
+        ):
+            assert t in KNOWN_TYPES
+            assert t in FALLBACK_TYPES
+
+    def test_unknown_type_emits_warning(self) -> None:
+        meta = {"uid": "abc12345", "type": "persn", "name": "X"}
+        with pytest.warns(UserWarning, match="unknown wiki type"):
+            validate_wiki_meta(meta)
+
+    def test_unknown_type_does_not_raise(self) -> None:
+        # Falls through to WikiBase — uid/type/name still validated.
+        meta = {"uid": "abc12345", "type": "novel-type", "name": "X"}
+        with pytest.warns(UserWarning):
+            m = validate_wiki_meta(meta)
+        assert m.type == "novel-type"
+
+    def test_known_type_emits_no_warning(self) -> None:
+        import warnings as _w
+
+        meta = {"uid": "abc12345", "type": "auto-memory", "name": "X"}
+        with _w.catch_warnings():
+            _w.simplefilter("error", UserWarning)
+            # Should not raise — no warning expected for KNOWN_TYPES.
+            validate_wiki_meta(meta)

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -116,7 +116,8 @@ class TestTier2:
         assert "untrusted user data" in system_msg
 
     def test_classify_includes_observation_filter(
-        self, wiki_dir: Path,
+        self,
+        wiki_dir: Path,
     ) -> None:
         """Issue #17: observation-filter.md should be injected into classify prompt."""
         from athenaeum.tiers import tier2_classify
@@ -131,7 +132,12 @@ class TestTier2:
         client = _mock_client("[]")
 
         tier2_classify(
-            raw, [], ["person"], [], ["internal"], client,
+            raw,
+            [],
+            ["person"],
+            [],
+            ["internal"],
+            client,
             wiki_root=wiki_dir,
         )
         call_args = client.messages.create.call_args
@@ -149,13 +155,19 @@ class TestTier2:
         mock_response = MagicMock()
         mock_response.content = [MagicMock(text="[]")]
         mock_response.usage = MagicMock(
-            input_tokens=150, output_tokens=20,
+            input_tokens=150,
+            output_tokens=20,
         )
         client.messages.create.return_value = mock_response
 
         usage = TokenUsage()
         tier2_classify(
-            raw, [], ["person"], [], ["internal"], client,
+            raw,
+            [],
+            ["person"],
+            [],
+            ["internal"],
+            client,
             usage=usage,
         )
         assert usage.input_tokens == 150
@@ -166,13 +178,17 @@ class TestTier2:
         from athenaeum.tiers import tier2_classify
 
         raw = _make_raw("Had coffee with Alice Zhang, she runs product at Acme.")
-        response_json = json.dumps([{
-            "name": "Alice Zhang",
-            "entity_type": "person",
-            "tags": ["active", "client"],
-            "access": "internal",
-            "observations": "Runs product at Acme.",
-        }])
+        response_json = json.dumps(
+            [
+                {
+                    "name": "Alice Zhang",
+                    "entity_type": "person",
+                    "tags": ["active", "client"],
+                    "access": "internal",
+                    "observations": "Runs product at Acme.",
+                }
+            ]
+        )
         client = _mock_client(response_json)
 
         result = tier2_classify(
@@ -203,17 +219,26 @@ class TestTier2:
         from athenaeum.tiers import tier2_classify
 
         raw = _make_raw("Some content about a widget.")
-        response_json = json.dumps([{
-            "name": "Widget",
-            "entity_type": "gadget",  # not in valid_types
-            "tags": [],
-            "access": "internal",
-            "observations": "A widget thing.",
-        }])
+        response_json = json.dumps(
+            [
+                {
+                    "name": "Widget",
+                    "entity_type": "gadget",  # not in valid_types
+                    "tags": [],
+                    "access": "internal",
+                    "observations": "A widget thing.",
+                }
+            ]
+        )
         client = _mock_client(response_json)
 
         result = tier2_classify(
-            raw, [], ["person", "company", "reference"], [], ["internal"], client,
+            raw,
+            [],
+            ["person", "company", "reference"],
+            [],
+            ["internal"],
+            client,
         )
         assert len(result) == 1
         assert result[0].entity_type == "reference"
@@ -222,12 +247,16 @@ class TestTier2:
         from athenaeum.tiers import tier2_classify
 
         raw = _make_raw("Some content.")
-        response_json = json.dumps([{
-            "name": "Test Entity",
-            "entity_type": "person",
-            "tags": [],
-            "access": "top-secret",  # not in valid_access
-        }])
+        response_json = json.dumps(
+            [
+                {
+                    "name": "Test Entity",
+                    "entity_type": "person",
+                    "tags": [],
+                    "access": "top-secret",  # not in valid_access
+                }
+            ]
+        )
         client = _mock_client(response_json)
 
         result = tier2_classify(
@@ -245,16 +274,25 @@ class TestTier2:
         from athenaeum.tiers import tier2_classify
 
         raw = _make_raw("Some content.")
-        response_json = json.dumps([{
-            "name": "Test",
-            "entity_type": "person",
-            "tags": ["active", "bogus-tag", "client"],
-            "access": "internal",
-        }])
+        response_json = json.dumps(
+            [
+                {
+                    "name": "Test",
+                    "entity_type": "person",
+                    "tags": ["active", "bogus-tag", "client"],
+                    "access": "internal",
+                }
+            ]
+        )
         client = _mock_client(response_json)
 
         result = tier2_classify(
-            raw, [], ["person"], ["active", "client"], ["internal"], client,
+            raw,
+            [],
+            ["person"],
+            ["active", "client"],
+            ["internal"],
+            client,
         )
         assert result[0].tags == ["active", "client"]
 
@@ -263,9 +301,9 @@ class TestTier2:
 
         raw = _make_raw("Met Bob at the conference.")
         fenced = (
-            '```json\n'
+            "```json\n"
             '[{"name": "Bob", "entity_type": "person", "tags": [], "access": "internal"}]\n'
-            '```'
+            "```"
         )
         client = _mock_client(fenced)
 
@@ -295,10 +333,17 @@ class TestTier2:
         from athenaeum.tiers import tier2_classify
 
         raw = _make_raw("Some content.")
-        response_json = json.dumps([
-            {"entity_type": "person", "tags": [], "access": "internal"},  # no name
-            {"name": "Valid", "entity_type": "person", "tags": [], "access": "internal"},
-        ])
+        response_json = json.dumps(
+            [
+                {"entity_type": "person", "tags": [], "access": "internal"},  # no name
+                {
+                    "name": "Valid",
+                    "entity_type": "person",
+                    "tags": [],
+                    "access": "internal",
+                },
+            ]
+        )
         client = _mock_client(response_json)
 
         result = tier2_classify(raw, [], ["person"], [], ["internal"], client)
@@ -383,7 +428,8 @@ class TestTier3Create:
         assert "data only" in user_msg
 
     def test_create_includes_entity_template(
-        self, wiki_dir: Path,
+        self,
+        wiki_dir: Path,
     ) -> None:
         """Issue #17: _entity-template.md should be fed to Tier 3 create."""
         schema_dir = wiki_dir / "_schema"
@@ -404,7 +450,10 @@ class TestTier3Create:
         client = _mock_client("# Test\n\nContent.")
 
         tier3_create(
-            action, "ref.md", client, wiki_root=wiki_dir,
+            action,
+            "ref.md",
+            client,
+            wiki_root=wiki_dir,
         )
         call_args = client.messages.create.call_args
         user_msg = call_args.kwargs["messages"][0]["content"]
@@ -637,7 +686,9 @@ class TestTier3Write:
         ]
 
         create_response = MagicMock()
-        create_response.content = [MagicMock(text="# Alice Zhang\n\nProduct lead at Acme.")]
+        create_response.content = [
+            MagicMock(text="# Alice Zhang\n\nProduct lead at Acme.")
+        ]
         merge_response = MagicMock()
         merge_response.content = [
             MagicMock(
@@ -649,7 +700,11 @@ class TestTier3Write:
         client.messages.create.side_effect = [create_response, merge_response]
 
         new_entities, updated_uids, escalations = tier3_write(
-            raw, actions, index, wiki_dir, client,
+            raw,
+            actions,
+            index,
+            wiki_dir,
+            client,
         )
 
         assert len(new_entities) == 1
@@ -731,7 +786,9 @@ class TestTier3Write:
             tier3_write(raw, actions, index, wiki_dir, client)
 
         acme_after = (wiki_dir / "a1b2c3d4-acme-corp.md").read_text()
-        assert acme_after == acme_before, "update was written despite subsequent failure"
+        assert (
+            acme_after == acme_before
+        ), "update was written despite subsequent failure"
 
     def test_uid_lookup_instead_of_glob(self, wiki_dir: Path) -> None:
         """tier3_write uses EntityIndex UID lookup, not filesystem glob."""
@@ -752,12 +809,118 @@ class TestTier3Write:
 
         client = _mock_client("# Acme Corp\n\nUpdated content.")
         new_entities, updated_uids, escalations = tier3_write(
-            raw, actions, index, wiki_dir, client,
+            raw,
+            actions,
+            index,
+            wiki_dir,
+            client,
         )
 
         assert updated_uids == ["a1b2c3d4"]
         acme_content = (wiki_dir / "a1b2c3d4-acme-corp.md").read_text()
         assert "Updated content" in acme_content
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — Provenance (issue #95)
+# ---------------------------------------------------------------------------
+
+
+class TestTier3Provenance:
+    """Issue #95: tier3 write paths must emit source / field_sources."""
+
+    def test_create_stamps_source_on_entity(self) -> None:
+        action = EntityAction(
+            kind="create",
+            name="Bob Test",
+            entity_type="person",
+            tags=[],
+            access="internal",
+            existing_uid=None,
+            observations="A new person.",
+        )
+        client = _mock_client("# Bob Test\n\nbody.")
+        entity = tier3_create(action, "sessions/raw.md", client)
+        assert entity.source is not None
+        assert isinstance(entity.source, str)
+        assert entity.source.startswith("claude:tier3-create:")
+
+    def test_create_render_emits_source_in_frontmatter(self) -> None:
+        action = EntityAction(
+            kind="create",
+            name="Carol",
+            entity_type="person",
+            tags=[],
+            access="internal",
+            existing_uid=None,
+            observations="text",
+        )
+        client = _mock_client("# Carol\n\nbody.")
+        entity = tier3_create(action, "sessions/raw.md", client)
+        rendered = entity.render()
+        assert "source: claude:tier3-create:" in rendered
+
+    def test_merge_sets_field_sources_for_overwritten_fields(
+        self,
+        wiki_dir: Path,
+    ) -> None:
+        """tier3_write merge attributes overwritten fields to the
+        merge source and preserves prior field_sources entries."""
+        import textwrap as _tw
+
+        (wiki_dir / "a1b2c3d4-acme-corp.md").write_text(
+            _tw.dedent(
+                """\
+            ---
+            uid: a1b2c3d4
+            type: company
+            name: Acme Corp
+            access: confidential
+            tags:
+              - client
+            created: '2024-03-15'
+            updated: '2024-04-06'
+            source: api:apollo
+            field_sources:
+              name: api:apollo
+              tags: manual:tristan
+            ---
+
+            # Acme Corp
+
+            Fintech startup.
+        """
+            )
+        )
+        raw = _make_raw("New info about Acme.")
+        index = EntityIndex(wiki_dir)
+
+        actions = [
+            EntityAction(
+                kind="update",
+                name="Acme Corp",
+                entity_type="company",
+                tags=[],
+                access="",
+                existing_uid="a1b2c3d4",
+                observations="Acme expanded ops.",
+            ),
+        ]
+        client = _mock_client("# Acme Corp\n\nFintech startup. Expanded ops.")
+        tier3_write(raw, actions, index, wiki_dir, client)
+
+        from athenaeum.models import parse_frontmatter
+
+        text = (wiki_dir / "a1b2c3d4-acme-corp.md").read_text()
+        meta, _body = parse_frontmatter(text)
+        fs = meta.get("field_sources")
+        assert isinstance(fs, dict)
+        # Overwritten fields attributed to merge source
+        assert fs["body"].startswith("claude:tier3-merge:")
+        assert fs["updated"].startswith("claude:tier3-merge:")
+        # Non-overwritten fields preserved
+        assert fs["name"] == "api:apollo"
+        assert fs["tags"] == "manual:tristan"
 
 
 # ---------------------------------------------------------------------------
@@ -838,14 +1001,12 @@ class TestTier4:
         lines = content.splitlines()
 
         # Find the header line and assert the next non-blank line is a `- [ ]`.
-        header_idx = next(
-            i for i, line in enumerate(lines) if line.startswith("## [")
-        )
+        header_idx = next(i for i, line in enumerate(lines) if line.startswith("## ["))
         # Checkbox may follow directly with no blank line between (per issue
         # schema: `directly under the header`).
-        assert lines[header_idx + 1].startswith("- [ ]"), (
-            f"expected checkbox line directly after header; got {lines[header_idx + 1]!r}"
-        )
+        assert lines[header_idx + 1].startswith(
+            "- [ ]"
+        ), f"expected checkbox line directly after header; got {lines[header_idx + 1]!r}"
         # Question text should be present on the checkbox line (derived
         # from the description).
         assert "Conflicting info about Acme" in lines[header_idx + 1]


### PR DESCRIPTION
## Summary

Phase 2 bundled lane: provenance + schema validation hardening.

### Issue #95 — tier3 emits `source` / `field_sources`

- `WikiEntity` (`models.py`) gains optional `source` and `field_sources` attributes mirroring the `WikiBase` schema. Both default to `None` so existing wikis without provenance still round-trip cleanly through tier0_passthrough.
- `WikiEntity.render` emits `source` and `field_sources` when present — old wikis without provenance render unchanged (no-key-emission preserves byte-for-byte round-trip for tier0).
- `tier3_create` stamps `source = "claude:tier3-create:<model>:<YYYY-MM-DD>"` on every new entity at construction time. The model name is read live from `_get_write_model()` so the stamp matches the model that actually wrote.
- `tier3_write` merge path attributes the fields it overwrites (`body`, `updated`) to `"claude:tier3-merge:<model>:<YYYY-MM-DD>"` while preserving the canonical's existing `field_sources` for fields the merge did not touch (Wikipedia rule: incoming wins for that field, so its source wins for that field).

### Issue #93 — `KNOWN_TYPES` allowlist guard

Live wiki audit (`~/knowledge/wiki/`, 2026-05-09):

| count | type |
| ----- | ---- |
| 16883 | person |
| 1507  | company |
| 236   | concept |
| 206   | auto-memory |
| 155   | tool |
| 109   | reference |
| 93    | principle |
| 61    | project |
| 24    | feedback |
| 9     | source |
| 4     | preference |
| 1     | user |

- `_BY_TYPE` already covers person/company/project/concept/source. New `FALLBACK_TYPES = frozenset({"auto-memory", "tool", "reference", "principle", "feedback", "preference", "user"})` — covers the rest of the live tree exactly.
- `KNOWN_TYPES = frozenset(_BY_TYPE) | FALLBACK_TYPES`.
- `validate_wiki_meta` now emits `warnings.warn(UserWarning)` (NOT raise) on unknown types. Recoverable — strict mode out of scope.

## Test plan

- [x] All existing tests still pass (534 baseline -> 542, +8 new)
- [x] Tier0 passthrough byte-for-byte round-trip preserved (19 passed under `-k "tier0 or passthrough or roundtrip"`)
- [x] New tests:
  - `TestTier3Provenance.test_create_stamps_source_on_entity`
  - `TestTier3Provenance.test_create_render_emits_source_in_frontmatter`
  - `TestTier3Provenance.test_merge_sets_field_sources_for_overwritten_fields` (verifies preservation of prior `field_sources` for non-overwritten fields)
  - `TestKnownTypes.test_known_types_includes_concrete_schemas`
  - `TestKnownTypes.test_known_types_includes_fallback_set`
  - `TestKnownTypes.test_unknown_type_emits_warning`
  - `TestKnownTypes.test_unknown_type_does_not_raise`
  - `TestKnownTypes.test_known_type_emits_no_warning`

## Out of scope

- Conflict-resolution semantics (#91 audit owns those)
- Strict-mode for unknown types (warn-only by design)

Closes #95
Closes #93
