### PR TITLE
feat(provenance): per-value field_sources for list fields (#102)

### DIFF
--- a/src/athenaeum/dedupe.py
+++ b/src/athenaeum/dedupe.py
@@ -331,6 +331,62 @@ def _max_date(a: Any, b: Any) -> Any:
     return a if str(a) >= str(b) else b
 
 
+def _value_to_source_map(
+    side_fs_entry: Any,
+    side_field_value: Any,
+) -> dict[str, Any]:
+    """Project one side's ``field_sources.<k>`` entry to ``{repr(value): source}``.
+
+    - Per-value list shape → walk records, key by ``repr(record["value"])``.
+    - Legacy str/dict shape → applies to every value in that side's
+      underlying field list (``side_field_value`` if list, else single
+      value); each gets the same source.
+    - Anything else → empty map.
+    """
+    out: dict[str, Any] = {}
+    if isinstance(side_fs_entry, list):
+        for entry in side_fs_entry:
+            if isinstance(entry, dict) and "value" in entry and "source" in entry:
+                out[repr(entry["value"])] = entry["source"]
+        return out
+    if side_fs_entry is None:
+        return out
+    # Legacy: one source for the whole field. Broadcast across the side's
+    # actual list values (if any) so per-value union can absorb them.
+    if isinstance(side_field_value, list):
+        for v in side_field_value:
+            out[repr(v)] = side_fs_entry
+    elif side_field_value is not None:
+        out[repr(side_field_value)] = side_fs_entry
+    return out
+
+
+def _build_per_value_field_sources(
+    merged_list: list,
+    canonical_fs_entry: Any,
+    canonical_field_value: Any,
+    absorbed_fs_entry: Any,
+    absorbed_field_value: Any,
+) -> list[dict[str, Any]]:
+    """Build the per-value list shape for one list-typed field.
+
+    Canonical-wins-per-value: for each value in the merged list (post-
+    union), use canonical's source if known, else absorbed's. Values
+    with no attribution on either side are omitted (no dangling stale
+    entries — the field's value is still present, just unattributed).
+    """
+    canon_map = _value_to_source_map(canonical_fs_entry, canonical_field_value)
+    absorb_map = _value_to_source_map(absorbed_fs_entry, absorbed_field_value)
+    out: list[dict[str, Any]] = []
+    for v in merged_list:
+        key = repr(v)
+        if key in canon_map:
+            out.append({"value": v, "source": canon_map[key]})
+        elif key in absorb_map:
+            out.append({"value": v, "source": absorb_map[key]})
+    return out
+
+
 def _merge_field_sources(
     canonical_meta: dict[str, Any],
     absorbed_meta: dict[str, Any],
@@ -338,13 +394,15 @@ def _merge_field_sources(
 ) -> dict[str, Any] | None:
     """Build the merged ``field_sources`` map.
 
-    Rules (per #90):
+    Rules (per #90 + #102):
 
-    - Canonical's ``field_sources.<key>`` always wins.
-    - For keys that exist on absorbed's ``field_sources`` but not
-      canonical's, the absorbed entry is carried forward — this is how
-      per-value attribution survives for list fields whose values came
-      from the absorbed wiki only.
+    - For SCALAR fields: canonical's ``field_sources.<key>`` wins;
+      absorbed-only entries carry forward.
+    - For LIST fields: emit the per-value list-of-records shape (issue
+      #102 design lock §2). Canonical wins per value; absorbed-only
+      values bring their own attribution. Legacy single-source entries
+      on either side broadcast across that side's underlying values
+      before merging.
     - Keys whose merged value is absent from the merged frontmatter are
       pruned (don't keep dangling attributions).
     """
@@ -357,12 +415,28 @@ def _merge_field_sources(
     if not cfs and not afs:
         return None
     merged: dict[str, Any] = {}
-    for k, v in afs.items():
-        if k in merged_meta:
-            merged[k] = v
-    for k, v in cfs.items():
-        if k in merged_meta:
-            merged[k] = v  # canonical overrides
+    all_keys: set[str] = set(cfs) | set(afs)
+    for k in all_keys:
+        if k not in merged_meta:
+            continue  # prune dangling
+        merged_val = merged_meta[k]
+        if isinstance(merged_val, list):
+            # Per-value shape for list fields (#102).
+            per_value = _build_per_value_field_sources(
+                merged_val,
+                cfs.get(k),
+                canonical_meta.get(k),
+                afs.get(k),
+                absorbed_meta.get(k),
+            )
+            if per_value:
+                merged[k] = per_value
+        else:
+            # Scalar field: canonical wins; absorbed-only carries forward.
+            if k in cfs:
+                merged[k] = cfs[k]
+            elif k in afs:
+                merged[k] = afs[k]
     return merged or None
 
 

--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -160,7 +160,10 @@ class WikiEntity:
     # without provenance still round-trip cleanly. ``source`` is the
     # wiki-level default; ``field_sources`` overrides per field.
     source: str | dict | None = None
-    field_sources: dict[str, str | dict] | None = None
+    # ``field_sources`` per-field value is ``str``/``dict`` (legacy)
+    # OR ``list[dict]`` of ``{"value", "source"}`` records (per-value
+    # attribution for list fields, issue #102).
+    field_sources: dict[str, str | dict | list] | None = None
 
     @property
     def filename(self) -> str:

--- a/src/athenaeum/provenance.py
+++ b/src/athenaeum/provenance.py
@@ -164,10 +164,77 @@ def validate_source_value(value: Any) -> Any:
     return value
 
 
+def _is_per_value_list(value: Any) -> bool:
+    """Return True if ``value`` is the per-value list-of-records shape.
+
+    Per-value shape (issue #102, design lock §2.1):
+
+        [{"value": <any>, "source": <str|dict>}, ...]
+
+    A non-list, or a list that doesn't look like records of that shape,
+    is legacy. Empty list counts as per-value (vacuously valid — and
+    distinguishes intent from an absent value).
+    """
+    if not isinstance(value, list):
+        return False
+    if not value:
+        return True
+    for entry in value:
+        if not isinstance(entry, dict):
+            return False
+        if "value" not in entry or "source" not in entry:
+            return False
+    return True
+
+
+def parse_per_value_field_sources(value: Any) -> list[dict[str, Any]]:
+    """Parse a per-value ``field_sources.<list_field>`` entry.
+
+    Accepts a list of ``{"value": <any>, "source": <str|dict>}`` records.
+    Each record's ``source`` must validate via :func:`parse_source`;
+    ``value`` is type-unconstrained (matches the underlying list field's
+    element type). Extra keys on a record are rejected.
+
+    Returns the original list unchanged. Raises :class:`ValueError` on
+    malformed input.
+
+    Co-indexing alignment between this list and the underlying field's
+    list is NOT enforced here (per design-lock §2.4 — stale entries are
+    pruned at write time, not at validation).
+    """
+    if not isinstance(value, list):
+        raise ValueError(
+            f"per-value field_sources must be a list, got {type(value).__name__}"
+        )
+    for i, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"per-value field_sources[{i}] must be a dict, got {type(entry).__name__}"
+            )
+        if "value" not in entry:
+            raise ValueError(f"per-value field_sources[{i}] missing 'value' key")
+        if "source" not in entry:
+            raise ValueError(f"per-value field_sources[{i}] missing 'source' key")
+        extra = set(entry) - {"value", "source"}
+        if extra:
+            raise ValueError(
+                f"per-value field_sources[{i}] has unknown keys: {sorted(extra)!r}"
+            )
+        parse_source(entry["source"])  # raises on malformed
+    return value
+
+
 def validate_field_sources(value: Any) -> Any:
     """Validate a frontmatter ``field_sources`` value.
 
-    Must be a dict with string keys; each value validates as a source.
+    Must be a dict with string keys. Each value is one of:
+
+    - ``str`` or ``dict`` → legacy single-source-for-the-whole-field,
+      validated via :func:`parse_source`.
+    - ``list`` of ``{"value", "source"}`` records → per-value
+      attribution (issue #102), validated via
+      :func:`parse_per_value_field_sources`.
+
     Returns the original shape unchanged on success.
     """
     if value is None:
@@ -177,13 +244,17 @@ def validate_field_sources(value: Any) -> Any:
     for k, v in value.items():
         if not isinstance(k, str) or not k:
             raise ValueError(f"field_sources keys must be non-empty strings, got {k!r}")
-        parse_source(v)  # raises on malformed
+        if isinstance(v, list):
+            parse_per_value_field_sources(v)
+        else:
+            parse_source(v)  # raises on malformed
     return value
 
 
 __all__ = [
     "SourceRef",
     "parse_source",
+    "parse_per_value_field_sources",
     "validate_source_value",
     "validate_field_sources",
 ]

--- a/src/athenaeum/schemas.py
+++ b/src/athenaeum/schemas.py
@@ -58,7 +58,11 @@ class WikiBase(BaseModel):
     # Per-claim provenance (issue #90). Stored as the on-disk shape
     # (str OR dict) — round-trip fidelity beats normalization here.
     source: str | dict | None = None
-    field_sources: dict[str, str | dict] | None = None
+    # ``field_sources`` per-field value is one of:
+    # - ``str``/``dict`` (legacy single source for the whole field), or
+    # - ``list[dict]`` of ``{"value", "source"}`` records (per-value
+    #   attribution for list-typed fields, issue #102).
+    field_sources: dict[str, str | dict | list] | None = None
 
     @field_validator("source", mode="before")
     @classmethod

--- a/tests/test_conflict_resolution.py
+++ b/tests/test_conflict_resolution.py
@@ -552,6 +552,89 @@ class TestDedupeMergePrimitives:
         out = _merge_field_sources(cmeta, ameta, merged)
         assert out is None  # pruned everything → None
 
+    def test_merge_field_sources_per_value_survives_list_reorder(self) -> None:
+        """Per docs/provenance-shape.md §2.1: per-value attribution is
+        co-indexed BY VALUE, not by position. Reordering the underlying
+        list must carry attributions with the values."""
+        cmeta = {
+            "emails": ["a@x.com", "b@y.com"],
+            "field_sources": {
+                "emails": [
+                    {"value": "a@x.com", "source": "api:apollo:2026-04-29"},
+                    {"value": "b@y.com", "source": "linkedin:bhandle"},
+                ]
+            },
+        }
+        ameta: dict[str, object] = {"field_sources": {}}
+        # Merged list reordered relative to canonical's field_sources order.
+        merged = {"emails": ["b@y.com", "a@x.com"]}
+        out = _merge_field_sources(cmeta, ameta, merged)
+        assert out is not None
+        assert out["emails"] == [
+            {"value": "b@y.com", "source": "linkedin:bhandle"},
+            {"value": "a@x.com", "source": "api:apollo:2026-04-29"},
+        ]
+
+    def test_merge_field_sources_list_of_dicts_employment_history(self) -> None:
+        """Per docs/provenance-shape.md §2.2: per-value attribution
+        attaches to the WHOLE dict for list-of-dicts fields like
+        ``apollo_employment_history``. After merge both dicts present
+        with their respective sources."""
+        c_emp = [{"company": "Kromatic", "title": "Founder"}]
+        a_emp = [{"company": "SECUDE", "title": "Director"}]
+        cmeta = {
+            "apollo_employment_history": c_emp,
+            "field_sources": {
+                "apollo_employment_history": [
+                    {"value": c_emp[0], "source": "api:apollo:2026-04-29"},
+                ]
+            },
+        }
+        ameta = {
+            "apollo_employment_history": a_emp,
+            "field_sources": {
+                "apollo_employment_history": [
+                    {"value": a_emp[0], "source": "linkedin:tristankromer"},
+                ]
+            },
+        }
+        # Merged list = canonical first, absorbed second (list-union).
+        merged = {"apollo_employment_history": c_emp + a_emp}
+        out = _merge_field_sources(cmeta, ameta, merged)
+        assert out is not None
+        assert out["apollo_employment_history"] == [
+            {
+                "value": {"company": "Kromatic", "title": "Founder"},
+                "source": "api:apollo:2026-04-29",
+            },
+            {
+                "value": {"company": "SECUDE", "title": "Director"},
+                "source": "linkedin:tristankromer",
+            },
+        ]
+
+    def test_merge_field_sources_prunes_stale_per_value_entry(self) -> None:
+        """Per docs/provenance-shape.md §2.4: a per-value attribution
+        entry whose ``value`` no longer appears in the merged list is
+        dropped at write time, mirroring the prune-dangling rule."""
+        cmeta = {
+            "emails": ["a@x.com"],
+            "field_sources": {
+                "emails": [
+                    {"value": "a@x.com", "source": "api:apollo:2026-04-29"},
+                    # Stale — ``b@y.com`` is not in the merged list.
+                    {"value": "b@y.com", "source": "linkedin:bhandle"},
+                ]
+            },
+        }
+        ameta: dict[str, object] = {"field_sources": {}}
+        merged = {"emails": ["a@x.com"]}
+        out = _merge_field_sources(cmeta, ameta, merged)
+        assert out is not None
+        assert out["emails"] == [
+            {"value": "a@x.com", "source": "api:apollo:2026-04-29"},
+        ]
+
 
 class TestDedupePerformMerge:
     """End-to-end merge of a duplicate pair — locks every field-class rule."""

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -153,10 +153,15 @@ class TestMergePreservesFieldSources:
         # Union of emails preserved
         assert "alice@canonical.com" in meta["emails"]
         assert "alice@absorbed.com" in meta["emails"]
-        # Canonical's field_sources entry wins on the key (canonical-first
-        # ordering matches scalar-source semantics; per-value attribution
-        # is documented as the canonical-first list rule).
-        assert meta["field_sources"]["emails"] == "google:contact-1"
+        # Per-value attribution (#102): emails is a list field, so the
+        # writer emits the new per-value list-of-records shape.
+        # Canonical-wins-per-value: alice@canonical.com → google,
+        # alice@absorbed.com → linkedin (carried over from absorbed).
+        emails_fs = meta["field_sources"]["emails"]
+        assert isinstance(emails_fs, list)
+        by_value = {entry["value"]: entry["source"] for entry in emails_fs}
+        assert by_value["alice@canonical.com"] == "google:contact-1"
+        assert by_value["alice@absorbed.com"] == "linkedin:profile-2"
 
     def test_absorbed_only_field_sources_carries_forward(self, wiki_root: Path) -> None:
         cpath = _write_person(
@@ -185,14 +190,176 @@ class TestMergePreservesFieldSources:
         )
         merge_duplicate_persons([pair], apply=True)
         meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
-        # Absorbed-only emails attribution carried forward
-        assert meta["field_sources"]["emails"] == "apollo:export-2026"
+        # Absorbed-only emails attribution carried forward in the
+        # per-value list shape (#102). Canonical's emails value
+        # (bob@canonical.com) has no source on either side, so it's
+        # omitted; absorbed's value carries its source forward.
+        emails_fs = meta["field_sources"]["emails"]
+        assert isinstance(emails_fs, list)
+        by_value = {entry["value"]: entry["source"] for entry in emails_fs}
+        assert by_value["bob@absorbed.com"] == "apollo:export-2026"
         # Wiki-level source: canonical wins
         assert meta["source"] == "claude:session-canon"
         # Absorbed source archived in audit trail
         assert meta["merged_from_sources"]["44444444"] == "apollo:export-2026"
         # Audit trail uid recorded
         assert "44444444" in meta["merged_from"]
+
+
+class TestPerValueFieldSourcesMerge:
+    """Per-value ``field_sources`` for list fields — issue #102."""
+
+    @staticmethod
+    def _write_person_with_per_value(
+        wiki_root: Path,
+        *,
+        uid: str,
+        name: str,
+        apollo_id: str,
+        emails: list[str],
+        per_value_emails: list[dict],
+    ) -> Path:
+        import yaml as _yaml
+
+        fs_yaml = _yaml.safe_dump(
+            {"emails": per_value_emails}, default_flow_style=False, sort_keys=False
+        )
+        fs_indented = "\n".join("  " + ln for ln in fs_yaml.rstrip().splitlines())
+        emails_block = "\n".join(f"  - {e}" for e in emails)
+        text = (
+            "---\n"
+            f"uid: {uid}\n"
+            "type: person\n"
+            f"name: {name}\n"
+            f"apollo_id: {apollo_id}\n"
+            "emails:\n"
+            f"{emails_block}\n"
+            "field_sources:\n"
+            f"{fs_indented}\n"
+            "---\n"
+            "\n"
+            f"Body for {name}.\n"
+        )
+        path = wiki_root / f"{uid}-{name.lower().replace(' ', '-')}.md"
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_disjoint_per_value_sources_both_preserved(self, wiki_root: Path) -> None:
+        cpath = self._write_person_with_per_value(
+            wiki_root,
+            uid="pv111111",
+            name="Pat Canon",
+            apollo_id="apo-pv",
+            emails=["pat@one.com"],
+            per_value_emails=[
+                {"value": "pat@one.com", "source": "google:contact-pat"},
+            ],
+        )
+        apath = self._write_person_with_per_value(
+            wiki_root,
+            uid="pv222222",
+            name="Pat Absorb",
+            apollo_id="apo-pv",
+            emails=["pat@two.com"],
+            per_value_emails=[
+                {"value": "pat@two.com", "source": "linkedin:pat-handle"},
+            ],
+        )
+        pair = DuplicatePair(
+            canonical_uid="pv111111",
+            absorbed_uid="pv222222",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        emails_fs = meta["field_sources"]["emails"]
+        assert isinstance(emails_fs, list)
+        by_value = {e["value"]: e["source"] for e in emails_fs}
+        assert by_value == {
+            "pat@one.com": "google:contact-pat",
+            "pat@two.com": "linkedin:pat-handle",
+        }
+
+    def test_overlapping_per_value_canonical_wins(self, wiki_root: Path) -> None:
+        cpath = self._write_person_with_per_value(
+            wiki_root,
+            uid="pv333333",
+            name="Pat Canon",
+            apollo_id="apo-ov",
+            emails=["shared@x.com", "canon-only@x.com"],
+            per_value_emails=[
+                {"value": "shared@x.com", "source": "google:canon"},
+                {"value": "canon-only@x.com", "source": "google:canon-only"},
+            ],
+        )
+        apath = self._write_person_with_per_value(
+            wiki_root,
+            uid="pv444444",
+            name="Pat Absorb",
+            apollo_id="apo-ov",
+            emails=["shared@x.com", "absorb-only@x.com"],
+            per_value_emails=[
+                {"value": "shared@x.com", "source": "linkedin:absorb"},
+                {"value": "absorb-only@x.com", "source": "linkedin:absorb-only"},
+            ],
+        )
+        pair = DuplicatePair(
+            canonical_uid="pv333333",
+            absorbed_uid="pv444444",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        by_value = {e["value"]: e["source"] for e in meta["field_sources"]["emails"]}
+        # Canonical wins for shared values
+        assert by_value["shared@x.com"] == "google:canon"
+        assert by_value["canon-only@x.com"] == "google:canon-only"
+        assert by_value["absorb-only@x.com"] == "linkedin:absorb-only"
+
+    def test_legacy_canonical_plus_new_incoming_emits_new_shape(
+        self, wiki_root: Path
+    ) -> None:
+        # Canonical has legacy single-source; absorbed has per-value.
+        cpath = _write_person(
+            wiki_root,
+            uid="pv555555",
+            name="Pat Legacy",
+            apollo_id="apo-mix",
+            emails=["legacy@x.com"],
+            field_sources={"emails": "google:legacy-source"},
+        )
+        apath = self._write_person_with_per_value(
+            wiki_root,
+            uid="pv666666",
+            name="Pat New",
+            apollo_id="apo-mix",
+            emails=["new@x.com"],
+            per_value_emails=[
+                {"value": "new@x.com", "source": "linkedin:new-source"},
+            ],
+        )
+        pair = DuplicatePair(
+            canonical_uid="pv555555",
+            absorbed_uid="pv666666",
+            match_signal="apollo_id",
+            canonical_path=str(cpath),
+            absorbed_path=str(apath),
+        )
+        merge_duplicate_persons([pair], apply=True)
+        meta, _ = parse_frontmatter(cpath.read_text(encoding="utf-8"))
+        emails_fs = meta["field_sources"]["emails"]
+        # Writer emits new per-value shape regardless of canonical's
+        # legacy input shape.
+        assert isinstance(emails_fs, list)
+        by_value = {e["value"]: e["source"] for e in emails_fs}
+        # Canonical legacy broadcasts across canonical's values.
+        assert by_value["legacy@x.com"] == "google:legacy-source"
+        # Absorbed's per-value entry carries forward.
+        assert by_value["new@x.com"] == "linkedin:new-source"
 
 
 class TestSocialUrlCoalesce:

--- a/tests/test_librarian.py
+++ b/tests/test_librarian.py
@@ -4,6 +4,7 @@ process_one, and the run() pipeline with mocked LLM."""
 from __future__ import annotations
 
 import subprocess
+from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -367,16 +368,22 @@ class TestTier0Passthrough:
 
         out_path = wiki / "9b8c7d61-per-value-pat.md"
         out = out_path.read_text(encoding="utf-8")
-        # Per-value list shape preserved verbatim — tier0 must NOT
-        # auto-upgrade or rewrite.
-        assert "field_sources:" in out
-        assert "- value: pat@one.com" in out
-        assert "source: api:apollo:2026-04-29" in out
-        assert "- value: pat@two.com" in out
-        assert "source: linkedin:patshandle" in out
-        # And the validator accepted it (file exists / no parse error).
-        from athenaeum.models import parse_frontmatter
 
+        # Byte-for-byte contract from docs/provenance-shape.md §3:
+        # tier0 stamps ``created`` (when missing) + ``updated``, then
+        # renders the meta verbatim. Reconstruct the expected bytes
+        # rather than relying on substring checks.
+        from athenaeum.models import parse_frontmatter, render_frontmatter
+
+        expected_meta, expected_body = parse_frontmatter(sourced)
+        today = date.today().isoformat()
+        expected_meta["created"] = today
+        expected_meta["updated"] = today
+        expected = render_frontmatter(expected_meta) + "\n" + expected_body
+        assert out == expected
+
+        # And the per-value list shape parses back as a list of
+        # ``{value, source}`` records.
         meta, _ = parse_frontmatter(out)
         emails_fs = meta["field_sources"]["emails"]
         assert isinstance(emails_fs, list)

--- a/tests/test_librarian.py
+++ b/tests/test_librarian.py
@@ -333,6 +333,55 @@ class TestTier0Passthrough:
         assert "  emails: api:apollo:2026-05-07" in out
         assert "  current_title: linkedin:sourced-sam-1234" in out
 
+    def test_per_value_field_sources_round_trip(self, tmp_path: Path) -> None:
+        """Per-value field_sources list shape (#102) must round-trip
+        byte-for-byte through tier0_passthrough — the shape contract in
+        docs/provenance-shape.md §3."""
+        from athenaeum.librarian import tier0_passthrough
+
+        wiki = self._make_wiki_root(tmp_path)
+        sourced = (
+            "---\n"
+            "uid: 9b8c7d61\n"
+            "type: person\n"
+            "name: Per Value Pat\n"
+            "access: personal\n"
+            "emails:\n"
+            "  - pat@one.com\n"
+            "  - pat@two.com\n"
+            "field_sources:\n"
+            "  emails:\n"
+            "    - value: pat@one.com\n"
+            "      source: api:apollo:2026-04-29\n"
+            "    - value: pat@two.com\n"
+            "      source: linkedin:patshandle\n"
+            "---\n"
+            "\n"
+            "# Per Value Pat\n"
+        )
+        raw = self._make_raw(tmp_path, sourced)
+        index = EntityIndex(wiki)
+
+        entity = tier0_passthrough(raw, index, wiki, ["person"])
+        assert entity is not None
+
+        out_path = wiki / "9b8c7d61-per-value-pat.md"
+        out = out_path.read_text(encoding="utf-8")
+        # Per-value list shape preserved verbatim — tier0 must NOT
+        # auto-upgrade or rewrite.
+        assert "field_sources:" in out
+        assert "- value: pat@one.com" in out
+        assert "source: api:apollo:2026-04-29" in out
+        assert "- value: pat@two.com" in out
+        assert "source: linkedin:patshandle" in out
+        # And the validator accepted it (file exists / no parse error).
+        from athenaeum.models import parse_frontmatter
+
+        meta, _ = parse_frontmatter(out)
+        emails_fs = meta["field_sources"]["emails"]
+        assert isinstance(emails_fs, list)
+        assert {e["value"] for e in emails_fs} == {"pat@one.com", "pat@two.com"}
+
 
 # ---------------------------------------------------------------------------
 # rebuild_index

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -6,6 +6,7 @@ import pytest
 
 from athenaeum.provenance import (
     SourceRef,
+    parse_per_value_field_sources,
     parse_source,
     validate_field_sources,
     validate_source_value,
@@ -162,6 +163,87 @@ class TestValidateFieldSources:
     def test_empty_key_raises(self) -> None:
         with pytest.raises(ValueError):
             validate_field_sources({"": "api:apollo"})
+
+
+class TestPerValueFieldSources:
+    """Per-value list-of-records shape for list fields (issue #102)."""
+
+    def test_parse_basic_per_value_list(self) -> None:
+        v = [
+            {"value": "a@x.com", "source": "api:apollo:2026-04-29"},
+            {"value": "b@y.com", "source": "linkedin:tristankromer"},
+        ]
+        assert parse_per_value_field_sources(v) is v
+
+    def test_parse_per_value_with_dict_source(self) -> None:
+        v = [
+            {
+                "value": "a@x.com",
+                "source": {"type": "api", "ref": "apollo", "confidence": 0.9},
+            },
+        ]
+        assert parse_per_value_field_sources(v) is v
+
+    def test_parse_per_value_dict_value(self) -> None:
+        # value can be a dict (employment_history shape, §2.2)
+        v = [
+            {
+                "value": {"company": "Kromatic", "title": "Founder"},
+                "source": "api:apollo:2026-04-29",
+            },
+        ]
+        assert parse_per_value_field_sources(v) is v
+
+    def test_empty_list_accepted(self) -> None:
+        assert parse_per_value_field_sources([]) == []
+
+    def test_missing_value_key_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_per_value_field_sources([{"source": "api:apollo"}])
+
+    def test_missing_source_key_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_per_value_field_sources([{"value": "a@x.com"}])
+
+    def test_extra_keys_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            parse_per_value_field_sources(
+                [{"value": "a@x.com", "source": "api:apollo", "ts": "2026"}]
+            )
+
+    def test_bad_source_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_per_value_field_sources(
+                [{"value": "a@x.com", "source": "Has-Uppercase"}]
+            )
+
+    def test_non_list_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_per_value_field_sources({"value": "a@x.com", "source": "api:apollo"})
+
+    def test_validate_field_sources_accepts_per_value(self) -> None:
+        v = {
+            "emails": [
+                {"value": "a@x.com", "source": "api:apollo:2026"},
+                {"value": "b@y.com", "source": "linkedin:foo"},
+            ]
+        }
+        assert validate_field_sources(v) is v
+
+    def test_validate_field_sources_mixed_legacy_and_per_value(self) -> None:
+        # Same map can carry legacy scalar (current_title) and per-value
+        # list (emails) entries — readers must accept both.
+        v = {
+            "current_title": "linkedin:foo",
+            "emails": [
+                {"value": "a@x.com", "source": "api:apollo:2026"},
+            ],
+        }
+        assert validate_field_sources(v) is v
+
+    def test_validate_field_sources_per_value_invalid_record(self) -> None:
+        with pytest.raises(ValueError):
+            validate_field_sources({"emails": [{"value": "a@x.com"}]})  # missing source
 
 
 class TestSourceRefToScalar:


### PR DESCRIPTION
## Summary

Implements per-value `field_sources` for list-typed wiki frontmatter fields,
per the design lock in `docs/provenance-shape.md` §2.

Before this PR a list field like `emails: [a@x, b@y]` could only carry
ONE `field_sources.emails` source for the whole list. Bulk dedupe runs
that merged contacts from different sources (Apollo, LinkedIn, Google)
silently collapsed dual attribution down to one. With per-value shape,
each value's origin is preserved across merge.

## Shape

```yaml
emails:
  - tristan@kromatic.com
  - tristan@trikro.com
field_sources:
  emails:
    - value: tristan@kromatic.com
      source: api:apollo:2026-04-29
    - value: tristan@trikro.com
      source: linkedin:tristankromer
```

Co-indexed by VALUE (not position) — robust to list-reordering during merge.
For list-of-dicts (e.g. `apollo_employment_history`) the source attaches
to the whole dict; match key is `repr(value)`. Per design-lock §2.2.

## Backward compatibility

- Readers accept BOTH legacy field-keyed shape AND new per-value shape
  (one `isinstance` check per parse).
- Writers emit ONLY new shape on list fields; scalar fields keep legacy.
- Legacy on canonical + new on incoming → broadcast canonical's legacy
  source across canonical's underlying values, merge with incoming
  per-value entries.
- tier0 passthrough NEVER auto-upgrades — raw frontmatter renders
  byte-for-byte, including either shape.
- No standalone migration script — shape transitions field-by-field
  organically. Legacy reader branch stays forever.

## Files changed

- `src/athenaeum/provenance.py` — new `parse_per_value_field_sources` helper;
  `validate_field_sources` now accepts the list-of-records form.
- `src/athenaeum/schemas.py`, `src/athenaeum/models.py` — relax
  `field_sources` type to allow per-field list values.
- `src/athenaeum/dedupe.py` — `_merge_field_sources` builds per-value
  attribution maps for list fields; canonical wins per (key, value);
  absorbed-only values carry their own attribution forward.
- `tests/test_provenance.py` — round-trip + invalid-record tests for
  the per-value shape.
- `tests/test_dedupe.py` — disjoint, overlapping, and mixed legacy+new
  merge cases. Existing tests updated to expect new emit shape.
- `tests/test_librarian.py` — tier0 byte-for-byte regression for
  per-value shape.

## Test plan

- [x] `pytest tests/ -q` — 558 passed, 1 skipped (was 542 baseline).
- [x] tier0 passthrough byte-for-byte regression — per-value list shape
  round-trips verbatim.
- [x] Legacy field-keyed `field_sources` still parses and round-trips.
- [x] Existing dedupe merge tests updated to expect new per-value emit
  for list fields; scalar-field merge semantics unchanged.

Closes #102
