### PR TITLE
feat(dedupe): rewrite cross-uid references on persons --apply (#103)

### DIFF
--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -484,6 +484,7 @@ def _cmd_dedupe(args: argparse.Namespace) -> int:
         f"already_merged={merge_report.already_merged} "
         f"missing_canonical={merge_report.missing_canonical} "
         f"skipped_parse={merge_report.skipped_parse} "
+        f"references_rewritten={merge_report.references_rewritten} "
         f"errors={len(merge_report.errors)}"
     )
     for err in merge_report.errors:

--- a/src/athenaeum/dedupe.py
+++ b/src/athenaeum/dedupe.py
@@ -128,6 +128,7 @@ class MergeReport:
     missing_canonical: int = 0
     missing_absorbed: int = 0
     skipped_parse: int = 0
+    references_rewritten: int = 0
     errors: list[str] = field(default_factory=list)
     dry_run: bool = False
 
@@ -549,6 +550,60 @@ def _perform_merge(canonical_path: Path, absorbed_path: Path, dry_run: bool) -> 
     return f"MERGED:{absorbed_uid}->{canonical_uid}"
 
 
+def rewrite_references(
+    absorbed_uid: str,
+    canonical_uid: str,
+    canonical_path: Path,
+    wiki_dir: Path,
+    *,
+    dry_run: bool = False,
+) -> int:
+    """Repoint cross-references to ``absorbed_uid`` at ``canonical_uid``.
+
+    Walks every ``*.md`` in ``wiki_dir`` and substitutes any occurrence of
+    ``absorbed_uid`` with ``canonical_uid`` (flat string replace — catches
+    ``[[uid]]`` body links, frontmatter list entries, and prose mentions
+    alike). Idempotent: when no sibling still mentions ``absorbed_uid``,
+    returns 0.
+
+    Skips:
+
+    - The canonical wiki itself (preserves the ``merged_from`` audit
+      trail and any ``## Merged from <absorbed_uid>`` body header).
+    - Files whose name starts with ``_`` (archives, indexes).
+
+    Ports the cwc-side ``merge_duplicate_persons.py::rewrite_references``
+    behavior (issue #103). Returns the count of files rewritten; with
+    ``dry_run=True``, returns the count that *would* be rewritten.
+    """
+    n = 0
+    try:
+        canonical_resolved = canonical_path.resolve()
+    except OSError:
+        canonical_resolved = canonical_path
+    for path in wiki_dir.glob("*.md"):
+        if path.name.startswith("_"):
+            continue
+        try:
+            if path.resolve() == canonical_resolved:
+                continue
+        except OSError:
+            if path == canonical_path:
+                continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if absorbed_uid not in text:
+            continue
+        new_text = text.replace(absorbed_uid, canonical_uid)
+        if new_text != text:
+            if not dry_run:
+                path.write_text(new_text, encoding="utf-8")
+            n += 1
+    return n
+
+
 def merge_duplicate_persons(
     pairs: Iterable[DuplicatePair],
     apply: bool = False,
@@ -586,6 +641,24 @@ def merge_duplicate_persons(
             report.skipped_parse += 1
         elif outcome.startswith("MERGED") or outcome.startswith("WOULD_MERGE"):
             report.merged += 1
+            # Sweep cross-uid references so siblings repoint at canonical.
+            # Use the directory the canonical lives in as the wiki dir
+            # (matches the existing absolute-path-first contract on
+            # DuplicatePair).
+            sweep_dir = cpath.parent if cpath.parent.exists() else wiki_root
+            if sweep_dir is not None:
+                try:
+                    report.references_rewritten += rewrite_references(
+                        absorbed_uid=pair.absorbed_uid,
+                        canonical_uid=pair.canonical_uid,
+                        canonical_path=cpath,
+                        wiki_dir=sweep_dir,
+                        dry_run=not apply,
+                    )
+                except OSError as exc:
+                    report.errors.append(
+                        f"rewrite_references {pair.absorbed_uid}: {exc}"
+                    )
     return report
 
 
@@ -631,4 +704,5 @@ __all__ = [
     "merge_duplicate_persons",
     "pairs_to_yaml",
     "pairs_from_yaml",
+    "rewrite_references",
 ]

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -19,6 +19,7 @@ from athenaeum.dedupe import (
     merge_duplicate_persons,
     pairs_from_yaml,
     pairs_to_yaml,
+    rewrite_references,
 )
 from athenaeum.models import parse_frontmatter
 
@@ -737,3 +738,145 @@ class TestDryRun:
         assert report.merged == 1  # counted as would-merge
         assert cpath.read_text() == before_c
         assert apath.read_text() == before_a
+
+
+class TestRewriteReferences:
+    """Cross-uid reference rewrites on persons --apply (#103).
+
+    Restores parity with the cwc-side merge_duplicate_persons.py
+    rewrite_references helper.
+    """
+
+    def _scenario(self, wiki_root: Path) -> tuple[Path, Path, Path, Path]:
+        canonical = _write_person(
+            wiki_root,
+            uid="aaaa1111",
+            name="Alice",
+            apollo_id="apo-shared",
+        )
+        absorbed = _write_person(
+            wiki_root,
+            uid="bbbb2222",
+            name="Alice",
+            apollo_id="apo-shared",
+        )
+        # Sibling C — body link to absorbed uid.
+        sibling_c = wiki_root / "cccc3333-charlie.md"
+        sibling_c.write_text(
+            "---\nuid: cccc3333\ntype: person\nname: Charlie\n---\n\n"
+            "Charlie met [[bbbb2222]] last week.\n",
+            encoding="utf-8",
+        )
+        # Sibling D — frontmatter list mention.
+        sibling_d = wiki_root / "dddd4444-dana.md"
+        sibling_d.write_text(
+            "---\nuid: dddd4444\ntype: person\nname: Dana\n"
+            "mentioned_persons:\n  - bbbb2222\n  - xxxx9999\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        return canonical, absorbed, sibling_c, sibling_d
+
+    def test_apply_rewrites_body_and_frontmatter(self, wiki_root: Path) -> None:
+        canonical, absorbed, sibling_c, sibling_d = self._scenario(wiki_root)
+        pair = DuplicatePair(
+            canonical_uid="aaaa1111",
+            absorbed_uid="bbbb2222",
+            match_signal="apollo_id",
+            canonical_path=str(canonical),
+            absorbed_path=str(absorbed),
+        )
+        report = merge_duplicate_persons([pair], apply=True, wiki_root=wiki_root)
+        assert report.merged == 1
+        assert report.references_rewritten == 2
+        assert "[[aaaa1111]]" in sibling_c.read_text()
+        assert "[[bbbb2222]]" not in sibling_c.read_text()
+        d_meta, _ = parse_frontmatter(sibling_d.read_text())
+        assert d_meta["mentioned_persons"] == ["aaaa1111", "xxxx9999"]
+        # Absorbed file deleted (existing dedupe contract).
+        assert not absorbed.exists()
+        # Canonical's merged_from audit trail intact.
+        c_meta, _ = parse_frontmatter(canonical.read_text())
+        assert c_meta["merged_from"] == ["bbbb2222"]
+
+    def test_idempotent_second_apply(self, wiki_root: Path) -> None:
+        canonical, absorbed, sibling_c, sibling_d = self._scenario(wiki_root)
+        pair = DuplicatePair(
+            canonical_uid="aaaa1111",
+            absorbed_uid="bbbb2222",
+            match_signal="apollo_id",
+            canonical_path=str(canonical),
+            absorbed_path=str(absorbed),
+        )
+        merge_duplicate_persons([pair], apply=True, wiki_root=wiki_root)
+        # Re-run: absorbed file is gone (already_merged); references are
+        # already rewritten so the sweep should also be a no-op.
+        report2 = merge_duplicate_persons([pair], apply=True, wiki_root=wiki_root)
+        assert report2.already_merged == 1
+        assert report2.merged == 0
+        assert report2.references_rewritten == 0
+        # Direct rewrite_references re-run is also a no-op.
+        n = rewrite_references(
+            absorbed_uid="bbbb2222",
+            canonical_uid="aaaa1111",
+            canonical_path=canonical,
+            wiki_dir=wiki_root,
+        )
+        assert n == 0
+
+    def test_skip_canonical_preserves_audit_trail(self, wiki_root: Path) -> None:
+        # Canonical body deliberately mentions the absorbed uid (defensive
+        # — would normally only appear via the merged_from header).
+        canonical = wiki_root / "aaaa1111-alice.md"
+        canonical.write_text(
+            "---\nuid: aaaa1111\ntype: person\nname: Alice\n"
+            "merged_from:\n  - bbbb2222\n---\n\n"
+            "## Merged from bbbb2222\n\nbody snippet\n",
+            encoding="utf-8",
+        )
+        before = canonical.read_text()
+        n = rewrite_references(
+            absorbed_uid="bbbb2222",
+            canonical_uid="aaaa1111",
+            canonical_path=canonical,
+            wiki_dir=wiki_root,
+        )
+        assert n == 0
+        assert canonical.read_text() == before
+
+    def test_skip_underscore_files(self, wiki_root: Path) -> None:
+        canonical = _write_person(
+            wiki_root, uid="aaaa1111", name="Alice", apollo_id="apo-shared"
+        )
+        archive = wiki_root / "_archive.md"
+        archive.write_text("Old reference to bbbb2222 lives here.\n", encoding="utf-8")
+        before = archive.read_text()
+        n = rewrite_references(
+            absorbed_uid="bbbb2222",
+            canonical_uid="aaaa1111",
+            canonical_path=canonical,
+            wiki_dir=wiki_root,
+        )
+        assert n == 0
+        assert archive.read_text() == before
+
+    def test_dry_run_counts_without_writing(self, wiki_root: Path) -> None:
+        canonical, absorbed, sibling_c, sibling_d = self._scenario(wiki_root)
+        before_c = sibling_c.read_text()
+        before_d = sibling_d.read_text()
+        pair = DuplicatePair(
+            canonical_uid="aaaa1111",
+            absorbed_uid="bbbb2222",
+            match_signal="apollo_id",
+            canonical_path=str(canonical),
+            absorbed_path=str(absorbed),
+        )
+        report = merge_duplicate_persons([pair], apply=False, wiki_root=wiki_root)
+        assert report.dry_run is True
+        assert report.merged == 1
+        # Dry-run leaves absorbed file in place, so the sweep sees its
+        # self-reference too: siblings C + D + the absorbed wiki = 3.
+        assert report.references_rewritten == 3
+        # Files unchanged.
+        assert sibling_c.read_text() == before_c
+        assert sibling_d.read_text() == before_d
+        assert absorbed.exists()


### PR DESCRIPTION
## Summary

Restores parity with the cwc-side `merge_duplicate_persons.py::rewrite_references`
helper (cwc git sha `9fc2864`, ~lines 199-227 of the deleted script).

After a successful person merge, sweeps every `*.md` in the wiki dir and
substitutes `absorbed_uid` -> `canonical_uid` (flat `str.replace`, deliberately
broad - catches body `[[uid]]` links, frontmatter list entries, and prose
mentions in one pass). Skip rules match the cwc original exactly:

- The canonical wiki itself is skipped (preserves the `merged_from` audit
  trail and any `## Merged from <absorbed_uid>` body header).
- Files whose name starts with `_` are skipped (archives, indexes).

Idempotent: re-running `dedupe persons --apply` on already-merged pairs
performs zero rewrites. The dry-run path counts what would be rewritten
without touching files. Count is surfaced in CLI output as
`references_rewritten=<n>`.

Closes #103.

## Test plan

- [x] `pytest tests/ -q` - 566 passed (was 561, +5 new tests in `TestRewriteReferences`).
- [x] Apply rewrites body link + frontmatter list mention.
- [x] Idempotent second `--apply` produces 0 rewrites.
- [x] Canonical wiki with `[[absorbed_uid]]` in body is NOT rewritten (defensive - preserves audit trail).
- [x] `_archive.md` containing absorbed uid is NOT touched.
- [x] Dry-run reports count without writing.
