### PR TITLE
feat(mcp): explicit _source / _field_sources wrappers for remember (#96)

### DIFF
--- a/src/athenaeum/mcp_server.py
+++ b/src/athenaeum/mcp_server.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from athenaeum.models import parse_frontmatter, render_frontmatter
-from athenaeum.provenance import validate_field_sources, validate_source_value
+from athenaeum.provenance import resolve_remember_sources
 from athenaeum.search import score_keyword_page, tokenize_keyword_query
 
 log = logging.getLogger(__name__)
@@ -225,31 +225,41 @@ def remember_write(
             the ``raw/<session>/`` subdirectory the file lands in.
             **Not** the per-claim provenance source — see ``sources``.
         wiki_root: Optional wiki root for path-traversal guards.
-        sources: Per-claim provenance (issue #90). Three accepted shapes:
+        sources: Per-claim provenance (issue #90, design-lock §4 in
+            ``docs/provenance-shape.md``). Three accepted shapes:
 
-            1. Scalar ``str`` of form ``"<type>:<ref>"`` — written as the
-               wiki-level ``source`` default for every field.
-            2. Structured ``dict`` ``{type, ref, ts?, confidence?, notes?}``
-               — also written as the wiki-level ``source`` default, but
-               with optional timestamp / confidence / notes preserved.
-            3. Per-field map ``dict`` ``{<field>: <source>}`` where each
-               value is a scalar or structured form — written as
-               ``field_sources`` (per-claim overrides). Keys must be
-               non-empty strings.
-            4. ``None`` (default) — stamps ``source: claude:inferred``
-               and emits a server-side warning. Untracked-source writes
-               are accepted but visible to downstream provenance audits.
+            1. Scalar ``str`` of form ``"<type>:<ref>"`` (e.g.
+               ``"api:apollo:2026-05-09"``) — applied as the wiki-level
+               ``source`` default for every field.
+            2. ``{"_source": <scalar-or-structured>}`` — wiki-level
+               default, structured form preserves
+               ``ts``/``confidence``/``notes``. Example::
+
+                   {"_source": {"type": "api", "ref": "apollo:2026-05-09",
+                                "confidence": 0.9}}
+
+            3. ``{"_field_sources": {<field>: <source>, ...}}`` — per-field
+               attribution. Each value is a scalar or structured source.
+               Example::
+
+                   {"_field_sources": {"current_title": "api:apollo:2026-05-09",
+                                       "linkedin_url":  "linkedin:tristankromer"}}
+
+            ``None`` (default) — stamps ``source: claude:inferred`` and
+            emits a server-side warning.
+
+            BREAKING (issue #96): the previous bare-dict heuristic that
+            inspected ``{type, ref}`` keys is REMOVED. Bare dicts without
+            the ``_source`` / ``_field_sources`` wrapper raise
+            ``ValueError``. The pathological case (fields literally named
+            ``type`` / ``ref``) is now safe via
+            ``{"_field_sources": {"type": ..., "ref": ...}}``.
 
             NOTE: this ``sources`` argument is DIFFERENT from the
             ``sources:`` frontmatter list used by cluster-merge in
             ``athenaeum.merge`` (which is a list of cluster-member uids
             being merged). They share a name for historical reasons; do
             not conflate them.
-
-            Known limitation: a per-field map whose field is literally
-            named ``type`` cannot be distinguished from a structured
-            single-source dict, since both have a top-level ``type`` key.
-            Tracked in issue #96.
 
     Returns:
         Confirmation message with the file path, or an error string.
@@ -269,25 +279,11 @@ def remember_write(
                 "source on every write (issue #90).",
                 _DEFAULT_INFERRED_SOURCE,
             )
-        elif isinstance(sources, str):
-            validate_source_value(sources)
-            wiki_source = sources
-            field_sources_map = None
-        elif isinstance(sources, dict):
-            # Two shapes accepted: a structured single-source dict
-            # ({type, ref, ...}), or a field_sources map ({field: src}).
-            # Disambiguate by checking for the SourceRef required keys.
-            if {"type", "ref"} <= set(sources.keys()):
-                validate_source_value(sources)
-                wiki_source = sources
-                field_sources_map = None
-            else:
-                validate_field_sources(sources)
-                wiki_source = None
-                field_sources_map = sources
         else:
-            return f"Error: `sources` must be str, dict, or None; got {type(sources).__name__}"
+            wiki_source, field_sources_map = resolve_remember_sources(sources)
     except ValueError as exc:
+        return f"Error: invalid `sources`: {exc}"
+    except TypeError as exc:
         return f"Error: invalid `sources`: {exc}"
 
     safe_source = "".join(c for c in source if c.isalnum() or c in "-_")
@@ -453,18 +449,22 @@ def create_server(
                 subdirectory the file lands in. Examples:
                 ``"claude-session"``, ``"manual"``. **Not** a per-claim
                 provenance source — pass ``sources`` for that.
-            sources: Per-claim provenance (issue #90). Either:
+            sources: Per-claim provenance (issue #90, design-lock §4 in
+                ``docs/provenance-shape.md``). Three accepted shapes:
 
                 - scalar ``"<type>:<ref>"`` (e.g.
-                  ``"claude:session-2026-05-08"``) — applied as the
-                  wiki-level default source for all fields,
-                - structured dict ``{type, ref, ts?, confidence?, notes?}``
-                  with the same wiki-level effect, or
-                - per-field map ``{<field>: <scalar-or-structured>}`` —
-                  written as ``field_sources``.
+                  ``"api:apollo:2026-05-09"``) — wiki-level default,
+                - ``{"_source": <scalar-or-structured>}`` — wiki-level
+                  default, structured form preserves
+                  ``ts``/``confidence``/``notes``,
+                - ``{"_field_sources": {<field>: <source>, ...}}`` —
+                  per-field attribution.
 
                 Omitting ``sources`` defaults to ``source: claude:inferred``
                 and logs a server-side warning. Always declare a source.
+
+                BREAKING (issue #96): bare dicts without the wrapper keys
+                are rejected — see ``remember_write`` for the rationale.
 
         Returns:
             Confirmation message with the file path.

--- a/src/athenaeum/provenance.py
+++ b/src/athenaeum/provenance.py
@@ -251,10 +251,74 @@ def validate_field_sources(value: Any) -> Any:
     return value
 
 
+def resolve_remember_sources(
+    sources: Any,
+) -> tuple[Any, dict | None]:
+    """Disambiguate the ``remember(sources=...)`` argument shape.
+
+    Settles design-lock §4 (``docs/provenance-shape.md``): the bare-dict
+    heuristic that previously inspected ``{type, ref}`` keys to guess
+    "structured single-source" vs "per-field map" is REMOVED. Callers
+    must use explicit wrapper keys for structured input.
+
+    Three accepted shapes:
+
+    - ``None`` → ``(None, None)``.
+    - ``str`` (e.g. ``"api:apollo:2026-05-09"``) → wiki-level scalar;
+      returns ``(<scalar>, None)``.
+    - ``dict`` containing only ``_source`` and/or ``_field_sources`` →
+      returns ``(<wiki_source>, <field_sources_map>)``.
+
+    Any bare dict (no wrapper keys) raises :class:`ValueError` directing
+    the caller to wrap. Any other type raises :class:`TypeError`.
+
+    Returns:
+        ``(wiki_source, field_sources_map)`` — either entry may be
+        ``None``. ``wiki_source`` is the validated scalar/structured
+        source; ``field_sources_map`` is the validated per-field dict.
+    """
+    if sources is None:
+        return None, None
+    if isinstance(sources, str):
+        validate_source_value(sources)
+        return sources, None
+    if isinstance(sources, dict):
+        allowed = {"_source", "_field_sources"}
+        keys = set(sources.keys())
+        unknown = keys - allowed
+        if unknown or not keys:
+            raise ValueError(
+                "MCP remember(sources=...) bare-dict shape removed. "
+                'Use {"_source": ...} for wiki-level or '
+                '{"_field_sources": {<field>: <source>}} for per-field. '
+                "See docs/provenance-shape.md §4."
+            )
+        wiki_source: Any = None
+        field_sources_map: dict | None = None
+        if "_source" in sources:
+            wiki_source = sources["_source"]
+            validate_source_value(wiki_source)
+        if "_field_sources" in sources:
+            fs = sources["_field_sources"]
+            if not isinstance(fs, dict):
+                raise ValueError(
+                    f"_field_sources must be a dict, got {type(fs).__name__}"
+                )
+            validate_field_sources(fs)
+            field_sources_map = fs
+        return wiki_source, field_sources_map
+    raise TypeError(
+        f"`sources` must be str, dict, or None; got {type(sources).__name__}. "
+        'Use {"_source": ...} or {"_field_sources": {...}} for structured input. '
+        "See docs/provenance-shape.md §4."
+    )
+
+
 __all__ = [
     "SourceRef",
     "parse_source",
     "parse_per_value_field_sources",
     "validate_source_value",
     "validate_field_sources",
+    "resolve_remember_sources",
 ]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -277,32 +277,77 @@ class TestRememberSources:
         assert "source: claude:session-2026-05-08" in text
         assert "claude:inferred" not in text
 
-    def test_field_sources_dict_propagates(self, tmp_path: Path) -> None:
+    def test_field_sources_wrapper_propagates(self, tmp_path: Path) -> None:
         raw = tmp_path / "raw"
         raw.mkdir()
         result = remember_write(
             raw,
             "Some claim",
-            sources={"emails": "api:apollo:2026-05-07"},
+            sources={"_field_sources": {"emails": "api:apollo:2026-05-07"}},
         )
         assert "Saved to" in result
         text = list((raw / "claude-session").glob("*.md"))[0].read_text()
         assert "field_sources:" in text
         assert "emails: api:apollo:2026-05-07" in text
 
-    def test_structured_single_source_dict(self, tmp_path: Path) -> None:
+    def test_source_wrapper_structured(self, tmp_path: Path) -> None:
         raw = tmp_path / "raw"
         raw.mkdir()
         result = remember_write(
             raw,
             "Some claim",
-            sources={"type": "api", "ref": "apollo", "confidence": 0.9},
+            sources={"_source": {"type": "api", "ref": "apollo", "confidence": 0.9}},
         )
         assert "Saved to" in result
         text = list((raw / "claude-session").glob("*.md"))[0].read_text()
         assert "source:" in text
         assert "type: api" in text
         assert "confidence: 0.9" in text
+
+    def test_bare_dict_without_wrappers_rejected(self, tmp_path: Path) -> None:
+        # Per design-lock §4: bare dict (no wrapper keys) is no longer
+        # accepted. Caller must use _source / _field_sources.
+        raw = tmp_path / "raw"
+        raw.mkdir()
+        result = remember_write(
+            raw, "Some claim", sources={"emails": "api:apollo:2026-05-07"}
+        )
+        assert "Error" in result
+        assert "_field_sources" in result
+
+    def test_pathological_type_ref_fields(self, tmp_path: Path) -> None:
+        # The locked pathological case: a wiki with frontmatter fields
+        # literally named ``type`` and ``ref``. Pre-#96 this was
+        # misclassified as a structured single-source dict; now it must
+        # be passed via ``_field_sources`` and round-trip intact.
+        raw = tmp_path / "raw"
+        raw.mkdir()
+
+        # Bare form is rejected with a wrapper hint.
+        bad = remember_write(
+            raw,
+            "Some claim",
+            sources={"type": "api:x", "ref": "linkedin:y"},
+        )
+        assert "Error" in bad
+        assert "_field_sources" in bad
+
+        # Wrapped form succeeds and writes the per-field map intact.
+        good = remember_write(
+            raw,
+            "Some claim",
+            sources={
+                "_field_sources": {
+                    "type": "api:x",
+                    "ref": "linkedin:y",
+                }
+            },
+        )
+        assert "Saved to" in good
+        text = list((raw / "claude-session").glob("*.md"))[0].read_text()
+        assert "field_sources:" in text
+        assert "type: api:x" in text
+        assert "ref: linkedin:y" in text
 
     def test_malformed_scalar_rejected(self, tmp_path: Path) -> None:
         raw = tmp_path / "raw"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -8,6 +8,7 @@ from athenaeum.provenance import (
     SourceRef,
     parse_per_value_field_sources,
     parse_source,
+    resolve_remember_sources,
     validate_field_sources,
     validate_source_value,
 )
@@ -250,3 +251,77 @@ class TestSourceRefToScalar:
     def test_round_trip(self) -> None:
         ref = parse_source("api:apollo")
         assert ref.to_scalar() == "api:apollo"
+
+
+class TestResolveRememberSources:
+    """Disambiguation helper for MCP ``remember(sources=...)`` (issue #96).
+
+    Locks design-lock §4 in ``docs/provenance-shape.md``: explicit
+    ``_source`` / ``_field_sources`` wrappers; the bare-dict heuristic
+    is removed; bare scalar shorthand stays.
+    """
+
+    def test_none_returns_both_none(self) -> None:
+        assert resolve_remember_sources(None) == (None, None)
+
+    def test_bare_scalar(self) -> None:
+        ws, fs = resolve_remember_sources("api:apollo:2026-04-29")
+        assert ws == "api:apollo:2026-04-29"
+        assert fs is None
+
+    def test_source_wrapper_structured(self) -> None:
+        payload = {"_source": {"type": "api", "ref": "apollo"}}
+        ws, fs = resolve_remember_sources(payload)
+        assert ws == {"type": "api", "ref": "apollo"}
+        assert fs is None
+
+    def test_field_sources_wrapper(self) -> None:
+        payload = {"_field_sources": {"emails": "api:apollo:2026-04-29"}}
+        ws, fs = resolve_remember_sources(payload)
+        assert ws is None
+        assert fs == {"emails": "api:apollo:2026-04-29"}
+
+    def test_both_wrappers(self) -> None:
+        payload = {
+            "_source": "api:apollo:2026-04-29",
+            "_field_sources": {"linkedin_url": "linkedin:tristankromer"},
+        }
+        ws, fs = resolve_remember_sources(payload)
+        assert ws == "api:apollo:2026-04-29"
+        assert fs == {"linkedin_url": "linkedin:tristankromer"}
+
+    def test_pathological_bare_type_ref_rejected(self) -> None:
+        # Locked pathological case from issue #96: bare dict whose user
+        # fields happen to be named ``type`` / ``ref``.
+        with pytest.raises(ValueError, match="_field_sources"):
+            resolve_remember_sources({"type": "api:x", "ref": "linkedin:y"})
+
+    def test_pathological_via_field_sources_wrapper_works(self) -> None:
+        payload = {"_field_sources": {"type": "api:x", "ref": "linkedin:y"}}
+        ws, fs = resolve_remember_sources(payload)
+        assert ws is None
+        assert fs == {"type": "api:x", "ref": "linkedin:y"}
+
+    def test_bare_dict_without_wrappers_rejected(self) -> None:
+        with pytest.raises(ValueError, match="_field_sources"):
+            resolve_remember_sources({"emails": "api:apollo:2026-04-29"})
+
+    def test_wrong_type_rejected(self) -> None:
+        with pytest.raises(TypeError):
+            resolve_remember_sources(42)
+
+    def test_empty_dict_rejected(self) -> None:
+        with pytest.raises(ValueError, match="_field_sources"):
+            resolve_remember_sources({})
+
+    def test_mixed_unknown_key_rejected(self) -> None:
+        with pytest.raises(ValueError, match="_field_sources"):
+            resolve_remember_sources({"_source": "api:x:y", "stray": "junk"})
+
+    def test_field_sources_value_not_dict_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            resolve_remember_sources({"_field_sources": "not-a-dict"})
+
+    def test_invalid_inner_source_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            resolve_remember_sources({"_source": "Has-Uppercase"})


### PR DESCRIPTION
## Summary

Implements [docs/provenance-shape.md §4](https://github.com/Kromatic-Innovation/athenaeum/blob/develop/docs/provenance-shape.md#4-mcp-remembersources-api) — disambiguates the `remember(sources=...)` argument shape with explicit wrapper keys.

- New `resolve_remember_sources` helper in `provenance.py` returns `(wiki_source, field_sources_map)` for `None` / scalar / `{_source}` / `{_field_sources}` / both-wrappers inputs.
- Bare-dict heuristic (`{"type", "ref"} <= sources.keys()` → structured single-source else per-field map) is **deleted** from `mcp_server.remember_write`.
- Bare dicts without a wrapper raise `ValueError` with a hint pointing at the design lock.
- Docstrings on both `remember_write` and the MCP `remember` tool updated with all three shapes + examples.

## BREAKING

Any caller previously passing a bare per-field map must rewrite:

```python
# before
remember(..., sources={"emails": "api:apollo:2026-05-09"})
# after
remember(..., sources={"_field_sources": {"emails": "api:apollo:2026-05-09"}})
```

No in-tree callers existed. The only updates were the two existing tests in `tests/test_mcp_server.py` that exercised the old shape.

## Pathological case fixed

A wiki with frontmatter fields literally named `type` / `ref` previously misclassified as a structured single-source dict. Now safe via:

```python
remember(..., sources={"_field_sources": {"type": "api:x", "ref": "linkedin:y"}})
```

The bare form `{"type": "api:x", "ref": "linkedin:y"}` raises a clear `ValueError`. Both paths (now-error AND corrected) have locked tests.

## Test plan

- [x] `pytest tests/` — 592 passed, 1 skipped (was 577 before; +16 new tests across `test_provenance.py::TestResolveRememberSources` and `test_mcp_server.py::TestRememberSources`)
- [x] Pathological-case test asserts BOTH the now-error path AND the corrected `_field_sources` invocation
- [x] Bare-dict-without-wrapper test asserts `ValueError` with `_field_sources` in the message
- [x] Old bare-dict heuristic code DELETED, not bypassed
- [x] Docstrings updated with all three shapes + examples

Closes #96.
