### PR TITLE
chore: ignore .codex/ workspace overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ htmlcov/
 
 # Distribution
 *.tar.gz
+
+# Workspace agent overrides
+.codex/


### PR DESCRIPTION
Add `.codex/` to `.gitignore` so Codex workspace overrides stop showing up as untracked debris in agent sessions. Pattern observed repeatedly during the 2026-05-09 Phase 2 orchestration on this repo.
