### PR TITLE
fix(repair): relax legacy-slug migration safeguard to source-line only

### DIFF
--- a/src/athenaeum/repair.py
+++ b/src/athenaeum/repair.py
@@ -247,8 +247,11 @@ class LegacySlugReport:
         files_scanned: total ``.md`` files inspected.
         would_rewrite: dry-run count of wikis that WOULD be migrated.
         rewrites_applied: apply-mode count of wikis ACTUALLY migrated.
-        skipped_validation_fail: rewrites whose post-rewrite frontmatter
-            failed :func:`validate_wiki_meta` and were skipped.
+        skipped_validation_fail: rewrites whose new typed ``source:``
+            value failed :func:`provenance.parse_source` and were
+            skipped. NOTE: name retained for CLI output stability; the
+            check now validates ONLY the rewritten source line, not the
+            full wiki frontmatter (see PR fix/migration-relax-safeguard).
         unknown_slugs: per-slug count of bare-slug values not present in
             :data:`LEGACY_SLUG_MAP`. Non-empty → migration ABORTED.
         unknown_slug_files: first 10 ``(path, slug)`` pairs for unknown
@@ -285,17 +288,20 @@ def migrate_legacy_source_slugs(
       is ABORTED before any rewrite is written. Per design-lock §5.2,
       this is deliberate — no guess, no partial apply.
 
-    In ``apply`` mode, every rewrite is validated via
-    :func:`athenaeum.schemas.validate_wiki_meta` BEFORE the file is
-    written; validation failures are recorded under
-    ``skipped_validation_fail`` and the original file is left intact.
+    In ``apply`` mode, every rewrite's NEW typed source value is parsed
+    via :func:`athenaeum.provenance.parse_source` BEFORE the file is
+    written. Failures are recorded under ``skipped_validation_fail``
+    and the original file is left intact. The check is intentionally
+    narrow: only the source line changes, so only the source line is
+    validated. Pre-existing frontmatter issues (e.g. unrelated invalid
+    fields) do NOT block the trivial source rewrite.
 
     Idempotent: a typed ``source: script:extended-tier-build`` does NOT
     match :data:`_SOURCE_LINE_RE` (the regex rejects values containing a
     colon), so a re-run on a fully migrated tree finds zero candidates.
     """
-    # Local import — avoids a top-level cycle between repair and schemas.
-    from athenaeum.schemas import validate_wiki_meta
+    # Local import — avoids a top-level cycle between repair and provenance.
+    from athenaeum.provenance import parse_source
 
     report = LegacySlugReport()
     if not wiki_root.is_dir():
@@ -350,24 +356,20 @@ def migrate_legacy_source_slugs(
             report.changes.append((path, f"{slug} -> {typed}"))
         return report
 
-    # Phase 4: apply. Validate each rewrite via validate_wiki_meta;
-    # skip (don't abort) on per-file validation failure — defensive guard.
+    # Phase 4: apply. Validate ONLY the new typed source value via
+    # parse_source — the source line is the only thing this migration
+    # changes, so it is the only thing we should gate on. Pre-existing
+    # frontmatter issues (e.g. integer uid, malformed unrelated fields)
+    # are out of scope for this migration and must NOT block the
+    # trivial source rewrite. Skip (don't abort) on per-file failure.
     for path, _orig, new_text, slug, typed in candidates:
-        # Parse the new frontmatter for validation.
-        parts = _split_frontmatter(new_text)
-        if parts is None:
-            report.skipped_validation_fail += 1
-            report.errors.append((path, "post_rewrite_frontmatter_missing"))
-            continue
-        new_fm, _ = parts
         try:
-            meta = yaml.safe_load(new_fm)
-            if not isinstance(meta, dict):
-                raise ValueError("frontmatter is not a mapping")
-            validate_wiki_meta(meta)
+            parsed = parse_source(typed)
+            if parsed is None:
+                raise ValueError("parse_source returned None")
         except Exception as exc:  # noqa: BLE001 — defensive guard
             report.skipped_validation_fail += 1
-            report.errors.append((path, f"validation_failed: {str(exc)[:120]}"))
+            report.errors.append((path, f"invalid_source: {str(exc)[:120]}"))
             continue
         try:
             _atomic_write(path, new_text)

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -494,34 +494,73 @@ def test_legacy_slugs_byte_for_byte_body_preservation(tmp_path: Path) -> None:
     assert diffs[0][2] == "source: script:extended-tier-build"
 
 
-def test_legacy_slugs_validation_failure_skips_file(
-    tmp_path: Path, monkeypatch
+def test_legacy_slugs_unrelated_frontmatter_issue_does_not_block(
+    tmp_path: Path,
 ) -> None:
-    """If ``validate_wiki_meta`` rejects the rewritten frontmatter, that
-    file is skipped (recorded in ``skipped_validation_fail``) and the
-    other files still proceed."""
+    """Unrelated pre-existing frontmatter issues must NOT block the
+    source-line rewrite. The migration's safeguard is scoped to the
+    rewritten ``source:`` value only — full-wiki validation is out of
+    scope (would over-reach and skip wikis with unrelated issues, as
+    happened to 350 integer-uid wikis on the live tree pre-fix).
+    """
+    # Integer uid is invalid per PersonWiki schema, but it is unrelated
+    # to the source-line rewrite. Migration should still proceed.
+    integer_uid_wiki = """\
+---
+uid: 15193201
+type: person
+name: Greg Test
+source: extended-tier-build
+---
+
+Body.
+"""
+    wiki = _make_wiki(
+        tmp_path,
+        {"greg.md": integer_uid_wiki, "hank.md": LEGACY_WARM},
+    )
+
+    report = migrate_legacy_source_slugs(wiki, apply=True)
+
+    assert report.skipped_validation_fail == 0
+    assert report.rewrites_applied == 2
+    assert "source: script:extended-tier-build" in (wiki / "greg.md").read_text()
+    assert "source: script:warm-network-detect" in (wiki / "hank.md").read_text()
+
+
+def test_legacy_slugs_invalid_source_skips_file(tmp_path: Path, monkeypatch) -> None:
+    """If the new typed source value fails to parse via parse_source,
+    that file is skipped (recorded in ``skipped_validation_fail``) and
+    the other files still proceed.
+    """
     wiki = _make_wiki(
         tmp_path,
         {"gail.md": LEGACY_EXTENDED, "hank.md": LEGACY_WARM},
     )
 
-    from athenaeum import schemas as schemas_mod
+    from athenaeum import provenance as provenance_mod
+    from athenaeum import repair as repair_mod
 
-    real_validate = schemas_mod.validate_wiki_meta
-    fail_target = "person:gail"
+    real_parse = provenance_mod.parse_source
 
-    def fake_validate(meta):
-        if meta.get("uid") == fail_target:
-            raise ValueError("synthetic validation failure")
-        return real_validate(meta)
+    def fake_parse(value):
+        if value == "script:extended-tier-build":
+            raise ValueError("synthetic parse_source failure")
+        return real_parse(value)
 
-    monkeypatch.setattr(schemas_mod, "validate_wiki_meta", fake_validate)
+    # Patch the binding inside repair.py's local import.
+    monkeypatch.setattr(
+        repair_mod,
+        "migrate_legacy_source_slugs",
+        repair_mod.migrate_legacy_source_slugs,
+    )
+    monkeypatch.setattr(provenance_mod, "parse_source", fake_parse)
 
     report = migrate_legacy_source_slugs(wiki, apply=True)
 
     assert report.skipped_validation_fail == 1
     assert report.rewrites_applied == 1
-    # gail.md untouched (validation failed).
+    # gail.md untouched (parse_source failed).
     assert (wiki / "gail.md").read_text() == LEGACY_EXTENDED
     # hank.md migrated.
     assert "source: script:warm-network-detect" in (wiki / "hank.md").read_text()


### PR DESCRIPTION
## Why

The legacy-slug migration shipped in #97 (PR #120) over-validates. In `apply` mode it ran `validate_wiki_meta` on the FULL post-rewrite frontmatter — failing for wikis that have pre-existing, unrelated data-shape issues.

Concrete live-tree finding (after applying the migration to `~/knowledge/wiki/`):

- `skipped_validation_fail: 350`
- All 350 wikis have `uid: <integer>` (bare int, not a quoted string). PersonWiki's validator rejects integer uids.
- The `source:` rewrite itself is trivially valid. The unrelated uid issue should not gate it.

Example: `15193201-greg-mandanis.md` — legacy `source: extended-tier-build` would migrate cleanly, but the wiki had an integer uid from an earlier intake path, so the full-wiki validator rejected the post-rewrite frontmatter.

## What

Replace the full-wiki `validate_wiki_meta` check with a per-source-line `provenance.parse_source(typed)` check. Scope is now exactly what the migration changes — the `source:` value — and nothing else.

- `src/athenaeum/repair.py` — `migrate_legacy_source_slugs` now imports `parse_source` (not `validate_wiki_meta`); Phase 4 validates only the new typed source string. Field name `skipped_validation_fail` retained for CLI output stability; docstring documents the narrower meaning.
- `tests/test_repair.py`:
  - Rewrote `test_legacy_slugs_validation_failure_skips_file` to `test_legacy_slugs_unrelated_frontmatter_issue_does_not_block`: integer-uid wiki + legacy source -> migration PROCEEDS.
  - New `test_legacy_slugs_invalid_source_skips_file`: monkeypatches `parse_source` to fail and asserts the per-file skip + other-file rewrite path.

LEGACY_SLUG_MAP and the slug regex are unchanged. Live-tree migration is NOT re-run from this PR — orchestrator will re-run after merge.

## Test plan

- [x] `pytest tests/test_repair.py -v` — 28 passed
- [x] Full suite — 593 passed, 1 skipped
- [ ] CI green
- [ ] Post-merge: orchestrator re-runs `repair --legacy-source-slugs --apply` and `skipped_validation_fail` drops to 0

## Scope

Does NOT close #97 — #97 is the migration tool itself (already shipped in #120). This is a follow-up safeguard fix. Linked for context.

Refs #97
