### PR TITLE
refactor(provenance)!: retire legacy bare-slug source parser (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Removed
+- **BREAKING: retired `provenance._LEGACY_SCALAR_RE` and the legacy
+  bare-slug `source:` parser branch.** Pre-#90 wikis stored `source:` as
+  a bare slug (`extended-tier-build`, `warm-network-detect`); the live
+  tree was migrated on 2026-05-09 via
+  `athenaeum repair --legacy-source-slugs --apply` (15,403 wikis rewritten
+  to `script:<slug>`). The parser branch and matching schema/test fixtures
+  retired in this PR. `provenance.parse_source` now raises `ValueError`
+  on bare-slug input with a pointer to the typed `<type>:<ref>` form.
+  External callers that still emit bare slugs must switch to the typed
+  form. The migration tool (`repair.migrate_legacy_source_slugs`) keeps
+  its own internal slug regex and ships unchanged for any future tree
+  that needs it. Completes athenaeum#97 acceptance criterion "Remove
+  legacy regex branch + its tests" which was deferred from #120 pending
+  live-tree migration. The field-keyed `field_sources` legacy reader
+  (per `docs/provenance-shape.md` §2.3) is a different legacy form and
+  remains accepted on read.
 - **BREAKING: extracted `enrich` subcommand and `connectors/apollo` module**
   (#112) — the Apollo people-match connector and the `athenaeum enrich
   --persons` CLI subcommand have been removed from the OSS package. Both

--- a/docs/provenance-shape.md
+++ b/docs/provenance-shape.md
@@ -21,10 +21,10 @@ contract.
 
 - **#90 — per-claim provenance primitives** (PR #94): `WikiBase.source`
   and `WikiBase.field_sources` round-trip on disk. `provenance.py` parses
-  the scalar `<type>:<ref>` form, the structured `{type, ref, ts?,
-  confidence?, notes?}` dict form, and a legacy single-token form
-  (`extended-tier-build`, `warm-network-detect`) so the live tree of
-  ~19k wikis doesn't break.
+  the scalar `<type>:<ref>` form and the structured `{type, ref, ts?,
+  confidence?, notes?}` dict form. (A legacy single-token form
+  — `extended-tier-build`, `warm-network-detect` — was accepted on read
+  until #97 migrated the live tree on 2026-05-09; see §5.)
 - **#95 — Tier 3 emits `field_sources`**: when Tier 3 creates or merges
   a person/company wiki, the relevant Apollo-namespace fields are
   attributed via `field_sources.<key> = "api:apollo:<date>"`.
@@ -42,9 +42,10 @@ contract.
   came from a LinkedIn export, the second source is lost.
 - **MCP `remember(sources=...)` shape** (#96). Three on-the-wire shapes
   collide today and the type-based disambiguation has a pathological case.
-- **Legacy slug → typed migration** (#97). 15,403 wikis still carry
-  `source: <bare-slug>`. They need a typed equivalent so the legacy
-  branch in `_LEGACY_SCALAR_RE` can retire.
+- ~~**Legacy slug → typed migration** (#97).~~ Resolved 2026-05-09:
+  `athenaeum repair --legacy-source-slugs --apply` migrated 15,403 wikis
+  from `<bare-slug>` to `script:<slug>`. The `_LEGACY_SCALAR_RE` branch
+  in `provenance.parse_source` retired in the follow-up PR.
 
 ---
 
@@ -334,8 +335,14 @@ After a successful migration of the live tree:
 
 - `_LEGACY_SCALAR_RE` and its branch in `provenance.parse_source` retire.
 - Tests that exercise the legacy branch retire with it.
-- This doc gets a note: "legacy bare-slug shape removed in
-  athenaeum#NNN, <date>."
+
+**Status (2026-05-09):** the live-tree migration ran and rewrote 15,403
+wikis to the `script:<slug>` typed form. The `_LEGACY_SCALAR_RE` constant
+and the legacy branch in `provenance.parse_source` were retired in the
+follow-up PR; `parse_source` now raises `ValueError` on bare-slug input
+with a pointer to the typed form. The migration tool itself
+(`repair.migrate_legacy_source_slugs`) keeps its own internal slug regex
+and ships unchanged for any future tree that needs it.
 
 ---
 

--- a/src/athenaeum/provenance.py
+++ b/src/athenaeum/provenance.py
@@ -42,13 +42,13 @@ from pydantic import BaseModel, ConfigDict, field_validator
 # be empty. We anchor with ``\Z`` so a trailing newline doesn't sneak in.
 _SCALAR_RE = re.compile(r"^([a-z][a-z0-9_-]*):([^\n]+)\Z")
 
-# Legacy single-token form (no colon) — for pre-#90 wikis whose ``source:``
-# is a bare slug like ``extended-tier-build`` or ``warm-network-detect``.
-# ~15k live wikis use this shape; the validator MUST accept them so the
-# schema doesn't break the live tree. New wikis SHOULD use the typed
-# ``<type>:<ref>`` form above. Migration of legacy → typed is tracked
-# separately in issue #97; once complete, this regex + branch can go.
-_LEGACY_SCALAR_RE = re.compile(r"^[a-z][a-z0-9_-]*\Z")
+# Note: the legacy single-token (bare-slug) ``source:`` form was retired
+# after issue #97 migrated 15,403 live-tree wikis from `<slug>` to
+# `script:<slug>` on 2026-05-09 via
+# ``athenaeum repair --legacy-source-slugs --apply``. New wikis MUST use
+# the typed ``<type>:<ref>`` form. The migration tool itself
+# (`repair.migrate_legacy_source_slugs`) keeps its own internal slug
+# regex and ships unchanged for any future tree that needs it.
 
 
 class SourceRef(BaseModel):
@@ -134,15 +134,13 @@ def parse_source(value: Any) -> SourceRef | None:
                     f"source ref must not have leading/trailing whitespace, got {value!r}"
                 )
             return SourceRef(type=m.group(1), ref=ref_part)
-        # Legacy single-token form (pre-#90 wikis). Accept but don't
-        # synthesize a structured SourceRef — the on-disk shape stays the
-        # bare slug; we model it as type="legacy", ref=<slug> for callers
-        # that need a SourceRef object. Validator preserves on-disk shape
-        # via validate_source_value (returns value unchanged).
-        if _LEGACY_SCALAR_RE.match(value):
-            return SourceRef(type="legacy", ref=value)
+        # Legacy bare-slug form retired post-#97 migration. Callers that
+        # still emit `source: <slug>` must switch to the typed
+        # `<type>:<ref>` form (e.g. `script:<slug>`).
         raise ValueError(
-            f"source scalar must match '<type>:<ref>' or legacy '[a-z][a-z0-9_-]*', got {value!r}"
+            f"source scalar must be typed '<type>:<ref>' (e.g. "
+            f"'script:extended-tier-build'); legacy bare-slug form retired "
+            f"in #97, got {value!r}"
         )
     if isinstance(value, dict):
         return SourceRef.model_validate(value)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -40,7 +40,9 @@ class TestParseSourceScalar:
             "Type:has-uppercase",
             "1numeric:start",
             "type:has\nnewline",
-            "Has-Uppercase",  # legacy form must also be lowercase-only
+            "Has-Uppercase",  # uppercase rejected
+            "extended-tier-build",  # legacy bare-slug form retired in #97
+            "warm-network-detect",  # legacy bare-slug form retired in #97
             "has spaces",
             "",  # empty
             "type:   ",  # whitespace-only ref
@@ -52,17 +54,16 @@ class TestParseSourceScalar:
         with pytest.raises(ValueError):
             parse_source(bad)
 
-    def test_legacy_single_token_accepted(self) -> None:
-        # Pre-#90 wikis store ``source:`` as a bare slug (no colon).
-        # ~15k live wikis use this form; the validator must accept them.
-        ref = parse_source("extended-tier-build")
-        assert ref.type == "legacy"
-        assert ref.ref == "extended-tier-build"
+    def test_legacy_bare_slug_retired(self) -> None:
+        # Legacy bare-slug form retired post-#97 (live tree migrated
+        # 15,403 wikis to `script:<slug>` on 2026-05-09). The parser now
+        # rejects bare slugs with a helpful pointer to the typed form.
+        with pytest.raises(ValueError, match="typed"):
+            parse_source("extended-tier-build")
 
-        ref2 = parse_source("warm-network-detect")
-        assert ref2.ref == "warm-network-detect"
-
-        # And the typed form still works on the same call site.
+    def test_typed_form_post_migration(self) -> None:
+        # Idempotency check: the typed form that #97 migrates to must
+        # round-trip cleanly through parse_source.
         typed = parse_source("script:extended-tier-build")
         assert typed.type == "script"
         assert typed.ref == "extended-tier-build"
@@ -131,11 +132,12 @@ class TestValidateSourceValue:
 
     def test_malformed_raises(self) -> None:
         with pytest.raises(ValueError):
-            validate_source_value("Has-Uppercase")  # neither typed nor legacy
+            validate_source_value("Has-Uppercase")  # malformed
 
-    def test_legacy_passes(self) -> None:
-        # Legacy single-token form must round-trip unchanged.
-        assert validate_source_value("extended-tier-build") == "extended-tier-build"
+    def test_legacy_bare_slug_rejected(self) -> None:
+        # Post-#97: legacy bare-slug form no longer validates.
+        with pytest.raises(ValueError):
+            validate_source_value("extended-tier-build")
 
 
 class TestValidateFieldSources:

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -628,10 +628,12 @@ def test_cli_legacy_slugs_unknown_slug_returns_1(tmp_path: Path, capsys) -> None
     assert "ABORTED" in captured.err
 
 
-def test_legacy_scalar_re_still_present_in_provenance() -> None:
-    """Quine gate: the legacy bare-slug regex MUST still be present in
-    ``provenance.py``. This PR ships the migration tool ONLY; the regex
-    retires in a separate follow-up after the live tree is migrated."""
+def test_legacy_scalar_re_retired_from_provenance() -> None:
+    """Quine gate: the legacy bare-slug regex is RETIRED from
+    ``provenance.py``. Live tree migrated 2026-05-09 (15,403 wikis to
+    `script:<slug>` via ``athenaeum repair --legacy-source-slugs --apply``),
+    and the parser branch retired in the follow-up PR. The migration tool
+    keeps its own internal slug regex in ``repair.py``."""
     from athenaeum import provenance
 
-    assert hasattr(provenance, "_LEGACY_SCALAR_RE")
+    assert not hasattr(provenance, "_LEGACY_SCALAR_RE")

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -314,16 +314,27 @@ class TestProvenanceFields:
                 field_sources={"emails": "Has-Uppercase"},
             )
 
-    def test_legacy_source_accepted(self) -> None:
-        # Pre-#90 wikis store ``source: extended-tier-build`` as a bare slug.
-        # ~15k live wikis use this shape; schema must accept them.
+    def test_legacy_bare_slug_source_rejected(self) -> None:
+        # Post-#97: legacy bare-slug `source:` form is retired. The live
+        # tree was migrated to `script:<slug>` on 2026-05-09; the schema
+        # now rejects bare slugs and requires the typed `<type>:<ref>` form.
+        with pytest.raises(ValueError):
+            PersonWiki(
+                uid="abc12345",
+                type="person",
+                name="X",
+                source="extended-tier-build",
+            )
+
+    def test_typed_script_source_accepted(self) -> None:
+        # Post-migration shape — `script:<slug>` is the typed equivalent.
         m = PersonWiki(
             uid="abc12345",
             type="person",
             name="X",
-            source="extended-tier-build",
+            source="script:extended-tier-build",
         )
-        assert m.source == "extended-tier-build"
+        assert m.source == "script:extended-tier-build"
 
     def test_none_passes(self) -> None:
         m = PersonWiki(uid="abc12345", type="person", name="X")


### PR DESCRIPTION
## Summary

The live-tree migration ran successfully on 2026-05-09: `athenaeum repair --legacy-source-slugs --apply` rewrote **15,403 wikis** from bare-slug `source: <slug>` to typed `source: script:<slug>` (15,117 `extended-tier-build` + 286 `warm-network-detect`). With zero remaining bare-slug values on disk, the legacy reader branch in `provenance.parse_source` retires.

## What changed

- **`src/athenaeum/provenance.py`** — delete `_LEGACY_SCALAR_RE` constant; remove the legacy fallback in `parse_source`. Bare-slug input now raises `ValueError` with a pointer to the typed `<type>:<ref>` form.
- **`tests/test_provenance.py`** — drop `test_legacy_single_token_accepted` and `test_legacy_passes`; add `test_legacy_bare_slug_retired` (asserts `ValueError`) and `test_typed_form_post_migration` (idempotency check on the migrated form). Add bare-slug examples to the malformed-scalar parametrize.
- **`tests/test_schemas.py`** — invert `test_legacy_source_accepted` to `test_legacy_bare_slug_source_rejected` and add `test_typed_script_source_accepted`.
- **`tests/test_repair.py`** — invert the Quine gate `test_legacy_scalar_re_still_present_in_provenance` to `test_legacy_scalar_re_retired_from_provenance` (the regex MUST now be absent).
- **`docs/provenance-shape.md`** — §1 "Already shipped" + §1 "Not yet decided" + §5 closing note updated to reflect retirement and cite the migration date / counts.
- **`CHANGELOG.md`** — `### Removed` entry marked BREAKING.

## Out of scope (intentionally untouched)

- **Migration tool** (`repair.migrate_legacy_source_slugs`) keeps its own internal slug regex and ships unchanged for any future tree that needs it.
- **Field-keyed `field_sources` legacy reader** (per `docs/provenance-shape.md` §2.3) is a different legacy form (one source for the whole list) and stays accepted on read — design-locked to stay forever.

## Test plan

- [x] `.venv/bin/pytest tests/ -q` returns 597 passed, 1 skipped (was 593 before; net +4 from added inverse tests)
- [x] `grep -r _LEGACY_SCALAR_RE src/` returns nothing
- [x] `parse_source("extended-tier-build")` raises `ValueError` mentioning "typed"
- [x] `parse_source("script:extended-tier-build")` returns `SourceRef(type="script", ref="extended-tier-build")`
- [x] Migration tool tests still green (`tests/test_repair.py`)
- [x] Field-keyed `field_sources` legacy-shape tests still green (unrelated)

## Issue link

Completes athenaeum#97 acceptance criterion "Remove legacy regex branch + its tests" which was deferred from #120 pending the live-tree migration. (Not using a `Closes` keyword — #97 was already closed by #120.)

Built with [WOZCODE](https://wozcode.com)
