### PR TITLE
feat(contradictions): cross-scope detection mode toggle (#125)

### DIFF
--- a/src/athenaeum/config.py
+++ b/src/athenaeum/config.py
@@ -46,6 +46,22 @@ _DEFAULTS: dict[str, Any] = {
         "cluster_threshold": 0.55,
         "cluster_output": "raw/_librarian-clusters.jsonl",
     },
+    "contradiction": {
+        # Cross-scope contradiction detection (issue #125, #81-A).
+        # Modes: off | ancestor | similarity | both. Default ``ancestor``
+        # pools each per-scope cluster with members from any ancestor scope
+        # (e.g. ``-Users-tristankromer-Code-foo``'s pool also includes
+        # ``-Users-tristankromer-Code``). ``similarity`` runs a cosine
+        # cross-product over the recall index (raw + wiki). ``both`` runs
+        # ancestor pooling AND the similarity sweep. Env override:
+        # ``ATHENAEUM_CROSS_SCOPE_MODE``.
+        "cross_scope_mode": "ancestor",
+        # Hard cap on pooled-cluster size before splitting into newest-first
+        # chunks for the detector.
+        "cluster_size_cap": 25,
+        # Cosine similarity threshold for the cross-scope sweep.
+        "similarity_threshold": 0.85,
+    },
 }
 
 
@@ -118,6 +134,22 @@ search_backend: fts5
 # librarian:
 #   cluster_threshold: 0.55
 #   cluster_output: raw/_librarian-clusters.jsonl
+
+# Cross-scope contradiction detection (issue #125).
+# cross_scope_mode: off | ancestor (default) | similarity | both.
+#   - off: per-scope cluster only.
+#   - ancestor: pool each cluster with ancestor scopes (-Users-foo-bar
+#     also includes -Users-foo, -Users) before running the detector.
+#   - similarity: per-scope pass + cosine sweep over raw + wiki.
+#   - both: ancestor pooling THEN similarity sweep.
+# cluster_size_cap: pooled-cluster size cap; oversized pools are split
+#   into newest-first chunks before detection.
+# similarity_threshold: cosine cutoff for the cross-scope sweep.
+# Env override: ATHENAEUM_CROSS_SCOPE_MODE.
+# contradiction:
+#   cross_scope_mode: ancestor
+#   cluster_size_cap: 25
+#   similarity_threshold: 0.85
 """
 
 

--- a/src/athenaeum/cross_scope.py
+++ b/src/athenaeum/cross_scope.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-scope contradiction detection helpers (issue #125, #81-A).
+
+The base C4 detector (:mod:`athenaeum.contradictions`) operates on one
+cluster at a time. Each cluster is scoped to a single ``raw/auto-memory/``
+subdirectory because C2's clustering is keyed by origin scope. That misses
+two manifestations the merge pipeline still has to catch:
+
+1. **Raw-vs-raw at merge time** — two raw entries that should be compared
+   sit in different scope folders (e.g. one under
+   ``-Users-tristankromer-Code-foo`` and one under
+   ``-Users-tristankromer-Code``). The per-scope clustering never groups
+   them, so the detector never sees them.
+2. **Wiki-vs-wiki post-merge** — distinct ``wiki/auto-*.md`` entries
+   merged from different clusters can still contradict each other, and
+   the librarian deletes the raw originals after a successful merge.
+
+This module adds two cooperative passes the merge orchestrator can
+toggle in via ``ATHENAEUM_CROSS_SCOPE_MODE``:
+
+- **ancestor pooling**: when materializing a per-scope cluster, also
+  include every member from any *ancestor* scope (root scope plus every
+  prefix). De-dupe by absolute path; if the pooled cluster exceeds
+  ``cluster_size_cap``, split into ordered chunks (newest-first by
+  ``created`` frontmatter, ``mtime`` fallback) and run the detector
+  once per chunk.
+- **similarity sweep**: a second-pass embedding cross-product over BOTH
+  ``raw/auto-memory/**`` AND ``wiki/**``. Any pair whose cosine
+  similarity exceeds the configured threshold and that is NOT already
+  contained in a single cluster is fed to the detector as a 2-member
+  pseudo-cluster. Embeddings come from the recall index — we do NOT
+  open a second chromadb collection.
+
+Modes:
+
+- ``off`` — pass through; no cross-scope work.
+- ``ancestor`` (default) — ancestor pooling only.
+- ``similarity`` — per-scope clusters + similarity sweep.
+- ``both`` — ancestor pooling first, similarity sweep second over the
+  remaining unpaired entries.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from athenaeum.models import AutoMemoryFile, parse_frontmatter
+
+log = logging.getLogger(__name__)
+
+
+# Env var + config defaults --------------------------------------------------
+
+ENV_VAR = "ATHENAEUM_CROSS_SCOPE_MODE"
+DEFAULT_MODE = "ancestor"
+VALID_MODES = ("off", "ancestor", "similarity", "both")
+
+DEFAULT_CLUSTER_SIZE_CAP = 25
+DEFAULT_SIMILARITY_THRESHOLD = 0.85
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_cross_scope_mode(config: dict[str, Any] | None = None) -> str:
+    """Resolve cross-scope mode. Env var wins over config; default ``ancestor``."""
+    env_val = os.environ.get(ENV_VAR)
+    if env_val:
+        env_val = env_val.strip().lower()
+        if env_val in VALID_MODES:
+            return env_val
+        log.warning(
+            "cross_scope: invalid %s=%r; falling back to %s",
+            ENV_VAR,
+            env_val,
+            DEFAULT_MODE,
+        )
+    if config is not None:
+        contradiction_cfg = config.get("contradiction") or {}
+        cfg_val = contradiction_cfg.get("cross_scope_mode")
+        if isinstance(cfg_val, str):
+            cfg_val = cfg_val.strip().lower()
+            if cfg_val in VALID_MODES:
+                return cfg_val
+            log.warning(
+                "cross_scope: invalid contradiction.cross_scope_mode=%r; "
+                "falling back to %s",
+                cfg_val,
+                DEFAULT_MODE,
+            )
+    return DEFAULT_MODE
+
+
+def resolve_cluster_size_cap(config: dict[str, Any] | None = None) -> int:
+    """Resolve the pooled-cluster size cap (default 25)."""
+    if config is None:
+        return DEFAULT_CLUSTER_SIZE_CAP
+    contradiction_cfg = config.get("contradiction") or {}
+    raw = contradiction_cfg.get("cluster_size_cap")
+    try:
+        if raw is None:
+            return DEFAULT_CLUSTER_SIZE_CAP
+        cap = int(raw)
+        return cap if cap > 0 else DEFAULT_CLUSTER_SIZE_CAP
+    except (TypeError, ValueError):
+        return DEFAULT_CLUSTER_SIZE_CAP
+
+
+def resolve_similarity_threshold(config: dict[str, Any] | None = None) -> float:
+    """Resolve cosine similarity threshold for cross-scope sweep (default 0.85)."""
+    if config is None:
+        return DEFAULT_SIMILARITY_THRESHOLD
+    contradiction_cfg = config.get("contradiction") or {}
+    raw = contradiction_cfg.get("similarity_threshold")
+    try:
+        if raw is None:
+            return DEFAULT_SIMILARITY_THRESHOLD
+        return float(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_SIMILARITY_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Ancestor scope walking
+# ---------------------------------------------------------------------------
+
+
+def scope_ancestors(scope: str) -> list[str]:
+    """Return ancestor scope identifiers for a path-hash scope.
+
+    Scope identifiers follow the convention ``-Users-tristankromer-Code-foo``
+    (slashes replaced by dashes, leading dash). Ancestors are produced by
+    successively dropping trailing segments. ``_unscoped`` and any scope
+    not starting with ``-`` has no ancestors.
+
+    Example:
+        ``-Users-tristankromer-Code-foo`` →
+        ``["-Users-tristankromer-Code", "-Users-tristankromer", "-Users"]``
+    """
+    if not isinstance(scope, str) or not scope.startswith("-"):
+        return []
+    parts = scope.lstrip("-").split("-")
+    if len(parts) <= 1:
+        return []
+    out: list[str] = []
+    for i in range(len(parts) - 1, 0, -1):
+        out.append("-" + "-".join(parts[:i]))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Ancestor pooling + size-cap chunking
+# ---------------------------------------------------------------------------
+
+
+def _created_sort_key(am: AutoMemoryFile) -> tuple[int, str]:
+    """Sort key for newest-first ordering. Uses frontmatter ``created`` if present.
+
+    Returns ``(rank, tiebreak)``. Rank is negated so a sort ascending puts
+    newer first. We coerce ``created`` to a string and rely on ISO ordering;
+    missing/unparseable creates fall back to mtime.
+    """
+    try:
+        text = am.path.read_text(encoding="utf-8")
+        meta, _ = parse_frontmatter(text)
+        created = meta.get("created") if isinstance(meta, dict) else None
+        if isinstance(created, str) and created:
+            # Negate by inverting via a lexicographically descending key
+            # achieved with a sentinel: pair (0, -ord-string) is awkward;
+            # simpler: store created and negate at the call site via reverse=True.
+            return (0, created)
+    except (OSError, UnicodeDecodeError):
+        pass
+    try:
+        mtime = am.path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    return (1, f"{mtime:020.6f}")
+
+
+def sort_newest_first(members: Sequence[AutoMemoryFile]) -> list[AutoMemoryFile]:
+    """Return members ordered newest-first by ``created`` (or mtime fallback)."""
+    return sorted(members, key=_created_sort_key, reverse=True)
+
+
+def pool_cluster_with_ancestors(
+    cluster_members: Sequence[AutoMemoryFile],
+    all_members: Sequence[AutoMemoryFile],
+) -> list[AutoMemoryFile]:
+    """Pool *cluster_members* with members from any ancestor scope.
+
+    The pool de-dupes by resolved absolute path. The original cluster
+    members are kept first (so downstream receipts still attribute to the
+    primary cluster), with ancestor-scope members appended in their
+    discovery order.
+    """
+    if not cluster_members:
+        return []
+    scopes = {am.origin_scope for am in cluster_members}
+    ancestors: set[str] = set()
+    for s in scopes:
+        ancestors.update(scope_ancestors(s))
+    if not ancestors:
+        return list(cluster_members)
+
+    seen: set[str] = set()
+    pooled: list[AutoMemoryFile] = []
+    for am in cluster_members:
+        try:
+            key = str(am.path.resolve())
+        except OSError:
+            key = str(am.path)
+        if key in seen:
+            continue
+        seen.add(key)
+        pooled.append(am)
+    for am in all_members:
+        if am.origin_scope not in ancestors:
+            continue
+        try:
+            key = str(am.path.resolve())
+        except OSError:
+            key = str(am.path)
+        if key in seen:
+            continue
+        seen.add(key)
+        pooled.append(am)
+    return pooled
+
+
+def chunk_by_cap(
+    members: Sequence[AutoMemoryFile],
+    cap: int,
+) -> list[list[AutoMemoryFile]]:
+    """Split *members* into newest-first chunks of size ``<= cap``.
+
+    Returns ``[list(members)]`` if ``len(members) <= cap`` (no work to do).
+    Otherwise sorts newest-first and slices into ``ceil(N/cap)`` chunks.
+    """
+    if cap <= 0 or len(members) <= cap:
+        return [list(members)]
+    ordered = sort_newest_first(members)
+    chunks: list[list[AutoMemoryFile]] = []
+    for i in range(0, len(ordered), cap):
+        chunks.append(ordered[i : i + cap])
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Similarity sweep
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SimilarityCandidate:
+    """One pair of paths that exceeded the cosine threshold."""
+
+    a_path: Path
+    b_path: Path
+    similarity: float
+    a_scope: str = ""
+    b_scope: str = ""
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    if len(a) != len(b):
+        return 0.0
+    import math
+
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def _wiki_indexed_id(wiki_path: Path, wiki_root: Path) -> str | None:
+    """Recall index id for a wiki page, or None if not under wiki_root."""
+    try:
+        rel = wiki_path.resolve().relative_to(wiki_root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return None
+    return rel
+
+
+def _raw_indexed_id(am_path: Path, extra_roots: Sequence[Path]) -> str | None:
+    """Recall index id for a raw auto-memory file."""
+    try:
+        ampath = am_path.resolve()
+    except OSError:
+        return None
+    for root in extra_roots:
+        try:
+            rel = ampath.relative_to(root.resolve()).as_posix()
+        except ValueError:
+            continue
+        return f"{root.name}/{rel}"
+    return None
+
+
+def cross_scope_similarity_pairs(
+    auto_memory_files: Sequence[AutoMemoryFile],
+    *,
+    wiki_files: Sequence[Path] = (),
+    wiki_root: Path | None = None,
+    extra_roots: Sequence[Path] = (),
+    cache_dir: Path,
+    threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    excluded_pair_keys: Iterable[tuple[str, str]] = (),
+    embedding_provider: Any = None,
+) -> list[SimilarityCandidate]:
+    """Find candidate pairs via cosine similarity over the recall index.
+
+    Args:
+        auto_memory_files: All discovered raw auto-memory files.
+        wiki_files: Optional list of compiled ``wiki/auto-*.md`` paths to
+            include in the sweep so wiki-vs-wiki contradictions can fire
+            after raw originals are deleted.
+        wiki_root: Wiki root directory (used to compute recall-index ids
+            for ``wiki_files``). Required if ``wiki_files`` is non-empty.
+        extra_roots: Same list passed to :mod:`athenaeum.clusters` —
+            translates absolute auto-memory paths into recall index ids.
+        cache_dir: Shared chromadb cache root (``<cache_dir>/wiki-vectors``).
+        threshold: Cosine cutoff (default 0.85).
+        excluded_pair_keys: Iterable of ``(path_a, path_b)`` string-key
+            pairs already contained in a single cluster — these are
+            filtered out so the per-scope pass's coverage isn't repeated.
+            Order-insensitive (we sort the key).
+        embedding_provider: Optional override for testing. Must expose a
+            ``fetch_embeddings(ids, cache_dir)`` method. Defaults to
+            :class:`athenaeum.search.VectorBackend`.
+
+    Returns:
+        List of :class:`SimilarityCandidate`, ordered by descending
+        similarity. Empty list when chromadb is unavailable or no pair
+        meets the threshold.
+    """
+    excluded: set[tuple[str, str]] = set()
+    for a, b in excluded_pair_keys:
+        excluded.add(tuple(sorted((str(a), str(b)))))
+
+    # Build id → (path, scope) map for both raw + wiki.
+    id_to_entry: dict[str, tuple[Path, str]] = {}
+    for am in auto_memory_files:
+        idx = _raw_indexed_id(am.path, extra_roots)
+        if idx is None:
+            continue
+        id_to_entry[idx] = (am.path, am.origin_scope)
+    if wiki_files and wiki_root is not None:
+        for wp in wiki_files:
+            idx = _wiki_indexed_id(wp, wiki_root)
+            if idx is None:
+                continue
+            id_to_entry[idx] = (wp, "<wiki>")
+
+    if len(id_to_entry) < 2:
+        return []
+
+    # Fetch embeddings from the shared collection (no new client/collection).
+    if embedding_provider is None:
+        try:
+            from athenaeum.search import VectorBackend
+
+            embedding_provider = VectorBackend()
+        except Exception as exc:  # noqa: BLE001
+            log.debug("cross_scope similarity: VectorBackend unavailable: %s", exc)
+            return []
+
+    try:
+        raw_embeds = embedding_provider.fetch_embeddings(
+            id_to_entry.keys(),
+            cache_dir,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.debug("cross_scope similarity: fetch_embeddings failed: %s", exc)
+        return []
+
+    items: list[tuple[str, Path, str, list[float]]] = []
+    for idx, vec in raw_embeds.items():
+        entry = id_to_entry.get(idx)
+        if entry is None:
+            continue
+        path, scope = entry
+        items.append((idx, path, scope, list(vec)))
+
+    candidates: list[SimilarityCandidate] = []
+    for i in range(len(items)):
+        idx_i, path_i, scope_i, vec_i = items[i]
+        for j in range(i + 1, len(items)):
+            idx_j, path_j, scope_j, vec_j = items[j]
+            sim = _cosine(vec_i, vec_j)
+            if sim < threshold:
+                continue
+            key = tuple(sorted((str(path_i), str(path_j))))
+            if key in excluded:
+                continue
+            candidates.append(
+                SimilarityCandidate(
+                    a_path=path_i,
+                    b_path=path_j,
+                    similarity=sim,
+                    a_scope=scope_i,
+                    b_scope=scope_j,
+                )
+            )
+    candidates.sort(key=lambda c: c.similarity, reverse=True)
+    return candidates
+
+
+def candidate_to_auto_memory_files(
+    candidate: SimilarityCandidate,
+) -> list[AutoMemoryFile]:
+    """Wrap a similarity candidate's two paths as :class:`AutoMemoryFile` records.
+
+    Reads frontmatter on demand to populate ``name``/``description``. The
+    detector consumes the file body itself, so this stub is sufficient
+    for 2-member detector calls.
+    """
+    out: list[AutoMemoryFile] = []
+    for path, scope in (
+        (candidate.a_path, candidate.a_scope),
+        (candidate.b_path, candidate.b_scope),
+    ):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            text = ""
+        meta, _ = parse_frontmatter(text) if text else ({}, "")
+        name = ""
+        description = ""
+        memory_type = "unknown"
+        if isinstance(meta, dict):
+            name = str(meta.get("name", "") or "")
+            description = str(meta.get("description", "") or "")
+            memory_type = str(meta.get("type", "unknown") or "unknown")
+        out.append(
+            AutoMemoryFile(
+                path=path,
+                origin_scope=scope or "<unknown>",
+                memory_type=memory_type,
+                name=name,
+                description=description,
+            )
+        )
+    return out

--- a/src/athenaeum/merge.py
+++ b/src/athenaeum/merge.py
@@ -50,6 +50,15 @@ from typing import TYPE_CHECKING, Any
 from athenaeum.clusters import resolve_cluster_output_path
 from athenaeum.config import load_config, resolve_extra_intake_roots
 from athenaeum.contradictions import ContradictionResult, detect_contradictions
+from athenaeum.cross_scope import (
+    candidate_to_auto_memory_files,
+    chunk_by_cap,
+    cross_scope_similarity_pairs,
+    pool_cluster_with_ancestors,
+    resolve_cluster_size_cap,
+    resolve_cross_scope_mode,
+    resolve_similarity_threshold,
+)
 from athenaeum.models import (
     AutoMemoryFile,
     EscalationItem,
@@ -86,11 +95,25 @@ AUTO_WIKI_PREFIX = "auto-"
 # filenames — these carry no semantic weight and would otherwise win
 # the frequency contest on naturally-clustered files (``feedback_`` is
 # the dominant prefix across memories, for example).
-_SLUG_BORING_TOKENS: frozenset[str] = frozenset({
-    "feedback", "project", "reference", "user", "recall", "auto",
-    "memory", "note", "the", "and", "for", "with", "file", "files",
-    "md",
-})
+_SLUG_BORING_TOKENS: frozenset[str] = frozenset(
+    {
+        "feedback",
+        "project",
+        "reference",
+        "user",
+        "recall",
+        "auto",
+        "memory",
+        "note",
+        "the",
+        "and",
+        "for",
+        "with",
+        "file",
+        "files",
+        "md",
+    }
+)
 
 
 @dataclass
@@ -149,7 +172,8 @@ def read_cluster_rows(jsonl_path: Path) -> list[dict[str, Any]]:
             except json.JSONDecodeError as exc:
                 log.warning(
                     "skipping malformed cluster row in %s: %s",
-                    jsonl_path, exc,
+                    jsonl_path,
+                    exc,
                 )
     return rows
 
@@ -160,7 +184,8 @@ def read_cluster_rows(jsonl_path: Path) -> list[dict[str, Any]]:
 
 
 def resolve_member_path(
-    member_ref: str, extra_roots: list[Path],
+    member_ref: str,
+    extra_roots: list[Path],
 ) -> Path | None:
     """Resolve a cluster row's ``member_paths`` entry to an absolute file.
 
@@ -197,7 +222,8 @@ def _slug_tokens_from_filename(filename: str) -> list[str]:
 
 
 def derive_topic_slug(
-    member_paths: list[str], cluster_id: str,
+    member_paths: list[str],
+    cluster_id: str,
 ) -> str:
     """Derive a filesystem-safe topic slug from cluster member filenames.
 
@@ -418,7 +444,8 @@ def merge_cluster_row(
         if resolved is None:
             log.warning(
                 "cluster %s: member %s did not resolve; skipping that member",
-                cluster_id, mp,
+                cluster_id,
+                mp,
             )
             continue
         key = str(resolved)
@@ -433,7 +460,8 @@ def merge_cluster_row(
             except (OSError, UnicodeDecodeError):
                 log.warning(
                     "cluster %s: %s unreadable; skipping that member",
-                    cluster_id, resolved,
+                    cluster_id,
+                    resolved,
                 )
                 continue
             meta, _ = parse_frontmatter(text)
@@ -458,8 +486,7 @@ def merge_cluster_row(
                 name=str(meta.get("name", "")) if meta else "",
                 description=str(meta.get("description", "")) if meta else "",
                 origin_session_id=(
-                    str(origin_session_id)
-                    if origin_session_id is not None else None
+                    str(origin_session_id) if origin_session_id is not None else None
                 ),
                 origin_turn=origin_turn,
                 sources=sources,
@@ -599,7 +626,8 @@ def merge_clusters_to_wiki(
         from athenaeum.librarian import discover_auto_memory_files
 
         auto_memory_files = discover_auto_memory_files(
-            knowledge_root, config=resolved_config,
+            knowledge_root,
+            config=resolved_config,
         )
 
     am_by_path = _collect_am_by_path(auto_memory_files)
@@ -607,7 +635,9 @@ def merge_clusters_to_wiki(
     entries: list[MergedWikiEntry] = []
     for row in rows:
         entry = merge_cluster_row(
-            row, extra_roots=extra_roots, am_by_path=am_by_path,
+            row,
+            extra_roots=extra_roots,
+            am_by_path=am_by_path,
         )
         if entry is None:
             continue
@@ -622,48 +652,151 @@ def merge_clusters_to_wiki(
         if base in slug_counts:
             slug_counts[base] += 1
             suffix = re.sub(r"[^a-z0-9]+", "-", entry.cluster_id.lower()).strip("-")
-            entry.topic_slug = f"{base}-{suffix}" if suffix else f"{base}-{slug_counts[base]}"
+            entry.topic_slug = (
+                f"{base}-{suffix}" if suffix else f"{base}-{slug_counts[base]}"
+            )
         else:
             slug_counts[base] = 1
 
-    # C4 (#198): claim-level contradiction detection per cluster. Runs for
-    # every cluster including in dry-run (so operators can preview which
-    # entries would flag) but only writes the escalation file on non-dry
-    # runs. Detector failures and missing keys degrade to detected=False.
+    # C4 (#198 + #125): claim-level contradiction detection.
+    #
+    # Mode toggle (issue #125, ATHENAEUM_CROSS_SCOPE_MODE):
+    # - off: per-cluster only (legacy behavior).
+    # - ancestor (default): pool each cluster with ancestor-scope members
+    #   then chunk by cap before running the detector.
+    # - similarity: per-cluster pass + cosine sweep over raw + wiki.
+    # - both: ancestor pooling THEN similarity sweep over remaining pairs.
     wiki_root = knowledge_root / "wiki"
     escalations: list[EscalationItem] = []
-    for entry in entries:
-        result = detect_contradictions(entry.resolved_members, client)
-        entry.contradiction = result
-        entry.contradictions_detected = bool(result.detected)
-        if result.detected:
-            wiki_ref = f"wiki/{entry.filename}"
-            description_parts: list[str] = []
-            if result.rationale:
-                description_parts.append(result.rationale)
-            if result.conflicting_passages:
-                for i, passage in enumerate(result.conflicting_passages, start=1):
-                    description_parts.append(f"Passage {i}: {passage}")
-            if result.members_involved:
-                description_parts.append(
-                    "Members involved: " + ", ".join(result.members_involved)
+    mode = resolve_cross_scope_mode(resolved_config)
+    cluster_size_cap = resolve_cluster_size_cap(resolved_config)
+    similarity_threshold = resolve_similarity_threshold(resolved_config)
+
+    haiku_calls = 0
+    pairs_added_via_similarity = 0
+    chunks_run = 0
+
+    # Track which (path_a, path_b) pairs are already covered by a single
+    # detector call so the similarity sweep can skip them.
+    covered_pair_keys: set[tuple[str, str]] = set()
+
+    def _record_pair_keys(members: list[AutoMemoryFile]) -> None:
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                covered_pair_keys.add(
+                    tuple(sorted((str(members[i].path), str(members[j].path))))
                 )
-            description = "\n".join(description_parts) or (
-                f"Cluster {entry.cluster_id} flagged by contradiction detector."
+
+    def _emit_escalation(entry: MergedWikiEntry, result: ContradictionResult) -> None:
+        if not result.detected:
+            return
+        wiki_ref = f"wiki/{entry.filename}"
+        description_parts: list[str] = []
+        if result.rationale:
+            description_parts.append(result.rationale)
+        if result.conflicting_passages:
+            for i, passage in enumerate(result.conflicting_passages, start=1):
+                description_parts.append(f"Passage {i}: {passage}")
+        if result.members_involved:
+            description_parts.append(
+                "Members involved: " + ", ".join(result.members_involved)
             )
-            escalations.append(EscalationItem(
+        description = "\n".join(description_parts) or (
+            f"Cluster {entry.cluster_id} flagged by contradiction detector."
+        )
+        escalations.append(
+            EscalationItem(
                 raw_ref=wiki_ref,
                 entity_name=entry.topic_slug,
                 conflict_type=result.conflict_type or "factual",
                 description=description,
-            ))
+            )
+        )
+
+    auto_memory_list = list(auto_memory_files)
+    use_ancestor = mode in ("ancestor", "both")
+
+    for entry in entries:
+        if use_ancestor:
+            pooled = pool_cluster_with_ancestors(
+                entry.resolved_members,
+                auto_memory_list,
+            )
+            chunks = chunk_by_cap(pooled, cluster_size_cap)
+        else:
+            chunks = [list(entry.resolved_members)]
+
+        # Track aggregate result across chunks: any chunk that detects
+        # wins. The first detected result is the canonical one for the
+        # entry's frontmatter.
+        aggregate: ContradictionResult | None = None
+        for chunk in chunks:
+            chunks_run += 1
+            if len(chunk) >= 2:
+                haiku_calls += 1
+            result = detect_contradictions(chunk, client)
+            _record_pair_keys(chunk)
+            if result.detected and aggregate is None:
+                aggregate = result
+                _emit_escalation(entry, result)
+        if aggregate is None:
+            # Use the last result so rationale (e.g. "singleton" /
+            # "llm-unavailable") is preserved on the entry.
+            aggregate = result if chunks else ContradictionResult(detected=False)
+        entry.contradiction = aggregate
+        entry.contradictions_detected = bool(aggregate.detected)
+
+    # Similarity sweep (mode in {similarity, both}).
+    if mode in ("similarity", "both"):
+        from athenaeum.clusters import DEFAULT_CACHE_DIR
+
+        wiki_files: list[Path] = []
+        if wiki_root.is_dir():
+            wiki_files = sorted(wiki_root.glob("auto-*.md"))
+        candidates = cross_scope_similarity_pairs(
+            auto_memory_list,
+            wiki_files=wiki_files,
+            wiki_root=wiki_root,
+            extra_roots=extra_roots,
+            cache_dir=DEFAULT_CACHE_DIR,
+            threshold=similarity_threshold,
+            excluded_pair_keys=covered_pair_keys,
+        )
+        for cand in candidates:
+            pair = candidate_to_auto_memory_files(cand)
+            haiku_calls += 1
+            result = detect_contradictions(pair, client)
+            if result.detected:
+                pairs_added_via_similarity += 1
+                # Synthesize a thin escalation entry; we don't have a
+                # MergedWikiEntry for cross-pair similarity hits, so
+                # build a minimal one tied to the first member's name.
+                synthetic = MergedWikiEntry(
+                    topic_slug=cand.a_path.stem,
+                    cluster_id=f"similarity-{cand.a_path.stem}-{cand.b_path.stem}",
+                    cluster_centroid_score=cand.similarity,
+                    contradictions_detected=True,
+                    contradiction=result,
+                )
+                _emit_escalation(synthetic, result)
+
+    log.info(
+        "contradictions: mode=%s; haiku_calls=%d; chunks_run=%d; "
+        "pairs_added_via_similarity=%d",
+        mode,
+        haiku_calls,
+        chunks_run,
+        pairs_added_via_similarity,
+    )
 
     if dry_run:
         for entry in entries:
             log.info(
                 "  [DRY RUN] merge %s → wiki/%s (%d source(s), contradictions=%s)",
-                entry.cluster_id, entry.filename,
-                len(entry.sources), entry.contradictions_detected,
+                entry.cluster_id,
+                entry.filename,
+                len(entry.sources),
+                entry.contradictions_detected,
             )
         return entries
 
@@ -673,7 +806,9 @@ def merge_clusters_to_wiki(
         page_path.write_text(render_merged_entry(entry), encoding="utf-8")
         log.info(
             "merge: wrote %s (cluster %s, %d source(s), contradictions=%s)",
-            page_path, entry.cluster_id, len(entry.sources),
+            page_path,
+            entry.cluster_id,
+            len(entry.sources),
             entry.contradictions_detected,
         )
 

--- a/tests/test_cross_scope.py
+++ b/tests/test_cross_scope.py
@@ -1,0 +1,730 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for cross-scope contradiction detection (issue #125).
+
+Covers the four modes (``off``, ``ancestor``, ``similarity``, ``both``),
+ancestor pooling, similarity-pair generation, and the cluster-size cap.
+
+No live network or live chromadb. The similarity sweep is exercised
+against a stubbed embedding provider with deterministic vectors.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from athenaeum.cross_scope import (
+    DEFAULT_CLUSTER_SIZE_CAP,
+    DEFAULT_MODE,
+    DEFAULT_SIMILARITY_THRESHOLD,
+    candidate_to_auto_memory_files,
+    chunk_by_cap,
+    cross_scope_similarity_pairs,
+    pool_cluster_with_ancestors,
+    resolve_cluster_size_cap,
+    resolve_cross_scope_mode,
+    resolve_similarity_threshold,
+    scope_ancestors,
+    sort_newest_first,
+)
+from athenaeum.merge import merge_clusters_to_wiki
+from athenaeum.models import AutoMemoryFile
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_am(
+    scope_dir: Path,
+    filename: str,
+    body: str,
+    *,
+    origin_scope: str,
+    created: str | None = None,
+) -> AutoMemoryFile:
+    scope_dir.mkdir(parents=True, exist_ok=True)
+    path = scope_dir / filename
+    fm = ["---", "name: probe", "type: feedback"]
+    if created:
+        fm.append(f"created: '{created}'")
+    fm.append("---")
+    path.write_text("\n".join(fm) + "\n" + body + "\n", encoding="utf-8")
+    return AutoMemoryFile(
+        path=path,
+        origin_scope=origin_scope,
+        memory_type="feedback",
+        name="probe",
+    )
+
+
+def _fake_client(payload_text: str) -> MagicMock:
+    client = MagicMock()
+    response = MagicMock()
+    response.content = [MagicMock(text=payload_text)]
+    client.messages.create.return_value = response
+    return client
+
+
+def _detected_payload(m1_ref: str, m2_ref: str) -> str:
+    return (
+        '{"detected": true, "conflict_type": "prescriptive", '
+        f'"members_involved": ["{m1_ref}", "{m2_ref}"], '
+        '"conflicting_passages": ["A", "B"], '
+        '"rationale": "synthetic conflict"}'
+    )
+
+
+def _no_conflict_payload() -> str:
+    return (
+        '{"detected": false, "conflict_type": null, '
+        '"members_involved": [], "conflicting_passages": [], '
+        '"rationale": ""}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# scope_ancestors
+# ---------------------------------------------------------------------------
+
+
+class TestScopeAncestors:
+    def test_three_level_scope(self) -> None:
+        assert scope_ancestors("-Users-tristankromer-Code-foo") == [
+            "-Users-tristankromer-Code",
+            "-Users-tristankromer",
+            "-Users",
+        ]
+
+    def test_root_scope_has_no_ancestors(self) -> None:
+        assert scope_ancestors("-Users") == []
+
+    def test_unscoped_has_no_ancestors(self) -> None:
+        assert scope_ancestors("_unscoped") == []
+
+    def test_empty_returns_empty(self) -> None:
+        assert scope_ancestors("") == []
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+class TestConfigResolution:
+    def test_default_mode_is_ancestor(self) -> None:
+        assert DEFAULT_MODE == "ancestor"
+        assert resolve_cross_scope_mode(None) == "ancestor"
+
+    def test_env_var_overrides_config(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("ATHENAEUM_CROSS_SCOPE_MODE", "similarity")
+        cfg = {"contradiction": {"cross_scope_mode": "off"}}
+        assert resolve_cross_scope_mode(cfg) == "similarity"
+
+    def test_invalid_env_falls_back_to_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("ATHENAEUM_CROSS_SCOPE_MODE", "garbage")
+        assert resolve_cross_scope_mode(None) == "ancestor"
+
+    def test_yaml_config_picked_up(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("ATHENAEUM_CROSS_SCOPE_MODE", raising=False)
+        cfg = {"contradiction": {"cross_scope_mode": "both"}}
+        assert resolve_cross_scope_mode(cfg) == "both"
+
+    def test_size_cap_default(self) -> None:
+        assert resolve_cluster_size_cap(None) == DEFAULT_CLUSTER_SIZE_CAP
+
+    def test_size_cap_override(self) -> None:
+        cfg = {"contradiction": {"cluster_size_cap": 5}}
+        assert resolve_cluster_size_cap(cfg) == 5
+
+    def test_threshold_default(self) -> None:
+        assert resolve_similarity_threshold(None) == DEFAULT_SIMILARITY_THRESHOLD
+
+    def test_threshold_override(self) -> None:
+        cfg = {"contradiction": {"similarity_threshold": 0.9}}
+        assert resolve_similarity_threshold(cfg) == 0.9
+
+
+# ---------------------------------------------------------------------------
+# Ancestor pooling + chunking
+# ---------------------------------------------------------------------------
+
+
+class TestAncestorPooling:
+    def test_pools_ancestor_scope_member(self, tmp_path: Path) -> None:
+        a = _write_am(
+            tmp_path / "child",
+            "feedback_a.md",
+            "A body",
+            origin_scope="-Users-tristankromer-Code-foo",
+        )
+        b = _write_am(
+            tmp_path / "parent",
+            "feedback_b.md",
+            "B body",
+            origin_scope="-Users-tristankromer-Code",
+        )
+        unrelated = _write_am(
+            tmp_path / "other",
+            "feedback_c.md",
+            "C body",
+            origin_scope="-Users-tristankromer-Code-bar",
+        )
+        pooled = pool_cluster_with_ancestors([a], [a, b, unrelated])
+        pooled_paths = {str(am.path) for am in pooled}
+        assert str(a.path) in pooled_paths
+        assert str(b.path) in pooled_paths
+        # Sibling scope is NOT an ancestor.
+        assert str(unrelated.path) not in pooled_paths
+
+    def test_dedupes_by_path(self, tmp_path: Path) -> None:
+        a = _write_am(
+            tmp_path / "child",
+            "a.md",
+            "A",
+            origin_scope="-Users-tristankromer-Code-foo",
+        )
+        # Same file appears in both lists; should appear once.
+        pooled = pool_cluster_with_ancestors([a], [a])
+        assert len(pooled) == 1
+
+    def test_no_ancestors_returns_originals(self, tmp_path: Path) -> None:
+        a = _write_am(
+            tmp_path / "u",
+            "a.md",
+            "A",
+            origin_scope="_unscoped",
+        )
+        pooled = pool_cluster_with_ancestors([a], [a])
+        assert pooled == [a]
+
+
+class TestChunkByCap:
+    def test_under_cap_no_split(self, tmp_path: Path) -> None:
+        members = [
+            _write_am(
+                tmp_path / "s",
+                f"a{i}.md",
+                f"body {i}",
+                origin_scope="-Users-tristankromer-Code-foo",
+            )
+            for i in range(3)
+        ]
+        chunks = chunk_by_cap(members, cap=5)
+        assert len(chunks) == 1
+        assert len(chunks[0]) == 3
+
+    def test_over_cap_splits_two_chunks(self, tmp_path: Path) -> None:
+        members = [
+            _write_am(
+                tmp_path / "s",
+                f"a{i}.md",
+                f"body {i}",
+                origin_scope="-Users-tristankromer-Code-foo",
+                created=f"2026-01-{i + 1:02d}",
+            )
+            for i in range(6)
+        ]
+        chunks = chunk_by_cap(members, cap=5)
+        assert len(chunks) == 2
+        assert len(chunks[0]) == 5
+        assert len(chunks[1]) == 1
+
+    def test_newest_first_in_chunks(self, tmp_path: Path) -> None:
+        members = [
+            _write_am(
+                tmp_path / "s",
+                f"a{i}.md",
+                f"body {i}",
+                origin_scope="-Users-tristankromer-Code-foo",
+                created=f"2026-01-{i + 1:02d}",
+            )
+            for i in range(4)
+        ]
+        ordered = sort_newest_first(members)
+        # Newest is the one with created '2026-01-04' (last index).
+        assert ordered[0].path.name == "a3.md"
+
+
+# ---------------------------------------------------------------------------
+# Similarity sweep (stubbed embedding provider)
+# ---------------------------------------------------------------------------
+
+
+class _StubEmbedder:
+    """Deterministic embedding provider for tests.
+
+    Constructor takes ``{recall_index_id: vector}``. ``fetch_embeddings``
+    returns the intersection of requested ids and the stored map.
+    """
+
+    def __init__(self, embeddings: dict[str, list[float]]) -> None:
+        self._embeddings = embeddings
+
+    def fetch_embeddings(
+        self,
+        ids: Any,
+        cache_dir: Path,
+    ) -> dict[str, list[float]]:
+        del cache_dir
+        return {i: self._embeddings[i] for i in ids if i in self._embeddings}
+
+
+class TestSimilaritySweep:
+    def test_finds_pair_above_threshold(self, tmp_path: Path) -> None:
+        # Two raw entries in DIFFERENT scope branches (no ancestor link).
+        root = tmp_path / "raw" / "auto-memory"
+        a = _write_am(
+            root / "-Users-trk-Code-foo",
+            "feedback_a.md",
+            "A body",
+            origin_scope="-Users-trk-Code-foo",
+        )
+        b = _write_am(
+            root / "-Users-trk-Code-bar",
+            "feedback_b.md",
+            "B body",
+            origin_scope="-Users-trk-Code-bar",
+        )
+        a_id = f"auto-memory/-Users-trk-Code-foo/feedback_a.md"
+        b_id = f"auto-memory/-Users-trk-Code-bar/feedback_b.md"
+        embedder = _StubEmbedder(
+            {
+                a_id: [1.0, 0.0],
+                b_id: [0.99, 0.05],  # ~0.998 cosine
+            }
+        )
+        candidates = cross_scope_similarity_pairs(
+            [a, b],
+            extra_roots=[root],
+            cache_dir=tmp_path / "cache",
+            threshold=0.85,
+            embedding_provider=embedder,
+        )
+        assert len(candidates) == 1
+        assert candidates[0].similarity > 0.85
+
+    def test_below_threshold_not_returned(self, tmp_path: Path) -> None:
+        root = tmp_path / "raw" / "auto-memory"
+        a = _write_am(
+            root / "-Users-trk-Code-foo",
+            "a.md",
+            "A",
+            origin_scope="-Users-trk-Code-foo",
+        )
+        b = _write_am(
+            root / "-Users-trk-Code-bar",
+            "b.md",
+            "B",
+            origin_scope="-Users-trk-Code-bar",
+        )
+        a_id = "auto-memory/-Users-trk-Code-foo/a.md"
+        b_id = "auto-memory/-Users-trk-Code-bar/b.md"
+        embedder = _StubEmbedder(
+            {
+                a_id: [1.0, 0.0],
+                b_id: [0.0, 1.0],  # cosine 0
+            }
+        )
+        candidates = cross_scope_similarity_pairs(
+            [a, b],
+            extra_roots=[root],
+            cache_dir=tmp_path / "cache",
+            threshold=0.85,
+            embedding_provider=embedder,
+        )
+        assert candidates == []
+
+    def test_excluded_pairs_filtered(self, tmp_path: Path) -> None:
+        root = tmp_path / "raw" / "auto-memory"
+        a = _write_am(
+            root / "-Users-trk-Code-foo",
+            "a.md",
+            "A",
+            origin_scope="-Users-trk-Code-foo",
+        )
+        b = _write_am(
+            root / "-Users-trk-Code-bar",
+            "b.md",
+            "B",
+            origin_scope="-Users-trk-Code-bar",
+        )
+        a_id = "auto-memory/-Users-trk-Code-foo/a.md"
+        b_id = "auto-memory/-Users-trk-Code-bar/b.md"
+        embedder = _StubEmbedder({a_id: [1.0, 0.0], b_id: [0.99, 0.05]})
+        excluded = {tuple(sorted((str(a.path), str(b.path))))}
+        candidates = cross_scope_similarity_pairs(
+            [a, b],
+            extra_roots=[root],
+            cache_dir=tmp_path / "cache",
+            threshold=0.85,
+            excluded_pair_keys=excluded,
+            embedding_provider=embedder,
+        )
+        assert candidates == []
+
+    def test_includes_wiki_files(self, tmp_path: Path) -> None:
+        raw_root = tmp_path / "raw" / "auto-memory"
+        wiki_root = tmp_path / "wiki"
+        wiki_root.mkdir(parents=True)
+        wiki_path = wiki_root / "auto-foo.md"
+        wiki_path.write_text(
+            "---\nname: foo\ntype: auto-memory\n---\nWiki body\n",
+            encoding="utf-8",
+        )
+        a = _write_am(
+            raw_root / "-Users-trk-Code-foo",
+            "a.md",
+            "A",
+            origin_scope="-Users-trk-Code-foo",
+        )
+        a_id = "auto-memory/-Users-trk-Code-foo/a.md"
+        wiki_id = "auto-foo.md"
+        embedder = _StubEmbedder(
+            {
+                a_id: [1.0, 0.0],
+                wiki_id: [0.99, 0.05],
+            }
+        )
+        candidates = cross_scope_similarity_pairs(
+            [a],
+            wiki_files=[wiki_path],
+            wiki_root=wiki_root,
+            extra_roots=[raw_root],
+            cache_dir=tmp_path / "cache",
+            threshold=0.85,
+            embedding_provider=embedder,
+        )
+        assert len(candidates) == 1
+        paths = {candidates[0].a_path, candidates[0].b_path}
+        assert wiki_path in paths
+
+
+# ---------------------------------------------------------------------------
+# End-to-end mode wiring through merge_clusters_to_wiki
+# ---------------------------------------------------------------------------
+
+
+def _build_knowledge_root(
+    tmp_path: Path,
+    *,
+    members: list[tuple[str, str, str]],
+    cluster_groups: list[list[int]] | None = None,
+) -> Path:
+    """Stand up a minimal knowledge-root with raw + cluster JSONL.
+
+    members: list of (scope, filename, body).
+    cluster_groups: list of index-lists. If None, each member is a singleton.
+    Returns the knowledge_root path.
+    """
+    root = tmp_path / "knowledge"
+    raw = root / "raw" / "auto-memory"
+    written: list[Path] = []
+    for scope, filename, body in members:
+        scope_dir = raw / scope
+        scope_dir.mkdir(parents=True, exist_ok=True)
+        path = scope_dir / filename
+        path.write_text(
+            "---\nname: probe\ntype: feedback\n---\n" + body + "\n",
+            encoding="utf-8",
+        )
+        written.append(path)
+
+    if cluster_groups is None:
+        cluster_groups = [[i] for i in range(len(members))]
+
+    rows: list[dict[str, Any]] = []
+    for seq, group in enumerate(cluster_groups):
+        member_paths = [f"{members[i][0]}/{members[i][1]}" for i in group]
+        first_scope = members[group[0]][0].lstrip("-_") or "unscoped"
+        rows.append(
+            {
+                "cluster_id": f"{first_scope}-{seq:04d}",
+                "member_paths": member_paths,
+                "centroid_score": 1.0,
+                "rationale": "test",
+            }
+        )
+    cluster_path = root / "raw" / "_librarian-clusters.jsonl"
+    cluster_path.parent.mkdir(parents=True, exist_ok=True)
+    cluster_path.write_text(
+        "\n".join(json.dumps(r, sort_keys=True) for r in rows) + "\n",
+        encoding="utf-8",
+    )
+    # Minimal config, points extra_intake_roots to raw/auto-memory.
+    (root / "athenaeum.yaml").write_text(
+        "recall:\n  extra_intake_roots:\n    - raw/auto-memory\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+class TestModeWiring:
+    def test_mode_off_per_cluster_only(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("ATHENAEUM_CROSS_SCOPE_MODE", "off")
+        root = _build_knowledge_root(
+            tmp_path,
+            members=[
+                ("-Users-trk-Code-foo", "feedback_a.md", "A"),
+                ("-Users-trk-Code", "feedback_b.md", "B"),
+            ],
+        )
+        client = _fake_client(_no_conflict_payload())
+        entries = merge_clusters_to_wiki(root, client=client, dry_run=True)
+        # Two singleton clusters; each is size 1 so detector short-circuits;
+        # no pooling because mode=off.
+        assert len(entries) == 2
+        # No detector calls because both clusters were singletons.
+        assert client.messages.create.call_count == 0
+
+    def test_mode_ancestor_pools_across_scopes(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """AC#4 reproducer: two raw entries in ancestor-related scopes pool
+        into one detector call."""
+        monkeypatch.setenv("ATHENAEUM_CROSS_SCOPE_MODE", "ancestor")
+        root = _build_knowledge_root(
+            tmp_path,
+            members=[
+                ("-Users-trk-Code-foo", "feedback_a.md", "Always commit directly."),
+                (
+                    "-Users-trk-Code",
+                    "feedback_b.md",
+                    "Never commit directly; park on WIP.",
+                ),
+            ],
+        )
+        # Cluster row 0 holds only `a`; b lives under an ancestor scope.
+        # Mode=ancestor pools b into the cluster, so the detector sees 2.
+        m1_ref = "-Users-trk-Code-foo/feedback_a.md"
+        m2_ref = "-Users-trk-Code/feedback_b.md"
+        client = _fake_client(_detected_payload(m1_ref, m2_ref))
+        entries = merge_clusters_to_wiki(root, client=client, dry_run=True)
+        # First entry's pooled cluster catches the contradiction.
+        flagged = [e for e in entries if e.contradictions_detected]
+        assert len(flagged) >= 1
+        assert client.messages.create.call_count >= 1
+
+    def test_mode_similarity_picks_up_cross_branch_pair(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cross-tree-branch pair (no ancestor link) is caught via similarity."""
+        monkeypatch.setenv("ATHENAEUM_CROSS_SCOPE_MODE", "similarity")
+        root = _build_knowledge_root(
+            tmp_path,
+            members=[
+                ("-Users-trk-Code-foo", "feedback_a.md", "Always X."),
+                ("-Users-trk-Code-bar", "feedback_b.md", "Never X."),
+            ],
+        )
+        # Patch the VectorBackend used inside merge.py's similarity sweep.
+        from athenaeum import cross_scope as cs
+
+        a_id = "auto-memory/-Users-trk-Code-foo/feedback_a.md"
+        b_id = "auto-memory/-Users-trk-Code-bar/feedback_b.md"
+        embedder = _StubEmbedder(
+            {
+                a_id: [1.0, 0.0],
+                b_id: [0.99, 0.05],
+            }
+        )
+        original_pairs = cs.cross_scope_similarity_pairs
+
+        def patched_pairs(*args: Any, **kwargs: Any):
+            kwargs["embedding_provider"] = embedder
+            return original_pairs(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "athenaeum.merge.cross_scope_similarity_pairs",
+            patched_pairs,
+        )
+
+        m1_ref = "-Users-trk-Code-foo/feedback_a.md"
+        m2_ref = "-Users-trk-Code-bar/feedback_b.md"
+        client = _fake_client(_detected_payload(m1_ref, m2_ref))
+        merge_clusters_to_wiki(root, client=client, dry_run=True)
+        # Detector should be called at least once for the similarity pair
+        # (singleton clusters skip per-cluster calls).
+        assert client.messages.create.call_count >= 1
+
+    def test_mode_similarity_covers_wiki_entry(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Wiki-vs-raw pair (raw original gone for wiki) flagged via similarity."""
+        monkeypatch.setenv("ATHENAEUM_CROSS_SCOPE_MODE", "similarity")
+        root = _build_knowledge_root(
+            tmp_path,
+            members=[
+                ("-Users-trk-Code-foo", "feedback_a.md", "Raw body"),
+            ],
+        )
+        # Pre-write a wiki/auto-bar.md (simulates a previous merge).
+        wiki = root / "wiki"
+        wiki.mkdir(parents=True, exist_ok=True)
+        (wiki / "auto-bar.md").write_text(
+            "---\nname: bar\ntype: auto-memory\n---\nWiki body\n",
+            encoding="utf-8",
+        )
+
+        a_id = "auto-memory/-Users-trk-Code-foo/feedback_a.md"
+        wiki_id = "auto-bar.md"
+        embedder = _StubEmbedder(
+            {
+                a_id: [1.0, 0.0],
+                wiki_id: [0.99, 0.05],
+            }
+        )
+        from athenaeum import cross_scope as cs
+
+        original_pairs = cs.cross_scope_similarity_pairs
+
+        def patched_pairs(*args: Any, **kwargs: Any):
+            kwargs["embedding_provider"] = embedder
+            return original_pairs(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "athenaeum.merge.cross_scope_similarity_pairs",
+            patched_pairs,
+        )
+
+        client = _fake_client(_detected_payload("a", "auto-bar"))
+        merge_clusters_to_wiki(root, client=client, dry_run=True)
+        # Similarity sweep should fire at least once on the raw+wiki pair.
+        assert client.messages.create.call_count >= 1
+
+    def test_mode_both_ancestor_and_similarity(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mode=both: ancestor catches case A, similarity catches case B."""
+        monkeypatch.setenv("ATHENAEUM_CROSS_SCOPE_MODE", "both")
+        root = _build_knowledge_root(
+            tmp_path,
+            members=[
+                ("-Users-trk-Code-foo", "feedback_a.md", "Always X."),
+                ("-Users-trk-Code", "feedback_b.md", "Never X."),
+                ("-Users-trk-Code-bar", "feedback_c.md", "Always Y."),
+                ("-Users-trk-Code-baz", "feedback_d.md", "Never Y."),
+            ],
+        )
+        a_id = "auto-memory/-Users-trk-Code-foo/feedback_a.md"
+        b_id = "auto-memory/-Users-trk-Code/feedback_b.md"
+        c_id = "auto-memory/-Users-trk-Code-bar/feedback_c.md"
+        d_id = "auto-memory/-Users-trk-Code-baz/feedback_d.md"
+        # a/b will be pooled by ancestor; c/d only via similarity.
+        embedder = _StubEmbedder(
+            {
+                a_id: [1.0, 0.0],
+                b_id: [0.0, 1.0],  # different vectors: NOT a similarity pair
+                c_id: [0.5, 0.5],
+                d_id: [0.51, 0.49],  # near-duplicate: similarity pair
+            }
+        )
+        from athenaeum import cross_scope as cs
+
+        original_pairs = cs.cross_scope_similarity_pairs
+
+        def patched_pairs(*args: Any, **kwargs: Any):
+            kwargs["embedding_provider"] = embedder
+            return original_pairs(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "athenaeum.merge.cross_scope_similarity_pairs",
+            patched_pairs,
+        )
+
+        client = _fake_client(_no_conflict_payload())
+        merge_clusters_to_wiki(root, client=client, dry_run=True)
+        # ancestor pools a+b → 1 call; similarity sweep for c+d → 1 call.
+        # Plus detection on each non-singleton-after-pooling cluster.
+        # Minimum guarantee: at least 2 calls (ancestor pool + similarity).
+        assert client.messages.create.call_count >= 2
+
+    def test_cluster_size_cap_splits_into_chunks(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """N+1 pooled members with cap=N → 2 detector calls."""
+        monkeypatch.setenv("ATHENAEUM_CROSS_SCOPE_MODE", "ancestor")
+        # Make 4 children + 2 ancestors, pool size = 6, cap=3 → 2 chunks.
+        members = [
+            ("-Users-trk-Code-foo", f"feedback_a{i}.md", f"body {i}") for i in range(4)
+        ] + [
+            ("-Users-trk-Code", "feedback_p1.md", "parent 1"),
+            ("-Users-trk-Code", "feedback_p2.md", "parent 2"),
+        ]
+        # Single cluster of just the foo children (indices 0..3); ancestors
+        # get pooled in by the runtime.
+        root = _build_knowledge_root(
+            tmp_path,
+            members=members,
+            cluster_groups=[[0, 1, 2, 3]],
+        )
+        # Override config to cap at 3.
+        (root / "athenaeum.yaml").write_text(
+            "recall:\n  extra_intake_roots:\n    - raw/auto-memory\n"
+            "contradiction:\n  cluster_size_cap: 3\n",
+            encoding="utf-8",
+        )
+        client = _fake_client(_no_conflict_payload())
+        merge_clusters_to_wiki(root, client=client, dry_run=True)
+        # Pool size 6, cap 3 → 2 chunks → 2 detector calls.
+        assert client.messages.create.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# candidate_to_auto_memory_files smoke
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateUnwrap:
+    def test_returns_two_records(self, tmp_path: Path) -> None:
+        from athenaeum.cross_scope import SimilarityCandidate
+
+        a = tmp_path / "a.md"
+        b = tmp_path / "b.md"
+        a.write_text(
+            "---\nname: a\ntype: feedback\n---\nA body\n",
+            encoding="utf-8",
+        )
+        b.write_text(
+            "---\nname: b\ntype: feedback\n---\nB body\n",
+            encoding="utf-8",
+        )
+        cand = SimilarityCandidate(
+            a_path=a,
+            b_path=b,
+            similarity=0.9,
+            a_scope="-X",
+            b_scope="-Y",
+        )
+        ams = candidate_to_auto_memory_files(cand)
+        assert len(ams) == 2
+        assert ams[0].name == "a"
+        assert ams[1].origin_scope == "-Y"

--- a/tests/test_cross_scope.py
+++ b/tests/test_cross_scope.py
@@ -34,7 +34,6 @@ from athenaeum.cross_scope import (
 from athenaeum.merge import merge_clusters_to_wiki
 from athenaeum.models import AutoMemoryFile
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -300,8 +299,8 @@ class TestSimilaritySweep:
             "B body",
             origin_scope="-Users-trk-Code-bar",
         )
-        a_id = f"auto-memory/-Users-trk-Code-foo/feedback_a.md"
-        b_id = f"auto-memory/-Users-trk-Code-bar/feedback_b.md"
+        a_id = "auto-memory/-Users-trk-Code-foo/feedback_a.md"
+        b_id = "auto-memory/-Users-trk-Code-bar/feedback_b.md"
         embedder = _StubEmbedder(
             {
                 a_id: [1.0, 0.0],


### PR DESCRIPTION
## Summary

Adds a cross-scope contradiction detection mode toggle (`ATHENAEUM_CROSS_SCOPE_MODE`) so the C4 detector can compare entries that previously lived in separate per-scope clusters. Default behavior shifts to `ancestor` pooling — strictly additive, no extra LLM calls beyond what pooled clusters cost.

## The four modes

| Mode | Per-scope | Ancestor pool | Similarity sweep | Notes |
|------|:---------:|:-------------:|:----------------:|-------|
| `off` | yes | no | no | Pre-#125 behavior. |
| `ancestor` (default) | yes | yes | no | Cheap; ancestor walk only. |
| `similarity` | yes | no | yes | Cross-product over recall index. |
| `both` | yes | yes | yes | Ancestor first, similarity over remainder. |

### Ancestor pooling
A scope `-Users-tristankromer-Code-foo` pulls members from `-Users-tristankromer-Code`, `-Users-tristankromer`, and `-Users` into its cluster. Dedupe by absolute path. If pooled size exceeds `contradiction.cluster_size_cap` (default 25), members are sorted newest-first by `created` frontmatter (mtime fallback) and split into chunks; the detector runs once per chunk.

### Similarity sweep
Pulls embeddings from the shared `wiki-vectors` chromadb collection (no new collection or client) covering BOTH `raw/auto-memory/**` AND `wiki/auto-*.md`. Pairs whose cosine similarity exceeds `contradiction.similarity_threshold` (default 0.85) and that are NOT already covered by a per-cluster detector call are sent through `detect_contradictions` as 2-member pseudo-clusters. Catches:
- Cross-tree-branch raw-vs-raw contradictions (no ancestor link).
- Wiki-vs-wiki contradictions where the raw originals were deleted post-merge.

## Config example

```yaml
# athenaeum.yaml
contradiction:
  cross_scope_mode: ancestor   # off | ancestor | similarity | both
  cluster_size_cap: 25
  similarity_threshold: 0.85
```

Env override (wins over YAML): `export ATHENAEUM_CROSS_SCOPE_MODE=both`

## Telemetry

Each `merge_clusters_to_wiki` run now logs:

```
contradictions: mode=ancestor; haiku_calls=12; chunks_run=12; pairs_added_via_similarity=0
```

`haiku_calls` is the number of detector invocations attributable to the run; `pairs_added_via_similarity` is the count of similarity-sweep pairs that escalated.

## Constraints honored

- Built-in tools only.
- No new chromadb collection — reuses `search.VectorBackend.fetch_embeddings`.
- `similarity` and `both` are NOT defaulted; only `ancestor` flips on.
- Tier 3 / repair / dedupe modules untouched.

## Test plan

- [x] `tests/test_cross_scope.py` — 29 new tests covering:
  - Mode resolution (env var, YAML, default fallback, invalid values).
  - `scope_ancestors()` walk for path-hash scopes including `_unscoped`.
  - Ancestor pooling, path-dedupe, no-ancestor passthrough.
  - `chunk_by_cap` newest-first ordering and split boundaries.
  - Similarity sweep: above-threshold pair, below-threshold filtered, excluded-pair filtering, wiki entry inclusion.
  - End-to-end mode wiring through `merge_clusters_to_wiki` for all four modes.
  - Cluster-size cap: pool of 6 with cap 3 → 2 detector calls.
- [x] Full suite: `pytest tests/ -q` — 626 passed, 1 skipped (was 597).

Closes #125

Built with [WOZCODE](https://wozcode.com)
