### PR TITLE
feat(sidecar): pending-questions surfacing in installable hook kit (#128)

### DIFF
--- a/.claude/skills/resolve-questions/SKILL.md
+++ b/.claude/skills/resolve-questions/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: resolve-questions
+description: Walk the user through unresolved entries in `_pending_questions.md` one at a time. Use when the SessionStart hook surfaces pending memory questions, when the user says "resolve pending questions" / "go through my questions" / "what questions do I have", or when the user wants to clear the contradiction queue.
+---
+
+# resolve-questions
+
+Interactive walk-through for `~/knowledge/wiki/_pending_questions.md`. Each
+entry is a contradiction or ambiguity the librarian flagged for human review.
+Some entries carry an Opus-backed proposed resolution (issue #126); some
+don't. The user is the final authority — never resolve without confirmation.
+
+## Surface
+
+- CLI: `athenaeum questions count|next|list [--with-proposal] [--json]`
+- MCP tools: `list_pending_questions`, `resolve_question(id, answer)`
+- Snooze file: `~/.cache/athenaeum/pending-questions-snoozed-until` (ISO-8601 UTC)
+
+## Flow (six steps)
+
+1. Run `athenaeum questions count --json`. If `count` is 0, tell the user
+   "no pending questions" and stop.
+
+2. Loop. On each iteration call
+   `athenaeum questions next --with-proposal --json`. The result has the
+   shape `{id, entity, source, question, conflict_type, description,
+   created_at, proposal}`. Render it to the user as a short block:
+
+   - entity, question, conflict_type
+   - description (verbatim)
+   - the proposal block when non-empty
+
+3. Ask the user one of four choices:
+
+   - **accept** the proposed resolution
+   - **override** with a different answer
+   - **defer** (snooze) — stop now, surface again tomorrow
+   - **stop** — stop now without snoozing
+
+4. **accept**: call the `resolve_question` MCP tool with `id` and the
+   proposed action (extract the action from the `**Proposed resolution**:`
+   line in the proposal block, e.g. `keep_a`, `merge`,
+   `retain_both_with_context`). Then loop back to step 2.
+
+5. **override**: ask the user for the answer text they want recorded. Call
+   `resolve_question` with `id=<id>, answer=<their text>`. Then loop back
+   to step 2.
+
+6. **defer**: write `~/.cache/athenaeum/pending-questions-snoozed-until`
+   containing an ISO-8601 UTC timestamp `ATHENAEUM_PQ_SNOOZE_HOURS` (default
+   24) hours from now. The SessionStart hook reads this and stays silent
+   until then. Stop. (**stop** is the same minus the snooze write.)
+
+## Snooze write — exact format
+
+The hook reads the file with a lexicographic compare against
+`date -u +%FT%TZ`. Match that format exactly:
+
+```bash
+mkdir -p ~/.cache/athenaeum
+date -u -v+24H +%FT%TZ > ~/.cache/athenaeum/pending-questions-snoozed-until
+```
+
+(GNU date uses `-d '+24 hours'` instead of `-v+24H`.)
+
+## Constraints
+
+- Never call `resolve_question` without explicit user confirmation of the
+  exact action.
+- If `athenaeum` CLI isn't installed, fall back to `list_pending_questions`
+  MCP tool and walk the list directly.
+- If the user says "skip this one and show the next", advance the cursor
+  by calling `list_pending_questions` and showing index 1 instead of 0 —
+  do NOT resolve the current one.
+- Resolved entries (`[x]`) are archived by `athenaeum ingest-answers` on
+  the next librarian run — you don't need to handle archival yourself.

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -10,6 +10,7 @@ agent runtime.
 | `session-start-recall.sh`| Start of each session| Builds the FTS5 (and optional vector) index, caches config       |
 | `user-prompt-recall.sh`  | Each user turn       | Hybrid FTS5+vector search, injects top-3 wiki page names         |
 | `pre-compact-save.sh`    | Before compaction    | Reminds the model to call `remember` on anything load-bearing    |
+| `pending-questions-surface.sh` | Start of each session | Surfaces unresolved `_pending_questions.md` entries with a snooze cache |
 
 ## How the sidecar works (read this first)
 
@@ -116,6 +117,8 @@ pages or the index hasn't been built — check `~/.cache/athenaeum/`.
 | `ATHENAEUM_SRC`          | —                                 | Source checkout path (skips `pip install`, runs from source)   |
 | `ATHENAEUM_OP_KEY_PATH`  | `op://Agent Tools/Anthropic API Key/credential` | 1Password secret reference for `ANTHROPIC_API_KEY` |
 | `ATHENAEUM_HOOK_DEBUG`   | `0`                               | Set to `1` to log vector-backend errors to stderr              |
+| `ATHENAEUM_PQ_SNOOZE_HOURS` | `24`                          | Snooze TTL for `pending-questions-surface.sh` (consumed by the `resolve-questions` skill when writing the snooze file) |
+| `ATHENAEUM_PQ_HOOK_DEBUG` | `0`                              | Set to `1` to log `pending-questions-surface.sh` diagnostics to stderr |
 | `SEARCH_BACKEND`         | from `athenaeum.yaml` (`fts5`)    | `fts5` (default) or `vector`                                   |
 | `AUTO_RECALL`            | from `athenaeum.yaml` (`true`)    | Set to `false` to disable per-turn recall                      |
 
@@ -164,6 +167,33 @@ Files in this directory supporting that integration:
 Full walkthrough — directory layout, citation policy, how the librarian
 ingests and consolidates, and an end-to-end quick start — lives in
 [`docs/integrations/claude-code.md`](../../docs/integrations/claude-code.md).
+
+## Pending-questions surface
+
+When the librarian flags a contradiction or ambiguity, it lands in
+`~/knowledge/wiki/_pending_questions.md` as a `- [ ]` checkbox block.
+The `pending-questions-surface.sh` SessionStart hook calls
+`athenaeum questions count --json` and prints a one-block prompt like:
+
+```
+[Pending memory questions] 3 unresolved (oldest: 2026-04-20).
+Resolve interactively now, defer to tomorrow, or skip?
+Available via: `athenaeum questions next --with-proposal` or the resolve-questions skill.
+```
+
+To resolve interactively, invoke the `resolve-questions` skill (shipped in
+the athenaeum repo at `.claude/skills/resolve-questions/SKILL.md`). It walks
+each entry and calls the `resolve_question` MCP tool with your decision.
+"Defer" writes `~/.cache/athenaeum/pending-questions-snoozed-until`; the
+hook stays silent until that ISO-8601 timestamp passes.
+
+CLI reference:
+
+```bash
+athenaeum questions count --json                    # {"count": N, "oldest": "..."}
+athenaeum questions next --with-proposal            # show oldest entry + proposal
+athenaeum questions list --with-proposal --limit 5  # all unresolved (capped)
+```
 
 ## Troubleshooting
 

--- a/examples/claude-code/pending-questions-surface.sh
+++ b/examples/claude-code/pending-questions-surface.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SessionStart hook: surface unresolved pending memory questions.
+#
+# When the librarian flags a contradiction or ambiguity, it lands in
+# `~/knowledge/wiki/_pending_questions.md` as a checkbox block. Until the
+# user resolves it (in the file, via the MCP `resolve_question` tool, or
+# the `resolve-questions` skill), it just sits there and the user forgets
+# it exists. This hook:
+#
+#   1. Resolves the athenaeum CLI binary (env: ATHENAEUM_CLI / ATHENAEUM_PYTHON
+#      + ATHENAEUM_SRC; falls back to `athenaeum` on PATH).
+#   2. Honors a snooze cache at `~/.cache/athenaeum/pending-questions-snoozed-until`.
+#      If the file exists with an ISO-8601 datetime in the future, the hook
+#      exits 0 silently. The skill (or the user) writes that file when they
+#      defer; this hook only reads it.
+#   3. Calls `athenaeum questions count --json` to get count + oldest date.
+#   4. If count > 0, prints a one-block prompt to stdout (Claude Code
+#      injects stdout as additional system context).
+#
+# Fail-silent guarantee: every external call has `|| true`. A malformed
+# pending-questions file or a missing CLI must NEVER block session startup.
+#
+# Configure in ~/.claude/settings.json:
+#   "hooks": {
+#     "SessionStart": [{
+#       "hooks": [{
+#         "type": "command",
+#         "command": "/path/to/pending-questions-surface.sh 2>/dev/null || true",
+#         "timeout": 5
+#       }]
+#     }]
+#   }
+#
+# Environment variables:
+#   KNOWLEDGE_ROOT             Default: ~/knowledge
+#   ATHENAEUM_CLI              Default: athenaeum (override for editable installs)
+#   ATHENAEUM_PYTHON           Default: python3
+#   ATHENAEUM_SRC              Optional source checkout — if set, runs
+#                              `python3 -m athenaeum.cli` from there.
+#   ATHENAEUM_PQ_SNOOZE_HOURS  Documented for the skill: 24 (default). The
+#                              hook itself only reads the snooze file; it
+#                              doesn't consult the env var.
+#   ATHENAEUM_PQ_HOOK_DEBUG    Set to 1 to surface CLI errors on stderr.
+
+set -euo pipefail
+
+KNOWLEDGE_ROOT="${KNOWLEDGE_ROOT:-$HOME/knowledge}"
+CACHE_DIR="${HOME}/.cache/athenaeum"
+SNOOZE_FILE="${CACHE_DIR}/pending-questions-snoozed-until"
+
+# Wiki must exist; otherwise nothing to do.
+[ -d "${KNOWLEDGE_ROOT}/wiki" ] || exit 0
+
+_debug() {
+  if [ "${ATHENAEUM_PQ_HOOK_DEBUG:-0}" = "1" ]; then
+    printf '[pending-questions] %s\n' "$*" >&2
+  fi
+}
+
+# ── Snooze check ──────────────────────────────────────────────────────────
+# The snooze file holds an ISO-8601 instant (`date -u +%FT%TZ`). If the
+# stored value is in the future, exit silently. Anything malformed is
+# ignored — fail-open is correct here so a corrupt cache doesn't lock
+# the user out of their pending-question stream forever.
+if [ -f "${SNOOZE_FILE}" ]; then
+  _snoozed_until="$(cat "${SNOOZE_FILE}" 2>/dev/null || true)"
+  _now="$(date -u +%FT%TZ 2>/dev/null || true)"
+  if [ -n "${_snoozed_until}" ] && [ -n "${_now}" ]; then
+    # Lexicographic compare works on `YYYY-MM-DDTHH:MM:SSZ` (UTC fixed zone).
+    if [ "${_now}" \< "${_snoozed_until}" ]; then
+      _debug "snoozed until ${_snoozed_until}"
+      exit 0
+    fi
+  fi
+fi
+
+# ── Resolve CLI invocation ────────────────────────────────────────────────
+_cli_argv=()
+
+if [ -n "${ATHENAEUM_SRC:-}" ] && [ -d "${ATHENAEUM_SRC}/src/athenaeum" ]; then
+  _python="${ATHENAEUM_PYTHON:-python3}"
+  _cli_argv=(
+    "${_python}"
+    "-c"
+    "import sys; sys.path.insert(0, '${ATHENAEUM_SRC}/src'); from athenaeum.cli import main; sys.exit(main(sys.argv[1:]))"
+  )
+elif [ -n "${ATHENAEUM_CLI:-}" ] && command -v "${ATHENAEUM_CLI}" >/dev/null 2>&1; then
+  _cli_argv=("${ATHENAEUM_CLI}")
+elif command -v athenaeum >/dev/null 2>&1; then
+  _cli_argv=(athenaeum)
+else
+  _debug "no athenaeum CLI on PATH; exiting silent"
+  exit 0
+fi
+
+# ── Query pending count ───────────────────────────────────────────────────
+_json="$(
+  "${_cli_argv[@]}" questions count --path "${KNOWLEDGE_ROOT}" --json 2>/dev/null \
+    || true
+)"
+
+if [ -z "${_json}" ]; then
+  _debug "questions count returned empty"
+  exit 0
+fi
+
+# Parse {"count": N, "oldest": "..."} without depending on jq. Pure-bash
+# extraction that fails open: any parse miss → exit 0 silently.
+_count="$(printf '%s' "${_json}" | sed -n 's/.*"count"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n1)"
+_oldest="$(printf '%s' "${_json}" | sed -n 's/.*"oldest"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+
+if [ -z "${_count}" ] || [ "${_count}" = "0" ]; then
+  _debug "count=${_count:-empty}; nothing to surface"
+  exit 0
+fi
+
+# ── Surface to Claude ─────────────────────────────────────────────────────
+# Plain text on stdout — Claude Code injects this as additional system
+# context for SessionStart hooks. Keep concise; the user reads it once.
+{
+  echo "[Pending memory questions] ${_count} unresolved (oldest: ${_oldest:-unknown})."
+  echo "Resolve interactively now, defer to tomorrow, or skip?"
+  echo "Available via: \`athenaeum questions next --with-proposal\` or the resolve-questions skill."
+} || true
+
+exit 0

--- a/examples/claude-code/settings-snippet.json
+++ b/examples/claude-code/settings-snippet.json
@@ -10,6 +10,11 @@
             "command": "/path/to/session-start-recall.sh 2>/dev/null || true",
             "timeout": 15,
             "statusMessage": "Building knowledge index..."
+          },
+          {
+            "type": "command",
+            "command": "/path/to/pending-questions-surface.sh 2>/dev/null || true",
+            "timeout": 5
           }
         ]
       }

--- a/src/athenaeum/_cmd_questions.py
+++ b/src/athenaeum/_cmd_questions.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``athenaeum questions {list,next,count}`` — surface unresolved pending questions.
+
+Reads ``~/knowledge/wiki/_pending_questions.md`` via the existing
+:mod:`athenaeum.answers` parser. Outputs are deterministic and JSON-friendly
+so the example SessionStart hook (``pending-questions-surface.sh``) and the
+shipped ``resolve-questions`` skill can rely on stable shapes.
+
+Three modes:
+
+- ``list``     all unresolved questions (optionally ``--with-proposal``,
+                 ``--limit``, ``--json``)
+- ``next``     the OLDEST unresolved question (one block)
+- ``count``    ``N unresolved (oldest: <iso-date>)`` summary
+
+The proposal block (``**Proposed resolution**`` etc., shipped in #126) is
+extracted from the raw block tail when present. Entries without a proposal
+remain valid and just emit an empty ``proposal`` field in JSON output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from athenaeum.answers import PendingQuestion, parse_pending_questions
+
+# Keys the resolver appends to a block tail (locked by issue #126 and the
+# resolutions.py module docstring). Order matters for re-extraction.
+_PROPOSAL_KEYS = (
+    "**Proposed resolution**:",
+    "**Confidence**:",
+    "**Rationale**:",
+    "**Source precedence**:",
+)
+
+
+def _extract_proposal_block(raw_block: str) -> str:
+    """Pull the trailing 4-key proposal block out of ``raw_block``.
+
+    Returns the verbatim proposal text (joined with ``\\n``) or ``""`` when
+    the block has no proposal. Tolerant of blank lines and ordering — we
+    just collect any line that starts with one of the four keys.
+    """
+    lines = raw_block.splitlines()
+    proposal_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if any(stripped.startswith(key) for key in _PROPOSAL_KEYS):
+            proposal_lines.append(stripped)
+    return "\n".join(proposal_lines)
+
+
+def _question_to_dict(pq: PendingQuestion, *, with_proposal: bool) -> dict:
+    out: dict = {
+        "id": pq.id,
+        "entity": pq.entity,
+        "source": pq.source,
+        "question": pq.question,
+        "conflict_type": pq.conflict_type,
+        "description": pq.description,
+        "created_at": pq.created_at,
+    }
+    if with_proposal:
+        out["proposal"] = _extract_proposal_block(pq.raw_block)
+    return out
+
+
+def _format_block(pq: PendingQuestion, *, with_proposal: bool) -> str:
+    """Human-readable rendering for stdout (non-JSON path)."""
+    lines = [
+        f"## [{pq.created_at}] Entity: {pq.entity!r} (from {pq.source})",
+        f"  id: {pq.id}",
+        f"  question: {pq.question}",
+    ]
+    if pq.conflict_type:
+        lines.append(f"  conflict_type: {pq.conflict_type}")
+    if pq.description:
+        lines.append(f"  description: {pq.description}")
+    if with_proposal:
+        proposal = _extract_proposal_block(pq.raw_block)
+        if proposal:
+            lines.append("  proposal:")
+            for p_line in proposal.splitlines():
+                lines.append(f"    {p_line}")
+    return "\n".join(lines)
+
+
+def _resolve_pending_path(args: argparse.Namespace) -> Path:
+    knowledge_root = (
+        (getattr(args, "path", None) or Path("~/knowledge")).expanduser().resolve()
+    )
+    return knowledge_root / "wiki" / "_pending_questions.md"
+
+
+def _unanswered(pending_path: Path) -> list[PendingQuestion]:
+    return [pq for pq in parse_pending_questions(pending_path) if not pq.answered]
+
+
+def cmd_questions(args: argparse.Namespace) -> int:
+    """Dispatch ``athenaeum questions {list,next,count}``.
+
+    The hook surface contract: this never raises on a missing or empty
+    ``_pending_questions.md`` — count returns 0 / null oldest, list/next
+    print nothing and exit 0. Lets the SessionStart hook fail-silent.
+    """
+    sub = getattr(args, "questions_target", None)
+    if sub not in ("list", "next", "count"):
+        print(
+            "usage: athenaeum questions {list,next,count} [...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    pending_path = _resolve_pending_path(args)
+    questions = _unanswered(pending_path)
+
+    if sub == "count":
+        oldest = questions[0].created_at if questions else None
+        if args.json:
+            sys.stdout.write(
+                json.dumps({"count": len(questions), "oldest": oldest}) + "\n"
+            )
+        else:
+            if not questions:
+                print("0 unresolved")
+            else:
+                print(f"{len(questions)} unresolved (oldest: {oldest})")
+        return 0
+
+    if sub == "next":
+        if not questions:
+            if args.json:
+                sys.stdout.write("null\n")
+            return 0
+        pq = questions[0]
+        if args.json:
+            sys.stdout.write(
+                json.dumps(_question_to_dict(pq, with_proposal=args.with_proposal))
+                + "\n"
+            )
+        else:
+            print(_format_block(pq, with_proposal=args.with_proposal))
+        return 0
+
+    # sub == "list"
+    limit = getattr(args, "limit", 0) or 0
+    if limit > 0:
+        questions = questions[:limit]
+
+    if args.json:
+        payload = [
+            _question_to_dict(pq, with_proposal=args.with_proposal) for pq in questions
+        ]
+        sys.stdout.write(json.dumps(payload) + "\n")
+        return 0
+
+    if not questions:
+        print("0 unresolved")
+        return 0
+
+    for idx, pq in enumerate(questions):
+        if idx > 0:
+            print()
+        print(_format_block(pq, with_proposal=args.with_proposal))
+    return 0
+
+
+def add_questions_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Register ``athenaeum questions`` and its three modes on ``subparsers``."""
+    q_parser = subparsers.add_parser(
+        "questions",
+        help=(
+            "Inspect unresolved entries in `_pending_questions.md`. "
+            "Three modes: list, next, count. Used by the example "
+            "SessionStart hook and the resolve-questions skill."
+        ),
+    )
+    q_sub = q_parser.add_subparsers(dest="questions_target")
+
+    common = {
+        "path": (
+            "--path",
+            {
+                "type": Path,
+                "default": Path("~/knowledge"),
+                "help": "Knowledge directory (default: ~/knowledge)",
+            },
+        ),
+        "json": (
+            "--json",
+            {
+                "action": "store_true",
+                "help": "Emit machine-readable JSON instead of plain text.",
+            },
+        ),
+        "with_proposal": (
+            "--with-proposal",
+            {
+                "action": "store_true",
+                "help": (
+                    "Include the (optional) `**Proposed resolution**` "
+                    "block from the resolver (#126)."
+                ),
+            },
+        ),
+    }
+
+    list_p = q_sub.add_parser("list", help="List all unresolved questions.")
+    list_p.add_argument(*((common["path"][0],)), **common["path"][1])
+    list_p.add_argument(*((common["json"][0],)), **common["json"][1])
+    list_p.add_argument(*((common["with_proposal"][0],)), **common["with_proposal"][1])
+    list_p.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Truncate to first N (default: 0 = unlimited).",
+    )
+
+    next_p = q_sub.add_parser(
+        "next", help="Show the oldest unresolved question (single block)."
+    )
+    next_p.add_argument(*((common["path"][0],)), **common["path"][1])
+    next_p.add_argument(*((common["json"][0],)), **common["json"][1])
+    next_p.add_argument(*((common["with_proposal"][0],)), **common["with_proposal"][1])
+
+    count_p = q_sub.add_parser(
+        "count", help="Print `N unresolved (oldest: <iso-date>)`."
+    )
+    count_p.add_argument(*((common["path"][0],)), **common["path"][1])
+    count_p.add_argument(*((common["json"][0],)), **common["json"][1])

--- a/src/athenaeum/cli.py
+++ b/src/athenaeum/cli.py
@@ -370,6 +370,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Wiki directory (default: ~/knowledge/wiki)",
     )
 
+    # questions command — surface unresolved pending-question blocks
+    from athenaeum._cmd_questions import add_questions_subparser
+
+    add_questions_subparser(subparsers)
+
     # rebuild-index command — rebuild the search index out-of-band
     rebuild_parser = subparsers.add_parser(
         "rebuild-index",
@@ -438,6 +443,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "repair":
         return _cmd_repair(args)
+
+    if args.command == "questions":
+        from athenaeum._cmd_questions import cmd_questions
+
+        return cmd_questions(args)
 
     return 0
 

--- a/tests/test_questions_cli.py
+++ b/tests/test_questions_cli.py
@@ -1,0 +1,223 @@
+"""Tests for `athenaeum questions {list,next,count}` (issue #128).
+
+Covers the three modes against a synthetic `_pending_questions.md`:
+
+- `count`: text + JSON
+- `list`: respects `--limit`, includes proposal block when `--with-proposal`,
+  excludes resolved (`[x]`) entries
+- `next`: returns oldest unresolved; emits `null` JSON on empty
+
+All tests build the file by hand (the parser fixtures live in
+`test_answers.py`); we re-use only `parse_pending_questions` indirectly
+through the CLI surface.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from athenaeum.cli import main as cli_main
+
+
+def _block(
+    *,
+    date: str,
+    entity: str,
+    question: str,
+    checkbox: str = "[ ]",
+    conflict_type: str = "principled",
+    description: str = "synthetic conflict",
+    proposal: str | None = None,
+) -> str:
+    block = (
+        f'## [{date}] Entity: "{entity}" (from sessions/{date}-x.md)\n'
+        f"- {checkbox} {question}\n"
+        f"**Conflict type**: {conflict_type}\n"
+        f"**Description**: {description}\n"
+    )
+    if proposal:
+        block += proposal.rstrip() + "\n"
+    return block
+
+
+@pytest.fixture
+def knowledge_root(tmp_path: Path) -> Path:
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    pending = wiki / "_pending_questions.md"
+    pending.write_text(
+        "# Pending Questions\n\n"
+        + _block(
+            date="2026-04-10",
+            entity="Acme Corp",
+            question="Is Acme still Series A?",
+            proposal=(
+                "**Proposed resolution**: keep_a\n"
+                "**Confidence**: 0.92\n"
+                "**Rationale**: user direct statement overrides legacy import.\n"
+                "**Source precedence**: a:user > b:unsourced"
+            ),
+        )
+        + "\n---\n\n"
+        + _block(
+            date="2026-04-20",
+            entity="Beta Inc",
+            question="Is Beta HQ in Boston?",
+        )
+        + "\n---\n\n"
+        + _block(
+            date="2026-04-25",
+            entity="Resolved Co",
+            question="Already answered question",
+            checkbox="[x]",
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _run(argv: list[str]) -> tuple[int, str]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli_main(argv)
+    return rc, buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# count
+# ---------------------------------------------------------------------------
+
+
+def test_count_text(knowledge_root: Path) -> None:
+    rc, out = _run(["questions", "count", "--path", str(knowledge_root)])
+    assert rc == 0
+    assert "2 unresolved" in out
+    assert "2026-04-10" in out  # oldest
+
+
+def test_count_json(knowledge_root: Path) -> None:
+    rc, out = _run(["questions", "count", "--path", str(knowledge_root), "--json"])
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload == {"count": 2, "oldest": "2026-04-10"}
+
+
+def test_count_empty_knowledge(tmp_path: Path) -> None:
+    (tmp_path / "wiki").mkdir()
+    rc, out = _run(["questions", "count", "--path", str(tmp_path), "--json"])
+    assert rc == 0
+    assert json.loads(out) == {"count": 0, "oldest": None}
+
+
+# ---------------------------------------------------------------------------
+# next
+# ---------------------------------------------------------------------------
+
+
+def test_next_returns_oldest(knowledge_root: Path) -> None:
+    rc, out = _run(["questions", "next", "--path", str(knowledge_root), "--json"])
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["entity"] == "Acme Corp"
+    assert payload["created_at"] == "2026-04-10"
+    # No --with-proposal => no proposal field.
+    assert "proposal" not in payload
+
+
+def test_next_with_proposal(knowledge_root: Path) -> None:
+    rc, out = _run(
+        [
+            "questions",
+            "next",
+            "--path",
+            str(knowledge_root),
+            "--with-proposal",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["entity"] == "Acme Corp"
+    assert "**Proposed resolution**: keep_a" in payload["proposal"]
+    assert "**Confidence**: 0.92" in payload["proposal"]
+
+
+def test_next_empty_returns_null(tmp_path: Path) -> None:
+    (tmp_path / "wiki").mkdir()
+    rc, out = _run(["questions", "next", "--path", str(tmp_path), "--json"])
+    assert rc == 0
+    assert json.loads(out) is None
+
+
+def test_next_text_format(knowledge_root: Path) -> None:
+    rc, out = _run(["questions", "next", "--path", str(knowledge_root)])
+    assert rc == 0
+    assert "Acme Corp" in out
+    assert "Is Acme still Series A?" in out
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_excludes_resolved(knowledge_root: Path) -> None:
+    rc, out = _run(["questions", "list", "--path", str(knowledge_root), "--json"])
+    assert rc == 0
+    payload = json.loads(out)
+    assert len(payload) == 2
+    entities = {item["entity"] for item in payload}
+    assert entities == {"Acme Corp", "Beta Inc"}
+    # Resolved Co has [x] — must not appear.
+    assert "Resolved Co" not in entities
+
+
+def test_list_with_limit(knowledge_root: Path) -> None:
+    rc, out = _run(
+        [
+            "questions",
+            "list",
+            "--path",
+            str(knowledge_root),
+            "--limit",
+            "1",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out)
+    assert len(payload) == 1
+    assert payload[0]["entity"] == "Acme Corp"  # oldest first
+
+
+def test_list_with_proposal_includes_proposal_block(knowledge_root: Path) -> None:
+    rc, out = _run(
+        [
+            "questions",
+            "list",
+            "--path",
+            str(knowledge_root),
+            "--with-proposal",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out)
+    by_entity = {item["entity"]: item for item in payload}
+    assert "**Proposed resolution**: keep_a" in by_entity["Acme Corp"]["proposal"]
+    # Beta has no resolver block — proposal field should be empty string.
+    assert by_entity["Beta Inc"]["proposal"] == ""
+
+
+def test_list_text_format_lists_both(knowledge_root: Path) -> None:
+    rc, out = _run(["questions", "list", "--path", str(knowledge_root)])
+    assert rc == 0
+    assert "Acme Corp" in out
+    assert "Beta Inc" in out
+    assert "Resolved Co" not in out

--- a/tests/test_shell_hooks.py
+++ b/tests/test_shell_hooks.py
@@ -26,6 +26,7 @@ HOOKS_DIR = Path(__file__).parent.parent / "examples" / "claude-code"
 SESSION_START = HOOKS_DIR / "session-start-recall.sh"
 USER_PROMPT = HOOKS_DIR / "user-prompt-recall.sh"
 PRE_COMPACT = HOOKS_DIR / "pre-compact-save.sh"
+PENDING_QUESTIONS = HOOKS_DIR / "pending-questions-surface.sh"
 
 
 def _require(tool: str) -> None:
@@ -83,7 +84,10 @@ class TestSessionStartRecall:
         _require("bash")
         result = subprocess.run(
             ["bash", str(SESSION_START)],
-            env=hook_env, capture_output=True, text=True, timeout=30,
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
 
@@ -105,7 +109,10 @@ class TestSessionStartRecall:
         }
         result = subprocess.run(
             ["bash", str(SESSION_START)],
-            env=env, capture_output=True, text=True, timeout=10,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         assert result.returncode == 0
 
@@ -114,7 +121,11 @@ class TestUserPromptRecall:
     def _seed_index(self, hook_env: dict[str, str]) -> None:
         subprocess.run(
             ["bash", str(SESSION_START)],
-            env=hook_env, capture_output=True, text=True, timeout=30, check=True,
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
         )
 
     def test_returns_wiki_match_as_additional_context(
@@ -125,14 +136,19 @@ class TestUserPromptRecall:
         _require("sqlite3")
         self._seed_index(hook_env)
 
-        stdin_payload = json.dumps({
-            "prompt": "Tell me about customer development frameworks",
-            "session_id": f"test-{uuid.uuid4().hex}",
-        })
+        stdin_payload = json.dumps(
+            {
+                "prompt": "Tell me about customer development frameworks",
+                "session_id": f"test-{uuid.uuid4().hex}",
+            }
+        )
         result = subprocess.run(
             ["bash", str(USER_PROMPT)],
-            input=stdin_payload, env=hook_env,
-            capture_output=True, text=True, timeout=10,
+            input=stdin_payload,
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
         assert result.stdout, "expected hookSpecificOutput JSON on stdout"
@@ -153,14 +169,19 @@ class TestUserPromptRecall:
         _require("sqlite3")
         self._seed_index(hook_env)
 
-        stdin_payload = json.dumps({
-            "prompt": "hi",
-            "session_id": f"test-{uuid.uuid4().hex}",
-        })
+        stdin_payload = json.dumps(
+            {
+                "prompt": "hi",
+                "session_id": f"test-{uuid.uuid4().hex}",
+            }
+        )
         result = subprocess.run(
             ["bash", str(USER_PROMPT)],
-            input=stdin_payload, env=hook_env,
-            capture_output=True, text=True, timeout=10,
+            input=stdin_payload,
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         assert result.returncode == 0
         assert result.stdout == ""
@@ -168,14 +189,19 @@ class TestUserPromptRecall:
     def test_exits_clean_with_no_index(self, hook_env: dict[str, str]) -> None:
         _require("bash")
         _require("jq")
-        stdin_payload = json.dumps({
-            "prompt": "anything at all with enough characters",
-            "session_id": f"test-{uuid.uuid4().hex}",
-        })
+        stdin_payload = json.dumps(
+            {
+                "prompt": "anything at all with enough characters",
+                "session_id": f"test-{uuid.uuid4().hex}",
+            }
+        )
         result = subprocess.run(
             ["bash", str(USER_PROMPT)],
-            input=stdin_payload, env=hook_env,
-            capture_output=True, text=True, timeout=10,
+            input=stdin_payload,
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         assert result.returncode == 0
         assert result.stdout == ""
@@ -195,9 +221,122 @@ class TestPreCompactSave:
         env = {"HOME": str(tmp_path), "PATH": os.environ.get("PATH", "")}
         result = subprocess.run(
             ["bash", str(PRE_COMPACT)],
-            env=env, capture_output=True, text=True, timeout=5,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         assert result.returncode == 0
         payload = json.loads(result.stdout)
         assert "systemMessage" in payload
         assert "Knowledge checkpoint" in payload["systemMessage"]
+
+
+class TestPendingQuestionsSurface:
+    """`pending-questions-surface.sh` — SessionStart hook that surfaces
+    unresolved `_pending_questions.md` blocks with a snooze cache.
+
+    Contract: never blocks startup. Empty / missing pending file → silent.
+    Populated → prints `[Pending memory questions] N unresolved (oldest: ...)`.
+    Snooze file with future date → silent. Past date → re-surfaces.
+    """
+
+    def _seed_pending(self, knowledge: Path, count: int = 2) -> None:
+        wiki = knowledge / "wiki"
+        wiki.mkdir(parents=True, exist_ok=True)
+        body = ["# Pending Questions", ""]
+        for i in range(count):
+            body.append(
+                f'## [2026-04-{10 + i:02d}] Entity: "Acme {i}" '
+                f"(from sessions/x-{i}.md)"
+            )
+            body.append(f"- [ ] Question {i}?")
+            body.append("**Conflict type**: principled")
+            body.append("**Description**: synthetic")
+            body.append("")
+            body.append("---")
+            body.append("")
+        (wiki / "_pending_questions.md").write_text("\n".join(body))
+
+    def test_silent_when_no_pending_file(
+        self, hook_env: dict[str, str]
+    ) -> None:
+        _require("bash")
+        # hook_env's wiki has wiki pages but no _pending_questions.md.
+        result = subprocess.run(
+            ["bash", str(PENDING_QUESTIONS)],
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_surfaces_count_when_populated(
+        self, hook_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        _require("bash")
+        knowledge = Path(hook_env["KNOWLEDGE_ROOT"])
+        self._seed_pending(knowledge, count=3)
+
+        result = subprocess.run(
+            ["bash", str(PENDING_QUESTIONS)],
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "[Pending memory questions]" in result.stdout
+        assert "3 unresolved" in result.stdout
+        assert "2026-04-10" in result.stdout  # oldest
+
+    def test_silent_when_snoozed_until_future(
+        self, hook_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        _require("bash")
+        knowledge = Path(hook_env["KNOWLEDGE_ROOT"])
+        self._seed_pending(knowledge, count=2)
+
+        cache_dir = tmp_path / ".cache" / "athenaeum"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        # Far-future ISO instant — must compare > now lexicographically.
+        (cache_dir / "pending-questions-snoozed-until").write_text(
+            "2999-01-01T00:00:00Z"
+        )
+
+        result = subprocess.run(
+            ["bash", str(PENDING_QUESTIONS)],
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_resurfaces_after_snooze_expires(
+        self, hook_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        _require("bash")
+        knowledge = Path(hook_env["KNOWLEDGE_ROOT"])
+        self._seed_pending(knowledge, count=1)
+
+        cache_dir = tmp_path / ".cache" / "athenaeum"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        # Past instant — should be ignored, count surfaces.
+        (cache_dir / "pending-questions-snoozed-until").write_text(
+            "2000-01-01T00:00:00Z"
+        )
+
+        result = subprocess.run(
+            ["bash", str(PENDING_QUESTIONS)],
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "[Pending memory questions]" in result.stdout
+        assert "1 unresolved" in result.stdout


### PR DESCRIPTION
## Summary

Pending memory questions used to live silently in `~/knowledge/wiki/_pending_questions.md` until the user happened to look. This PR surfaces them through the installable Claude Code hook kit so every athenaeum install gets the loop for free.

Three deliverables:

1. **`athenaeum questions {list,next,count}` CLI** (`src/athenaeum/_cmd_questions.py`)
   - `count [--json]` returns `{"count": N, "oldest": "<iso-date>"}`
   - `next [--with-proposal] [--json]` returns the oldest unresolved block; emits `null` when empty
   - `list [--with-proposal] [--limit N] [--json]` returns all unresolved (resolved `[x]` excluded)
   - When `--with-proposal` is set, the trailing 4-key proposal block from the Opus resolver (#126) is extracted byte-verbatim. Entries without a proposal still parse — `proposal` is `""`.

2. **`examples/claude-code/pending-questions-surface.sh` SessionStart hook**
   - Resolves CLI via `ATHENAEUM_CLI` / `ATHENAEUM_PYTHON` + `ATHENAEUM_SRC` / PATH.
   - Reads snooze cache at `~/.cache/athenaeum/pending-questions-snoozed-until`. ISO-8601 UTC; future means silent, past/missing means surface.
   - Calls `athenaeum questions count --json`, prints a one-block prompt to stdout when count > 0.
   - Fail-silent on every external call (`|| true`); never blocks startup.

3. **`.claude/skills/resolve-questions/SKILL.md`** — six-step interactive walk-through. Reuses the existing `resolve_question` MCP tool, no new MCP surface added. The skill writes the snooze file when the user defers; the hook only reads it.

`examples/claude-code/README.md` gets a new hook row + `ATHENAEUM_PQ_SNOOZE_HOURS` / `ATHENAEUM_PQ_HOOK_DEBUG` env-var docs + a "Pending-questions surface" section. `settings-snippet.json` gets a SessionStart entry for the new hook.

Backward compat: the answers.py parser is untouched. Entries written before #126 (no proposal block) parse identically; the new CLI just reports `proposal: ""` for them.

## Test plan

- [x] `pytest tests/test_questions_cli.py -q` → 11 passed (count/list/next x text+json, --with-proposal, --limit, resolved-excluded, empty-knowledge)
- [x] `pytest tests/test_shell_hooks.py::TestPendingQuestionsSurface -q` → 4 passed (silent-no-file, populated-surfaces, snoozed-future-silent, snoozed-past-resurfaces)
- [x] `pytest tests/ -q` → 664 passed, 1 skipped (was 649; +15 new)
- [x] `ruff check` clean on all modified Python
- [x] `shellcheck examples/claude-code/pending-questions-surface.sh` clean

## Self-Quine gates

- [x] CLI subcommand: 3 modes (list/next/count) tested; `--json` and `--with-proposal` covered
- [x] Hook: empty + populated fixture; snooze cache (future + past) respected
- [x] Skill: 6-step flow, cites `resolve_question` MCP tool + `athenaeum questions` CLI exactly
- [x] README hook table updated; new env vars documented
- [x] `settings-snippet.json` updated with SessionStart entry
- [x] Backward-compat with answers.py parser preserved (entries without proposal still parse; resolved `[x]` excluded from all surfaces)
- [x] No MCP server changes; uses existing `resolve_question` + `list_pending_questions` tools

Closes #128
