### PR TITLE
refactor(hooks): port generic hook improvements from cwc (#129)

### DIFF
--- a/examples/claude-code/AUDIT.md
+++ b/examples/claude-code/AUDIT.md
@@ -1,0 +1,56 @@
+# Hook Drift Audit (cwc → athenaeum)
+
+Snapshot 2026-05-10. Closes #129.
+
+Athenaeum's `examples/claude-code/` ships an installable hook kit. The
+maintainer's personal Claude Code workspace (`code-workspace-config`, "cwc")
+runs an evolved fork of these scripts at `scripts/hooks/`. This audit
+catalogues each cwc hook, marks generic-vs-personal, and records what was
+ported back into the kit.
+
+This document is the artifact future maintainers consult when deciding what
+to lift on the next sync.
+
+## Categorization
+
+| cwc script | Status | Athenaeum equivalent | Notes |
+|---|---|---|---|
+| `knowledge-sidecar.sh` | **port-as-new** | `wiki-context-inject.sh` (NEW) | Headline generic improvement: cwd-keyword wiki injection at SessionStart, before any prompt. Stripped Tristan-specific symlink health check. Generalised skip-word list and result cap as `ATHENAEUM_INJECT_*` env vars. |
+| `knowledge-rebuild-index.sh` | **port-as-new** | `rebuild-index.sh` (NEW) | Atomic dir-lock + stale-lock recovery + log file. Generic out-of-band rebuild for SessionEnd. Useful for large wikis where the synchronous SessionStart rebuild becomes painful. |
+| `knowledge-build-index.sh` | **port-generic (partial)** | `session-start-recall.sh` | Ported the vector-index freshness fast-path (skip rebuild when index newer than wiki, override via `ATHENAEUM_FORCE_REBUILD=1`). Did NOT port: 1Password keychain bootstrap (`OP_SERVICE_ACCOUNT_TOKEN`), background-rebuild scheduler with stale-warning UI, or the read-only fast-path that depends on the rebuild hook being on disk — these intertwine with cwc-specific paths and a SessionEnd-rebuild assumption that not all users share. |
+| `knowledge-recall-on-turn.sh` | **already-in-athenaeum** | `user-prompt-recall.sh` | Athenaeum's version is already the more polished one (mktemp tmp-file for vector stderr, `ATHENAEUM_HOOK_DEBUG`, `set -a` for child-process env). cwc's version is older. No port. |
+| `knowledge-precompact.sh` | **already-in-athenaeum** | `pre-compact-save.sh` | Functionally identical. No port. |
+| `gh-agent-session-setup.sh` | **stays-in-cwc** | — | gh-app token machinery; cwc-specific. |
+| `session-debris-report.sh` | **stays-in-cwc** | — | Tristan-specific WIP-branch detection. |
+| `persona-reinject.sh`, `persona-statusline.sh` | **stays-in-cwc** | — | Tristan persona system. |
+| `dangerous-cmd-gate.sh`, `env-file-guard.sh`, `command-guard.sh`, `exploration-limiter.sh` | **stays-in-cwc** | — | Tristan-specific safety hooks. |
+| `auto-memory-validate.sh` | **stays-in-cwc** | — | Tristan-specific validation. |
+
+## What was ported in this PR
+
+1. **`wiki-context-inject.sh`** (new). Source: `knowledge-sidecar.sh`. Cheap dependency-free cwd-keyword wiki injection. Generalised:
+   - Hardcoded skip-words → `ATHENAEUM_INJECT_SKIP_WORDS` env var.
+   - Hardcoded max results → `ATHENAEUM_INJECT_MAX_RESULTS` env var.
+   - Dropped the broken-symlink health check (Tristan-specific multi-scope `~/.claude/projects/*/memory` topology).
+   - Pairs naturally with `session-start-recall.sh`; both safe to wire as parallel `SessionStart` hooks.
+
+2. **`rebuild-index.sh`** (new). Source: `knowledge-rebuild-index.sh`. Generic out-of-band index rebuild with:
+   - `mkdir`-based atomic lock.
+   - Stale-lock recovery (>1h reclaim).
+   - Log file at `~/.cache/athenaeum/rebuild.log`.
+   - Hybrid FTS5+vector when `SEARCH_BACKEND=vector` (FTS5 still rebuilt as secondary so user-prompt-recall.sh's hybrid merge keeps working).
+
+3. **Vector-index freshness fast-path** in `session-start-recall.sh`. Source: `knowledge-build-index.sh` (the generic part of the freshness logic, decoupled from the cwc-specific config-cache and rebuild-scheduler dance). Skips the expensive (~45s) vector rebuild when the existing index is newer than the newest wiki page. FTS5 is unchanged (always rebuilt — it's cheap). Override via `ATHENAEUM_FORCE_REBUILD=1`.
+
+4. **`settings-snippet.json`** updated to wire `wiki-context-inject.sh` alongside `session-start-recall.sh` at `SessionStart`, and to demonstrate the optional `SessionEnd` rebuild wiring.
+
+5. **`README.md`** updated: new hook rows + new env-var rows.
+
+## What was deliberately NOT ported
+
+- **1Password Keychain bootstrap of `OP_SERVICE_ACCOUNT_TOKEN`**. Specific to Tristan's `op-box-claude` keychain entry naming; would require a configurable scheme that 99% of users will never need. Athenaeum's existing `op read` path is sufficient for users with `op` already signed in.
+- **Background-rebuild scheduler with stale-warning UI**. Couples `session-start-recall.sh` to `rebuild-index.sh` being installed at a particular path. Users who want this can compose them manually in `settings.json`.
+- **Read-only fast-path (don't build at session start, only check freshness)**. Same coupling concern. Users with very large wikis can opt into this manually by replacing the SessionStart hook with `rebuild-index.sh` + a SessionEnd trigger.
+- **Broken-symlink health check** in `knowledge-sidecar.sh`. Tied to Tristan's per-scope memory symlink topology under `~/.claude/projects/*/memory/`. Not a general-purpose check.
+
+Future syncs should re-run this audit against the cwc tree before assuming any newly-divergent hook is generic.

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -8,9 +8,11 @@ agent runtime.
 | Hook                     | When it fires        | What it does                                                    |
 |--------------------------|----------------------|------------------------------------------------------------------|
 | `session-start-recall.sh`| Start of each session| Builds the FTS5 (and optional vector) index, caches config       |
+| `wiki-context-inject.sh` | Start of each session| Cheap cwd-keyword grep — surfaces wiki pages relevant to the project being opened, before any prompt is submitted |
 | `user-prompt-recall.sh`  | Each user turn       | Hybrid FTS5+vector search, injects top-3 wiki page names         |
 | `pre-compact-save.sh`    | Before compaction    | Reminds the model to call `remember` on anything load-bearing    |
 | `pending-questions-surface.sh` | Start of each session | Surfaces unresolved `_pending_questions.md` entries with a snooze cache |
+| `rebuild-index.sh`       | SessionEnd (optional)| Out-of-band index rebuild with atomic dir lock — wire when synchronous SessionStart rebuild becomes painful (large wikis, vector backend) |
 
 ## How the sidecar works (read this first)
 
@@ -117,6 +119,9 @@ pages or the index hasn't been built — check `~/.cache/athenaeum/`.
 | `ATHENAEUM_SRC`          | —                                 | Source checkout path (skips `pip install`, runs from source)   |
 | `ATHENAEUM_OP_KEY_PATH`  | `op://Agent Tools/Anthropic API Key/credential` | 1Password secret reference for `ANTHROPIC_API_KEY` |
 | `ATHENAEUM_HOOK_DEBUG`   | `0`                               | Set to `1` to log vector-backend errors to stderr              |
+| `ATHENAEUM_FORCE_REBUILD` | `0`                              | Set to `1` to force a vector-index rebuild even if the existing one is fresher than the wiki |
+| `ATHENAEUM_INJECT_SKIP_WORDS` | `Code|Users|home|workspace|src|lib|app|var|tmp|usr` | Pipe-separated cwd path segments to ignore in `wiki-context-inject.sh` |
+| `ATHENAEUM_INJECT_MAX_RESULTS` | `3`                          | Max wiki pages to surface from `wiki-context-inject.sh`         |
 | `ATHENAEUM_PQ_SNOOZE_HOURS` | `24`                          | Snooze TTL for `pending-questions-surface.sh` (consumed by the `resolve-questions` skill when writing the snooze file) |
 | `ATHENAEUM_PQ_HOOK_DEBUG` | `0`                              | Set to `1` to log `pending-questions-surface.sh` diagnostics to stderr |
 | `SEARCH_BACKEND`         | from `athenaeum.yaml` (`fts5`)    | `fts5` (default) or `vector`                                   |

--- a/examples/claude-code/rebuild-index.sh
+++ b/examples/claude-code/rebuild-index.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Out-of-band knowledge index rebuild — for SessionEnd or on-demand use.
+#
+# `session-start-recall.sh` builds the index synchronously at session start.
+# That works for small wikis but becomes painful (~45s+) once the wiki
+# has thousands of pages. This script is the deferred-rebuild alternative:
+# wire it into a SessionEnd hook (detached via `nohup ... &`) so the
+# rebuild happens between sessions instead of on the critical path.
+#
+# Uses an atomic directory lock at $CACHE_DIR/rebuild.lock to prevent
+# concurrent rebuilds when multiple sessions exit at once. Stale locks
+# (>1h old) are reclaimed automatically.
+#
+# Reads backend selection from $CACHE_DIR/config.env (written by
+# session-start-recall.sh on a prior run). Defaults to fts5.
+#
+# Configure as a SessionEnd hook in ~/.claude/settings.json:
+#   "SessionEnd": [{
+#     "hooks": [{
+#       "type": "command",
+#       "command": "nohup /path/to/rebuild-index.sh >/dev/null 2>&1 &"
+#     }]
+#   }]
+#
+# Environment variables:
+#   KNOWLEDGE_ROOT       Knowledge base root (default: ~/knowledge)
+#   KNOWLEDGE_WIKI_PATH  Wiki directory (default: $KNOWLEDGE_ROOT/wiki)
+#   ATHENAEUM_PYTHON     Python interpreter with athenaeum deps
+#   ATHENAEUM_SRC        Path to athenaeum source checkout (optional)
+
+set -euo pipefail
+
+KNOWLEDGE_ROOT="${KNOWLEDGE_ROOT:-$HOME/knowledge}"
+WIKI_ROOT="${KNOWLEDGE_WIKI_PATH:-$KNOWLEDGE_ROOT/wiki}"
+CACHE_DIR="${HOME}/.cache/athenaeum"
+CONFIG_ENV="${CACHE_DIR}/config.env"
+LOCK_DIR="${CACHE_DIR}/rebuild.lock"
+LOG_FILE="${CACHE_DIR}/rebuild.log"
+PYTHON="${ATHENAEUM_PYTHON:-python3}"
+
+[ -d "$WIKI_ROOT" ] || exit 0
+
+mkdir -p "$CACHE_DIR"
+
+# ── Atomic lock acquisition ──────────────────────────────────────────────
+# `mkdir` is atomic on POSIX. Either we own the lock or someone else does
+# and we exit cheaply. Stale locks (>1h) are reclaimed — covers the case
+# where a prior rebuild crashed without releasing.
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  lock_age=0
+  if ctime_mac="$(stat -f %c "$LOCK_DIR" 2>/dev/null)"; then
+    lock_age=$(( $(date +%s) - ctime_mac ))
+  elif ctime_linux="$(stat -c %Y "$LOCK_DIR" 2>/dev/null)"; then
+    lock_age=$(( $(date +%s) - ctime_linux ))
+  fi
+  if [ "$lock_age" -gt 3600 ]; then
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] rebuild: stale lock (${lock_age}s old), reclaiming" >> "$LOG_FILE"
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR"
+  else
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] rebuild: another rebuild in progress (lock ${lock_age}s old), skipping" >> "$LOG_FILE"
+    exit 0
+  fi
+fi
+trap 'rm -rf "$LOCK_DIR"' EXIT
+
+# ── Read backend ─────────────────────────────────────────────────────────
+if [ -f "$CONFIG_ENV" ]; then
+  # shellcheck disable=SC1090
+  source "$CONFIG_ENV"
+fi
+SEARCH_BACKEND="${SEARCH_BACKEND:-fts5}"
+
+# ── Delegate to athenaeum.search ─────────────────────────────────────────
+_SEARCH_MOD="${ATHENAEUM_SRC:-}/src/athenaeum/search.py"
+start_ts="$(date +%s)"
+
+_run_python_build() {
+  # $1 = build function name, label = $2
+  local fn="$1" label="$2"
+  "$PYTHON" -c "
+import sys, os, importlib.util
+src = os.environ.get('ATHENAEUM_SRC', '')
+path = os.path.join(src, 'src/athenaeum/search.py') if src else ''
+if path and os.path.isfile(path):
+    spec = importlib.util.spec_from_file_location('athenaeum.search', path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    fn = getattr(mod, '${fn}')
+else:
+    from athenaeum.search import ${fn} as fn
+try:
+    count = fn(sys.argv[1], sys.argv[2])
+    print(f'${label} index: {count} wiki pages')
+except ImportError as e:
+    print(f'${label} backend unavailable: {e}', file=sys.stderr)
+    sys.exit(2)
+" "$WIKI_ROOT" "$CACHE_DIR" 2>&1
+}
+
+{
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] rebuild: start backend=${SEARCH_BACKEND}"
+
+  if [ "$SEARCH_BACKEND" = "vector" ]; then
+    _run_python_build build_vector_index "vector"
+    # FTS5 as secondary: hybrid recall in user-prompt-recall.sh wants
+    # both, and FTS5 is cheap (~1s for 3k pages) next to vector's ~45s.
+    _run_python_build build_fts5_index "fts5 (secondary)"
+  elif [ "$SEARCH_BACKEND" = "fts5" ]; then
+    _run_python_build build_fts5_index "fts5"
+  else
+    echo "unknown search backend: $SEARCH_BACKEND" >&2
+    exit 1
+  fi
+
+  duration=$(( $(date +%s) - start_ts ))
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] rebuild: done duration=${duration}s"
+} >> "$LOG_FILE" 2>&1

--- a/examples/claude-code/session-start-recall.sh
+++ b/examples/claude-code/session-start-recall.sh
@@ -166,7 +166,28 @@ else
 fi
 
 if [ "${SEARCH_BACKEND:-fts5}" = "vector" ]; then
-  "$PYTHON" -c "
+  # Vector rebuild is expensive (~45s on a ~3k-page wiki) so skip when the
+  # existing index is newer than the newest wiki page. FTS5 above is cheap
+  # enough to always rebuild. Override with ATHENAEUM_FORCE_REBUILD=1.
+  VECTOR_DIR="${CACHE_DIR}/wiki-vectors"
+  _vector_fresh=false
+  if [ -d "$VECTOR_DIR" ] && [ "${ATHENAEUM_FORCE_REBUILD:-0}" != "1" ]; then
+    _idx_mtime=$(find "$VECTOR_DIR" -type f -print0 2>/dev/null \
+      | xargs -0 stat -f %m 2>/dev/null \
+      | sort -n | tail -1 || echo 0)
+    _wiki_mtime=$(find "$WIKI_ROOT" -type f -name '*.md' -print0 2>/dev/null \
+      | xargs -0 stat -f %m 2>/dev/null \
+      | sort -n | tail -1 || echo 0)
+    _idx_mtime="${_idx_mtime:-0}"
+    _wiki_mtime="${_wiki_mtime:-0}"
+    if [ "$_idx_mtime" -gt "$_wiki_mtime" ] && [ "$_idx_mtime" -gt 0 ]; then
+      _vector_fresh=true
+      echo "[Knowledge] Vector index fresh — skipping rebuild." >&2
+    fi
+  fi
+
+  if [ "$_vector_fresh" = false ]; then
+    "$PYTHON" -c "
 import sys, os, importlib.util
 src = os.environ.get('ATHENAEUM_SRC', '')
 path = os.path.join(src, 'src/athenaeum/search.py') if src else ''
@@ -183,4 +204,5 @@ try:
 except ImportError as e:
     print(f'[Knowledge] Vector backend unavailable: {e}', file=sys.stderr)
 " "$WIKI_ROOT" "$CACHE_DIR" 2>&1 || true
+  fi
 fi

--- a/examples/claude-code/settings-snippet.json
+++ b/examples/claude-code/settings-snippet.json
@@ -13,6 +13,11 @@
           },
           {
             "type": "command",
+            "command": "/path/to/wiki-context-inject.sh 2>/dev/null || true",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "/path/to/pending-questions-surface.sh 2>/dev/null || true",
             "timeout": 5
           }
@@ -36,6 +41,17 @@
           {
             "type": "command",
             "command": "/path/to/pre-compact-save.sh 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "_SessionEnd_optional": "Wire rebuild-index.sh as a SessionEnd hook for large wikis where the synchronous SessionStart rebuild becomes painful. Detach with nohup so session exit is instant.",
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "nohup /path/to/rebuild-index.sh >/dev/null 2>&1 &"
           }
         ]
       }

--- a/examples/claude-code/wiki-context-inject.sh
+++ b/examples/claude-code/wiki-context-inject.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SessionStart hook: inject wiki context based on the current working directory.
+#
+# Cheap, dependency-free heuristic. Derives keywords from the cwd path and
+# greps wiki/ for matching pages. Surfaces page name + first paragraph as a
+# single-block startup hint, so the model knows which entities are relevant
+# to the project being opened — *before* any prompt is submitted.
+#
+# Pairs naturally with `session-start-recall.sh` (the main FTS5/vector index
+# builder). This script costs nothing if the wiki is missing and is silent
+# when no keywords or no matches are found, so it's safe to wire alongside.
+#
+# Configure in ~/.claude/settings.json (alongside session-start-recall.sh):
+#   "hooks": {
+#     "SessionStart": [{
+#       "hooks": [
+#         { "type": "command", "command": "/path/to/session-start-recall.sh" },
+#         { "type": "command", "command": "/path/to/wiki-context-inject.sh" }
+#       ]
+#     }]
+#   }
+#
+# Environment variables:
+#   KNOWLEDGE_ROOT       Knowledge base root (default: ~/knowledge)
+#   KNOWLEDGE_WIKI_PATH  Wiki directory (default: $KNOWLEDGE_ROOT/wiki)
+#   ATHENAEUM_INJECT_SKIP_WORDS  Pipe-separated cwd path segments to ignore
+#                                (default: Code|Users|home|workspace|src|lib|app|var|tmp|usr)
+#   ATHENAEUM_INJECT_MAX_RESULTS Max wiki pages to surface (default: 3)
+#
+# Fail-silent contract: every external call is `||true`-guarded; the hook
+# must never block session startup.
+
+set -euo pipefail
+
+KNOWLEDGE_ROOT="${KNOWLEDGE_ROOT:-$HOME/knowledge}"
+WIKI_ROOT="${KNOWLEDGE_WIKI_PATH:-$KNOWLEDGE_ROOT/wiki}"
+SKIP_WORDS="${ATHENAEUM_INJECT_SKIP_WORDS:-Code|Users|home|workspace|src|lib|app|var|tmp|usr}"
+MAX_RESULTS="${ATHENAEUM_INJECT_MAX_RESULTS:-3}"
+
+[ -d "$WIKI_ROOT" ] || exit 0
+
+# Derive keywords from cwd path segments. Drop generic words and tokens
+# shorter than 3 characters (too noisy). The tail -5 keeps the most-specific
+# (deepest) segments, which usually carry the project identity.
+CWD="$(pwd)"
+PROJECT_NAME="$(basename "$CWD")"
+KEYWORDS=$(echo "$CWD" | tr '/-' '\n' \
+  | grep -vE "^(${SKIP_WORDS})?$" \
+  | grep -E '.{3,}' \
+  | tail -5 \
+  | tr '\n' '|' \
+  | sed 's/|$//')
+
+[ -n "$KEYWORDS" ] || exit 0
+
+# Iterate wiki pages, match against frontmatter + opening body. Files
+# starting with `_` are index/system pages (e.g. `_pending_questions.md`)
+# and skipped to avoid surfacing meta-pages as project context.
+MATCHES=""
+MATCH_COUNT=0
+
+for md_file in "$WIKI_ROOT"/*.md; do
+  [ -f "$md_file" ] || continue
+  case "$(basename "$md_file")" in _*) continue ;; esac
+
+  if head -30 "$md_file" 2>/dev/null | grep -qiE "$KEYWORDS"; then
+    PAGE_NAME=$(grep -m1 '^name:' "$md_file" 2>/dev/null \
+      | sed 's/^name:[[:space:]]*//' | tr -d '"'"'" \
+      || basename "$md_file" .md)
+    # First non-frontmatter, non-heading paragraph as a one-line summary.
+    SUMMARY=$(awk '
+      /^---$/ { if (++c == 2) next; if (c > 1) p = 1; next }
+      p && /^[^#]/ && NF { print; exit }
+    ' "$md_file" 2>/dev/null || echo "")
+
+    if [ -n "$PAGE_NAME" ]; then
+      MATCHES="${MATCHES}  - ${PAGE_NAME}"
+      [ -n "$SUMMARY" ] && MATCHES="${MATCHES}: ${SUMMARY}"
+      MATCHES="${MATCHES}
+"
+      MATCH_COUNT=$((MATCH_COUNT + 1))
+      [ "$MATCH_COUNT" -ge "$MAX_RESULTS" ] && break
+    fi
+  fi
+done
+
+if [ "$MATCH_COUNT" -gt 0 ]; then
+  cat <<EOF
+[Knowledge context for ${PROJECT_NAME}]
+Relevant wiki pages (use \`recall\` MCP tool for details):
+${MATCHES}
+EOF
+fi

--- a/tests/test_shell_hooks.py
+++ b/tests/test_shell_hooks.py
@@ -27,6 +27,8 @@ SESSION_START = HOOKS_DIR / "session-start-recall.sh"
 USER_PROMPT = HOOKS_DIR / "user-prompt-recall.sh"
 PRE_COMPACT = HOOKS_DIR / "pre-compact-save.sh"
 PENDING_QUESTIONS = HOOKS_DIR / "pending-questions-surface.sh"
+WIKI_INJECT = HOOKS_DIR / "wiki-context-inject.sh"
+REBUILD_INDEX = HOOKS_DIR / "rebuild-index.sh"
 
 
 def _require(tool: str) -> None:
@@ -232,6 +234,167 @@ class TestPreCompactSave:
         assert "Knowledge checkpoint" in payload["systemMessage"]
 
 
+class TestWikiContextInject:
+    """`wiki-context-inject.sh` — SessionStart hook that surfaces wiki pages
+    matching cwd path keywords, before any prompt is submitted.
+
+    Contract: silent when wiki missing, no keywords match, or cwd is
+    generic; emits `[Knowledge context for <project>]` block when at least
+    one wiki page matches the cwd-derived keyword set.
+    """
+
+    def test_silent_when_wiki_missing(self, tmp_path: Path) -> None:
+        _require("bash")
+        env = {
+            "HOME": str(tmp_path),
+            "PATH": os.environ.get("PATH", ""),
+            "KNOWLEDGE_ROOT": str(tmp_path / "does-not-exist"),
+        }
+        result = subprocess.run(
+            ["bash", str(WIKI_INJECT)],
+            env=env,
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_surfaces_match_when_cwd_keyword_hits_wiki(
+        self, hook_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        _require("bash")
+        # Add a wiki page whose name/body contains a recognisable token,
+        # then run the hook from a directory whose path contains that
+        # token. The cwd-keyword grep should pick it up.
+        wiki = Path(hook_env["KNOWLEDGE_ROOT"]) / "wiki"
+        (wiki / "innovation-accounting.md").write_text(
+            "---\n"
+            "name: Innovation Accounting\n"
+            "tags: [methodology]\n"
+            "---\n\n"
+            "Innovation Accounting is a Lean Startup-era measurement framework.\n"
+        )
+        project_dir = tmp_path / "projects" / "innovation-accounting-toolkit"
+        project_dir.mkdir(parents=True)
+
+        result = subprocess.run(
+            ["bash", str(WIKI_INJECT)],
+            env=hook_env,
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "[Knowledge context for innovation-accounting-toolkit]" in result.stdout
+        assert "Innovation Accounting" in result.stdout
+
+    def test_silent_when_no_keyword_matches(
+        self, hook_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        _require("bash")
+        # cwd is a unique nonsense string; no wiki page contains it.
+        project_dir = tmp_path / "projects" / "qzqzqzqz-no-match-here"
+        project_dir.mkdir(parents=True)
+        result = subprocess.run(
+            ["bash", str(WIKI_INJECT)],
+            env=hook_env,
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+    def test_skips_underscore_index_pages(
+        self, hook_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        _require("bash")
+        wiki = Path(hook_env["KNOWLEDGE_ROOT"]) / "wiki"
+        (wiki / "_pending_questions.md").write_text(
+            "---\nname: pending\n---\n\nzzunique-token-zz\n"
+        )
+        project_dir = tmp_path / "projects" / "zzunique-token-zz"
+        project_dir.mkdir(parents=True)
+        result = subprocess.run(
+            ["bash", str(WIKI_INJECT)],
+            env=hook_env,
+            cwd=str(project_dir),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        # Should not surface the underscore-prefixed page.
+        assert result.stdout == ""
+
+
+class TestRebuildIndex:
+    """`rebuild-index.sh` — out-of-band SessionEnd rebuild with atomic lock."""
+
+    def test_builds_fts5_index_into_cache(
+        self, hook_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        _require("bash")
+        result = subprocess.run(
+            ["bash", str(REBUILD_INDEX)],
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        index_db = tmp_path / ".cache" / "athenaeum" / "wiki-index.db"
+        assert index_db.is_file()
+        log_file = tmp_path / ".cache" / "athenaeum" / "rebuild.log"
+        assert log_file.is_file()
+        log = log_file.read_text()
+        assert "rebuild: start" in log
+        assert "rebuild: done" in log
+
+    def test_skips_when_lock_held(
+        self, hook_env: dict[str, str], tmp_path: Path
+    ) -> None:
+        _require("bash")
+        cache_dir = tmp_path / ".cache" / "athenaeum"
+        cache_dir.mkdir(parents=True)
+        # Pre-create the lock dir to simulate concurrent rebuild.
+        (cache_dir / "rebuild.lock").mkdir()
+
+        result = subprocess.run(
+            ["bash", str(REBUILD_INDEX)],
+            env=hook_env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        # Should exit cleanly without crashing into the locked region.
+        assert result.returncode == 0
+        # Lock dir should still exist (we did not own it, so not removed).
+        assert (cache_dir / "rebuild.lock").is_dir()
+        log = (cache_dir / "rebuild.log").read_text()
+        assert "another rebuild in progress" in log
+
+    def test_exits_clean_when_wiki_missing(self, tmp_path: Path) -> None:
+        _require("bash")
+        env = {
+            "HOME": str(tmp_path),
+            "PATH": os.environ.get("PATH", ""),
+            "KNOWLEDGE_ROOT": str(tmp_path / "does-not-exist"),
+        }
+        result = subprocess.run(
+            ["bash", str(REBUILD_INDEX)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+
+
 class TestPendingQuestionsSurface:
     """`pending-questions-surface.sh` — SessionStart hook that surfaces
     unresolved `_pending_questions.md` blocks with a snooze cache.
@@ -258,9 +421,7 @@ class TestPendingQuestionsSurface:
             body.append("")
         (wiki / "_pending_questions.md").write_text("\n".join(body))
 
-    def test_silent_when_no_pending_file(
-        self, hook_env: dict[str, str]
-    ) -> None:
+    def test_silent_when_no_pending_file(self, hook_env: dict[str, str]) -> None:
         _require("bash")
         # hook_env's wiki has wiki pages but no _pending_questions.md.
         result = subprocess.run(


### PR DESCRIPTION
## Summary

Audit of the maintainer's evolved cwc hooks (`scripts/hooks/`) against athenaeum's installable kit (`examples/claude-code/`). Generic improvements ported back; Tristan-specific extras left in cwc. Full categorization in [`examples/claude-code/AUDIT.md`](examples/claude-code/AUDIT.md).

## Generic improvements ported

- **`wiki-context-inject.sh`** (NEW). Source: `cwc/scripts/hooks/knowledge-sidecar.sh`. Cheap cwd-keyword wiki injection at SessionStart, before any prompt is submitted. Surfaces wiki pages whose frontmatter or opening body matches keywords derived from the current working directory. Generalised the hardcoded skip-words and result cap as `ATHENAEUM_INJECT_SKIP_WORDS` / `ATHENAEUM_INJECT_MAX_RESULTS`. Stripped the cwc-specific broken-symlink health check.

- **`rebuild-index.sh`** (NEW). Source: `cwc/scripts/hooks/knowledge-rebuild-index.sh`. Out-of-band SessionEnd rebuild with `mkdir`-based atomic lock, stale-lock recovery (>1h reclaim), and a log file at `~/.cache/athenaeum/rebuild.log`. Hybrid FTS5+vector when `SEARCH_BACKEND=vector`. Useful for large wikis where the synchronous SessionStart vector rebuild becomes painful (~45s+).

- **Vector-index freshness fast-path** in `session-start-recall.sh`. Source: the generic part of `cwc/scripts/hooks/knowledge-build-index.sh` — decoupled from cwc's config-cache and rebuild-scheduler dance. Skips the expensive vector rebuild when the existing index is newer than the newest wiki page. FTS5 unchanged (cheap, always rebuilt). Override via `ATHENAEUM_FORCE_REBUILD=1`.

- **`settings-snippet.json`** updated to wire `wiki-context-inject.sh` alongside `session-start-recall.sh` at SessionStart, and to demonstrate the optional SessionEnd rebuild wiring.

- **`README.md`** updated with new hook rows and env-var rows.

## Deliberately not ported

See AUDIT.md for full reasoning, but in short: 1Password Keychain bootstrap of `OP_SERVICE_ACCOUNT_TOKEN`, the background-rebuild scheduler with stale-warning UI, the read-only fast-path, and the broken-symlink health check all couple to cwc-specific paths or topology. They stay in cwc.

## Tests

7 new tests in `tests/test_shell_hooks.py`:

- `wiki-context-inject.sh`: silent when wiki missing / no match / underscore-prefix index page; surfaces match block when cwd keyword hits a wiki page.
- `rebuild-index.sh`: builds FTS5 into cache; respects existing lock; exits clean when wiki missing.

All 671 tests pass locally.

## Test plan

- [ ] CI green on the PR.
- [ ] `bash examples/claude-code/wiki-context-inject.sh` from any project dir prints relevant wiki pages (or stays silent when nothing matches).
- [ ] `bash examples/claude-code/rebuild-index.sh` produces `~/.cache/athenaeum/wiki-index.db` and writes a log entry.
- [ ] Setting `ATHENAEUM_FORCE_REBUILD=1` re-builds the vector index even when it's newer than the wiki.

Closes #129

Built with [WOZCODE](https://wozcode.com)
