### PR TITLE
chore(release): prepare 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,143 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-11
+
+This release ships three coherent streams of work: (a) the auto-memory
+intake → cluster → merge → contradiction-detection pipeline (#195, #196,
+#197, #198), which lets the librarian fold per-scope Claude Code memory
+and other auto-captured turns into the wiki without manual triage;
+(b) per-claim provenance, per-value `field_sources`, cross-uid dedupe,
+legacy-slug repair tooling, and an Opus-backed contradiction resolver
+(#90, #102, #103, #97, #126, #128); and (c) the Apollo connector
+extraction and `athenaeum people` filter CLI (#82, #112). Includes **two
+BREAKING changes**; see Removed.
+
+### Added
+
+#### Auto-memory pipeline
+- **Auto-memory contradiction detection (C4)** (#198) — see details below.
+- **Auto-memory cluster merge (C3)** (#197) — see details below.
+- **Auto-memory cluster pass (C2)** (#196) — see details below.
+- **Auto-memory ingest path** (#195) — see details below.
+- **Claude Code auto-memory integration guide** (#200) — see details below.
+- **`raw/auto-memory` indexed as first-class recall source** (#192) — the
+  FTS5/vector index now ingests `raw/auto-memory/<scope>/*.md` alongside
+  wiki pages so recall surfaces auto-captured turns before they’re merged.
+
+#### Provenance, dedupe, and contradiction tooling
+- **Per-claim `source:` on every CLAIM** (#90) — every emitted claim now
+  carries a typed `<type>:<ref>` provenance pointer.
+- **Per-value `field_sources` for list fields** (#102) — list-valued
+  frontmatter (tags, aliases, etc.) carries per-value provenance instead
+  of a single field-level source.
+- **Tier 3 emits `source`/`field_sources` + `KNOWN_TYPES` allowlist** —
+  the Sonnet writer now produces provenance-shaped output natively.
+- **Cross-uid reference rewriter for dedupe** (#103) — `athenaeum dedupe
+  persons --apply` rewrites every cross-uid reference to the survivor uid
+  in one pass; idempotent.
+- **Opus-backed contradiction resolver with provenance precedence** (#126)
+  — `athenaeum contradictions resolve` calls Opus on flagged clusters and
+  applies a deterministic source-precedence tie-breaker.
+- **Cross-scope contradiction-detection mode toggle** (#125) — per-scope
+  / cross-scope contradiction detection is now configurable.
+- **Pending-questions installable sidecar** (#128) — `athenaeum questions`
+  CLI (list / next / count) replaces ad-hoc grep against
+  `_pending_questions.md`; consumed by the example SessionStart hook and
+  the `resolve-questions` skill.
+- **Legacy bare-slug repair migration** (#97) — `athenaeum repair
+  --legacy-source-slugs` rewrites pre-#90 `source:` slugs to typed
+  `script:<slug>` form; the live tree was migrated 2026-05-09 before the
+  parser branch was retired (see Removed).
+- **`athenaeum repair` CLI** — dry-run-by-default YAML-frontmatter repair
+  for tag-indent corruption, missing fields, and legacy slug migration.
+
+#### Tooling and ingest
+- **`athenaeum people` CLI** (#82) — frontmatter-only `type:person` filter
+  (company / tag / tier / score, plus `--title-regex` / `--company-regex`).
+  No LLM, no embeddings — deterministic over the wiki tree.
+- **`athenaeum recall <query>` CLI** (#71) — shell-accessible wrapper
+  around the MCP recall tool; see details below.
+- **MCP `remember(sources=…)` wrappers** (#96) — the MCP `remember` tool
+  now accepts an optional list of typed source pointers; the server
+  routes them into the same provenance pipeline the librarian uses.
+- **Init templates for entity-author markdown** (#89) — `athenaeum init`
+  scaffolds example entity templates so first-time authors have a working
+  shape to copy.
+- **`tier0_passthrough` preserves pre-structured raw-intake** — raw files
+  that already carry `uid` + `type` + `name` round-trip byte-for-byte
+  through the librarian without LLM tier costs.
+- **Pydantic models + write-time validation** (#88) — wiki frontmatter is
+  validated against typed schemas at write time.
+- **`extra_intake_root` config warns when missing** — stale config paths
+  no longer fail silently at discovery time.
+- **p95 search-latency benchmark harness** (#69) — see details below.
+- **Auto-memory contradiction detection (C4) (#198) [details]** — new
+  `athenaeum.contradictions` module runs one claim-level Haiku call per
+  merged cluster to decide whether member bodies state or prescribe
+  contradictory things (factual or prescriptive). Wires into
+  `athenaeum.merge`: flagged clusters carry `status: contradiction-flagged`
+  in their wiki frontmatter and append a round-trippable block to
+  `wiki/_pending_questions.md` via the existing `tier4_escalate` helper.
+  The C3 centroid-cohesion heuristic (`CONTRADICTION_COHESION_THRESHOLD`)
+  is retired as the contradiction signal but kept exported for
+  backwards-compatibility. Deterministic fallback: when
+  `ANTHROPIC_API_KEY` is unset, every cluster reports `detected=False`
+  with `rationale="llm-unavailable"`. Includes
+  `scripts/measure_contradiction_baseline.py` for local corpus baselining.
+- **Claude Code auto-memory integration guide (#200) [details]** — new
+  `docs/integrations/claude-code.md` documents the generic symlink-bridge
+  pattern from `~/.claude/projects/<scope>/memory/` into
+  `raw/auto-memory/<scope>/`, a citation frontmatter policy, and an
+  end-to-end quick start. Adds `examples/claude-code/setup-symlinks.sh`
+  (idempotent bridge with `--dry-run`),
+  `examples/claude-code/stop-hook-validate.sh` (non-blocking citation
+  validator), and `examples/claude-code/auto-memory-frontmatter.example.md`
+  (reference memory file). `examples/claude-code/README.md` gains an
+  "Auto-memory integration" section linking the three.
+- **Auto-memory cluster merge (C3) (#197) [details]** — new
+  `athenaeum.merge` module consumes the C2 cluster JSONL and emits one
+  consolidated wiki entry per cluster at `wiki/auto-<topic-slug>.md` with
+  a deduped `sources[]` union (dedupe key: `(session, turn)`), propagated
+  `origin_scope` per source, and a `contradictions_detected` heuristic
+  flag (`centroid_score < 0.75`) for the C4 review queue. Size-1
+  clusters ARE emitted as wiki entries; raw intake files remain
+  untouched. New `--merge-only` CLI flag mirrors `--cluster-only` for
+  iterating on merge output without re-embedding.
+- **p95 search-latency benchmark harness (#69) [details]** — new
+  `tests/benchmarks/test_search_bench.py` checks in the ad-hoc benchmark
+  used for the Session-2 recall budget as a pytest-benchmark fixture.
+  One bench per backend (keyword, fts5; vector opt-in via
+  `ATHENAEUM_BENCH_VECTOR=1`), asserts p95 stays within 20% of a locally
+  pinned baseline. Ignored by the default `pytest` run (so CI stays
+  fast); execute with `pytest tests/benchmarks/ --benchmark-only`.
+  `pytest-benchmark` is an optional `[bench]` extra, not a runtime dep.
+- **Auto-memory cluster pass (C2) (#196) [details]** — new
+  `athenaeum.clusters` module groups `AutoMemoryFile` records into
+  near-duplicate clusters using the existing chromadb `VectorBackend`
+  embedder (no parallel embedding pipeline). Single-linkage clustering
+  with cosine cutoff configurable via `librarian.cluster_threshold`
+  (default 0.55, tuned against the voltaire/nanoclaw regression fixture).
+  Writes JSONL cluster report to `raw/_librarian-clusters.jsonl` with
+  rotated timestamped siblings. New `--cluster-only` CLI flag skips the
+  tier pipeline. C3 merge (#197) consumes the JSONL output.
+- **Auto-memory ingest path (#195) [details]** — librarian now discovers
+  files under `raw/auto-memory/<scope>/*.md` as a parallel intake channel
+  alongside the entity-schema `discover_raw_files`. New
+  `AUTO_MEMORY_FILE_RE`, `discover_auto_memory_files()`, and
+  `AutoMemoryFile` record carry `origin_scope`, `origin_session_id`,
+  `origin_turn`, `memory_type`, and `sources` through to downstream
+  tiers. Discovery uses `resolve_extra_intake_roots()` so config is
+  single-sourced with recall; `MEMORY.md` and `_migration-log.jsonl`
+  are excluded; `_unscoped/` is ingested as a first-class scope.
+  Clustering (#196) and wiki merge (#197) ship in subsequent lanes.
+- **`athenaeum recall <query>` CLI (#71) [details]** — shell-accessible
+  wrapper around the MCP `recall` tool for validation harnesses and
+  operator debugging. Prints one tab-separated hit per line
+  (`<score>\t<filename>\t<preview>`). Respects configured `search_backend`
+  and extra intake roots; `--top-k`, `--path`, `--cache-dir`, and
+  `--backend` flags supported.
+
 ### Removed
 - **BREAKING: retired `provenance._LEGACY_SCALAR_RE` and the legacy
   bare-slug `source:` parser branch.** Pre-#90 wikis stored `source:` as
@@ -36,72 +173,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`enrich_person` + CLI write path); the conflict-resolution audit suite
   drops `TestEnrichPersonResolution` and `TestCliEnrichWriteFieldSourcesMerge`.
   No other resolver or schema is affected.
-
-### Added
-- **Auto-memory contradiction detection (C4)** (#198) — new
-  `athenaeum.contradictions` module runs one claim-level Haiku call per
-  merged cluster to decide whether member bodies state or prescribe
-  contradictory things (factual or prescriptive). Wires into
-  `athenaeum.merge`: flagged clusters carry `status: contradiction-flagged`
-  in their wiki frontmatter and append a round-trippable block to
-  `wiki/_pending_questions.md` via the existing `tier4_escalate` helper.
-  The C3 centroid-cohesion heuristic (`CONTRADICTION_COHESION_THRESHOLD`)
-  is retired as the contradiction signal but kept exported for
-  backwards-compatibility. Deterministic fallback: when
-  `ANTHROPIC_API_KEY` is unset, every cluster reports `detected=False`
-  with `rationale="llm-unavailable"`. Includes
-  `scripts/measure_contradiction_baseline.py` for local corpus baselining.
-- **Claude Code auto-memory integration guide** (#200) — new
-  `docs/integrations/claude-code.md` documents the generic symlink-bridge
-  pattern from `~/.claude/projects/<scope>/memory/` into
-  `raw/auto-memory/<scope>/`, a citation frontmatter policy, and an
-  end-to-end quick start. Adds `examples/claude-code/setup-symlinks.sh`
-  (idempotent bridge with `--dry-run`),
-  `examples/claude-code/stop-hook-validate.sh` (non-blocking citation
-  validator), and `examples/claude-code/auto-memory-frontmatter.example.md`
-  (reference memory file). `examples/claude-code/README.md` gains an
-  "Auto-memory integration" section linking the three.
-- **Auto-memory cluster merge (C3)** (#197) — new `athenaeum.merge`
-  module consumes the C2 cluster JSONL and emits one consolidated wiki
-  entry per cluster at `wiki/auto-<topic-slug>.md` with a deduped
-  `sources[]` union (dedupe key: `(session, turn)`), propagated
-  `origin_scope` per source, and a `contradictions_detected` heuristic
-  flag (`centroid_score < 0.75`) for the C4 review queue. Size-1
-  clusters ARE emitted as wiki entries; raw intake files remain
-  untouched. New `--merge-only` CLI flag mirrors `--cluster-only` for
-  iterating on merge output without re-embedding.
-- **p95 search-latency benchmark harness** (#69) — new
-  `tests/benchmarks/test_search_bench.py` checks in the ad-hoc benchmark
-  used for the Session-2 recall budget as a pytest-benchmark fixture.
-  One bench per backend (keyword, fts5; vector opt-in via
-  `ATHENAEUM_BENCH_VECTOR=1`), asserts p95 stays within 20% of a locally
-  pinned baseline. Ignored by the default `pytest` run (so CI stays
-  fast); execute with `pytest tests/benchmarks/ --benchmark-only`.
-  `pytest-benchmark` is an optional `[bench]` extra, not a runtime dep.
-- **Auto-memory cluster pass (C2)** (#196) — new `athenaeum.clusters`
-  module groups `AutoMemoryFile` records into near-duplicate clusters
-  using the existing chromadb `VectorBackend` embedder (no parallel
-  embedding pipeline). Single-linkage clustering with cosine cutoff
-  configurable via `librarian.cluster_threshold` (default 0.55, tuned
-  against the voltaire/nanoclaw regression fixture). Writes JSONL cluster
-  report to `raw/_librarian-clusters.jsonl` with rotated timestamped
-  siblings. New `--cluster-only` CLI flag skips the tier pipeline. C3
-  merge (#197) consumes the JSONL output.
-- **Auto-memory ingest path** (#195) — librarian now discovers files
-  under `raw/auto-memory/<scope>/*.md` as a parallel intake channel
-  alongside the entity-schema `discover_raw_files`. New
-  `AUTO_MEMORY_FILE_RE`, `discover_auto_memory_files()`, and
-  `AutoMemoryFile` record carry `origin_scope`, `origin_session_id`,
-  `origin_turn`, `memory_type`, and `sources` through to downstream
-  tiers. Discovery uses `resolve_extra_intake_roots()` so config is
-  single-sourced with recall; `MEMORY.md` and `_migration-log.jsonl`
-  are excluded; `_unscoped/` is ingested as a first-class scope.
-  Clustering (#196) and wiki merge (#197) ship in subsequent lanes.
-- **`athenaeum recall <query>` CLI** (#71) — shell-accessible wrapper around
-  the MCP `recall` tool for validation harnesses and operator debugging.
-  Prints one tab-separated hit per line (`<score>\t<filename>\t<preview>`).
-  Respects configured `search_backend` and extra intake roots; `--top-k`,
-  `--path`, `--cache-dir`, and `--backend` flags supported.
 
 ## [0.3.1] - 2026-04-21
 
@@ -352,7 +423,8 @@ knowledge librarian.
 - Test suite extracted from upstream + CI coverage enforcement (`>=75%`)
 - Transactional writes, type-safety hardening, prompt-injection mitigation, API budget caps
 
-[Unreleased]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/Kromatic-Innovation/athenaeum/compare/v0.2.2...v0.2.3

--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ Entities are indexed in `wiki/_index.md` grouped by type. Conflicts requiring
 human review are appended to `wiki/_pending_questions.md`. Each run logs
 token usage and estimated costs at the end.
 
-## Known limitations (v0.2.x)
+## Known limitations
 
-Athenaeum is pre-1.0. These trade-offs are intentional for this release and
-slated for revisit in v0.3:
+Athenaeum is pre-1.0. These trade-offs are intentional for the current
+release line:
 
 - **No retrieval benchmarks yet.** The hybrid-search claim rests on concrete
   failure modes (proper-noun collision, no-overlap semantic queries) and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "athenaeum"
-version = "0.3.1"
+version = "0.4.0"
 description = "Open source knowledge management pipeline — append-only intake, tiered compilation, configurable schemas"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/athenaeum/__init__.py
+++ b/src/athenaeum/__init__.py
@@ -1,7 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Athenaeum — open source knowledge management pipeline."""
+"""Athenaeum — open source knowledge management pipeline.
 
-__version__ = "0.3.1"
+The Python API surface (``__all__``) is intentionally narrow and stable.
+Most new functionality in this release is delivered via CLI subcommands
+(``athenaeum people``, ``athenaeum recall``, ``athenaeum repair``,
+``athenaeum dedupe``, ``athenaeum questions``, ``athenaeum ingest-answers``,
+etc.) — see the CLI documentation in ``README.md`` and ``athenaeum --help``
+for the full subcommand list. Internal modules (``contradictions``,
+``merge``, ``clusters``, ``dedupe``, ``repair``, ``answers``,
+``provenance``, ``resolutions``) are importable but not part of the stable
+public surface; their signatures may change between minor releases.
+"""
+
+__version__ = "0.4.0"
 
 from athenaeum.init import init_knowledge_dir
 from athenaeum.librarian import discover_raw_files, process_one, rebuild_index, run

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the stable Python public API surface.
+
+Catches drift between ``athenaeum.__all__``, ``athenaeum.__version__``,
+and the ``version`` field in ``pyproject.toml``. These three must agree;
+a 0.4.0 release that self-identifies as 0.3.1 is what triggered the
+Zenodotus FAIL verdict on the prior candidate.
+"""
+
+from __future__ import annotations
+
+import importlib
+import tomllib
+from pathlib import Path
+
+import athenaeum
+
+
+def test_all_names_are_importable() -> None:
+    """Every name in ``__all__`` must actually resolve on the package."""
+    for name in athenaeum.__all__:
+        assert hasattr(
+            athenaeum, name
+        ), f"athenaeum.__all__ lists {name!r} but it is not importable"
+
+
+def test_version_matches_pyproject() -> None:
+    """``__version__`` must match the version declared in pyproject.toml."""
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    with pyproject_path.open("rb") as fh:
+        pyproject = tomllib.load(fh)
+    declared = pyproject["project"]["version"]
+    assert athenaeum.__version__ == declared, (
+        f"athenaeum.__version__ ({athenaeum.__version__!r}) "
+        f"does not match pyproject.toml ({declared!r})"
+    )
+
+
+def test_package_reimport_is_idempotent() -> None:
+    """Reimporting the package must not raise or mutate ``__all__``."""
+    before = tuple(athenaeum.__all__)
+    importlib.reload(athenaeum)
+    after = tuple(athenaeum.__all__)
+    assert before == after


### PR DESCRIPTION
## Summary

Release hygiene for v0.4.0 per the Zenodotus verdict at `.zenodotus/0.4.0/verdict.md` (FAIL on release-prep dimensions; substance is ready). Applies must-fix items 1-5 + 7 in one commit.

- **Version bump 0.3.1 -> 0.4.0** in `pyproject.toml` and `src/athenaeum/__init__.py` (must-fix #1, #2 — three reviewers converged on the version-drift blocker).
- **CHANGELOG.md**: convert `[Unreleased]` -> `[0.4.0] - 2026-05-11` with a thesis paragraph summarizing the three release streams (auto-memory pipeline, provenance/dedupe, Apollo connector extraction). Add ~10 missing user-visible entries the maintainer reviewer flagged (must-fix #3, #5): `athenaeum people` CLI (#82), cross-uid dedupe rewriter (#103), per-value `field_sources` (#102), init templates (#89), MCP `remember(sources=...)` wrappers (#96), pending-questions sidecar (#128), Opus-backed resolver (#126), cross-scope toggle (#125), tier3 provenance emission, legacy-slug repair (#97). Fix compare-link footnote. Two BREAKING items already in `Removed` are preserved verbatim under the new heading.
- **`src/athenaeum/__init__.py` docstring**: clarify that the Python `__all__` surface is intentionally narrow and stable, and that most new functionality in this release ships via CLI subcommands. Satisfies must-fix #4 without expanding the public Python API.
- **README.md**: drop the stale `(v0.2.x)` suffix on the Known limitations header (must-fix #7).
- **`tests/test_public_api.py`** (new): regression test pinning `__all__` importability and `__version__` ↔ `pyproject.toml` agreement, so the version-drift mode that triggered the Zenodotus FAIL cannot silently recur.

Out of scope (deferred from the verdict, not blockers): must-fix #6 (maintenance signal), #8 (CONTRIBUTING expectations), #9 (already partially addressed via the thesis paragraph).

## Test plan

- [x] `pytest tests/test_public_api.py -v` — 3 passed
- [x] `pytest tests/ -x --ignore=tests/benchmarks` — 674 passed, 1 skipped
- [x] `ruff check src/ tests/` — clean
- [ ] CI green on this PR before Occam hand-back

## Refs

- Skill issue: Kromatic-Innovation/code-workspace-config#234
- Verdict: `.zenodotus/0.4.0/verdict.md` (local, not committed in this repo)
