### PR TITLE
docs(deps-policy): refresh stale 'pre-1.0' rationale for fastmcp

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,7 +32,7 @@ jobs:
           #   - Auto-merge minor updates EXCEPT for deps where pyproject.toml
           #     explicitly comments "bumps are explicit PRs":
           #     * anthropic — pre-1.0, breaking changes ship freely
-          #     * fastmcp — pre-1.0, MCP protocol shifts
+          #     * fastmcp — post-1.0, still iterating on MCP protocol surface
           #     * chromadb — minor bumps have migrated SQLite schemas
           #   - Do NOT auto-merge major updates — those follow §3.2 (and would
           #     exceed the package-author-set upper bounds in pyproject.toml).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,12 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml>=6.0,<7",
-    # anthropic and fastmcp are pre-1.0 and ship breaking changes freely.
-    # chromadb has shipped sqlite schema migrations in minor bumps. We cap
-    # at the next-major boundary (1.0 / 3.0) so a surprise release can't
-    # silently break a released athenaeum wheel — bumps are explicit PRs.
+    # anthropic is pre-1.0 and ships breaking changes freely; fastmcp is
+    # post-1.0 (3.x as of 2026-05) but still iterating on its MCP protocol
+    # surface; chromadb has shipped sqlite schema migrations in minor bumps.
+    # We cap each at an explicit upper bound (next-major boundary or wider)
+    # so a surprise release can't silently break a released athenaeum
+    # wheel — bumps are explicit PRs.
     "anthropic>=0.30.0,<1.0",
     "pydantic>=2.0,<3.0",
 ]


### PR DESCRIPTION
## Summary

Docs-only refresh of the stale "fastmcp — pre-1.0" rationale in
two places:

- `.github/workflows/dependabot-auto-merge.yml` HOLD_LIST comment
- `pyproject.toml` dependency-cap rationale block

fastmcp shipped 1.0 in 2024-08 and is now at 3.2.4. The HOLD_LIST
entry itself and the upper-bound caps are unchanged — the new wording
keeps the policy intent (explicit-PR review for fastmcp bumps because
the MCP protocol surface is still evolving) while removing the
factually-stale claim.

## Why this exists

Unblocks the re-disposition of #142 (fastmcp constraint widening
2.x → <4.0). The prior hestia maintenance-sweep cited the "pre-1.0"
rationale as the reason to hold #142; refreshing it lets the follow-on
review proceed on the actual technical merits.

Athenaeum's fastmcp surface is the decorator-only API
(`FastMCP(name, instructions=...)` + `@mcp.tool()`), which is stable
across 2.x → 3.x. The 3.x breaking changes (task scope, `ctx.elicit()`
deprecation, AuthKit token binding, FileUpload size validation) do
not touch any API path athenaeum uses; CI is already green on the
#142 widened constraint.

## Test plan

- [ ] CI runs on this branch (pytest 3.11/3.12/3.13) — docs-only change
- [ ] No code change — only doc comments

Generated by Hestia maintenance-sweep
