### PR TITLE
feat(resolutions): auto-apply high-confidence proposals (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ silently to the regex extractor if the API key or CLI is unavailable.
 | `ANTHROPIC_API_KEY` | Yes (unless `--dry-run`) | API key for Tier 2/3 LLM calls |
 | `ATHENAEUM_CLASSIFY_MODEL` | No | Override Tier 2 model (default: `claude-haiku-4-5-20251001`) |
 | `ATHENAEUM_WRITE_MODEL` | No | Override Tier 3 model (default: `claude-sonnet-4-6`) |
+| `ATHENAEUM_RESOLVE_MODEL` | No | Override the contradiction-resolver model (default: `claude-opus-4-7`) |
+| `ATHENAEUM_RESOLVE_MAX_PER_RUN` | No | Cap resolver calls per ingest run (default: `50`) |
+| `ATHENAEUM_RESOLVE_AUTO_APPLY` | No | Auto-apply high-confidence resolutions (default: `true`). See [`docs/auto-resolve.md`](docs/auto-resolve.md) |
+| `ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD` | No | Confidence floor for auto-apply, in `[0.0, 1.0]` (default: `0.90`) |
 | `ATHENAEUM_TOPIC_MODEL` | No | Override query-topic model (default: `claude-haiku-4-5-20251001`) |
 | `ATHENAEUM_OP_KEY_PATH` | No | 1Password path for the session-start `ANTHROPIC_API_KEY` bootstrap (default: `op://Agent Tools/Anthropic API Key/credential`) |
 | `AUTO_RECALL` | No | Per-turn recall on/off (hook shell env; overrides `athenaeum.yaml`'s `auto_recall`). Default: `true` |
@@ -253,6 +257,19 @@ with `401 OAuth authentication is currently not supported`. The pipeline and
 example hooks need a separate console API key — see
 [`docs/recall-architecture.md`](docs/recall-architecture.md#anthropic_api_key-bootstrap-sessionstart)
 for the 1Password bootstrap pattern.
+
+## Configuration
+
+Settings are resolved in the order **env var > `<knowledge_root>/athenaeum.yaml` > built-in default**, so a one-off shell export beats the yaml without requiring an edit. The contradiction-resolver knobs live under a top-level `resolve:` block:
+
+```yaml
+resolve:
+  model: claude-opus-4-7          # ATHENAEUM_RESOLVE_MODEL
+  auto_apply: true                # ATHENAEUM_RESOLVE_AUTO_APPLY (default: true)
+  auto_apply_threshold: 0.90      # ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD, [0.0, 1.0]
+```
+
+When `auto_apply` is on and a proposal's confidence meets or exceeds `auto_apply_threshold`, the pending-question block is auto-flipped to answered with an `Auto-resolved: true` audit-trail tag. See [`docs/auto-resolve.md`](docs/auto-resolve.md) for the full lane, including how to disable, lower the threshold, or reverse an auto-resolution.
 
 ## Data formats
 

--- a/docs/auto-resolve.md
+++ b/docs/auto-resolve.md
@@ -1,0 +1,130 @@
+# Auto-resolving high-confidence contradictions
+
+When the librarian's cheap detector flags two memory snippets as
+contradictory, an Opus-backed resolver weighs them under a source-precedence
+taxonomy and writes a proposal block onto `wiki/_pending_questions.md`.
+Historically every proposal — even at 0.99 confidence — sat in the queue
+until a human flipped the checkbox. The auto-resolve lane (issue #156)
+closes that loop: when the resolver is confident enough, the librarian
+marks the block as answered itself, leaving a clean audit trail.
+
+## What auto-resolve does
+
+For each detected contradiction:
+
+1. The cheap detector flags a pair of snippets.
+2. The resolver (default `claude-opus-4-7`) proposes a winner, action,
+   rationale, and confidence under the precedence taxonomy documented
+   in `docs/conflict-resolution.md`.
+3. If auto-apply is enabled **and** the proposal's confidence is `>=` the
+   configured threshold, the rendered pending-question block is rewritten:
+
+   - `- [ ]` becomes `- [x]`.
+   - An **Answer:** paragraph is inserted with the resolver's rationale.
+   - `**Auto-resolved**: true`, `**Resolver model**: <id>`, and
+     `**Resolver confidence**: <0.NN>` lines follow as the audit trail.
+   - The original `**Proposed resolution** / **Confidence** / **Rationale** /
+     **Source precedence**` block is left in place — the annotation is
+     additive, never destructive.
+
+4. On the next `athenaeum ingest-answers` run, the `[x]` block flows
+   through the standard archive lane: a raw intake file is written to
+   `raw/answers/{TS}-{slug}.md` with `Auto-resolved` carried in the body,
+   and the original block is appended to `_pending_questions_archive.md`.
+
+Low-confidence proposals (below the threshold), the deterministic
+fallback proposal (`confidence == 0.0`), and items the resolver budget
+already exhausted continue to ship as unchecked `[ ]` blocks for human
+review — exactly as before.
+
+## Configuration
+
+Three precedence layers, resolved as **env > yaml > default**:
+
+| Setting | Env var | YAML path | Default |
+|---|---|---|---|
+| Enable auto-apply | `ATHENAEUM_RESOLVE_AUTO_APPLY` | `resolve.auto_apply` | `true` |
+| Confidence threshold | `ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD` | `resolve.auto_apply_threshold` | `0.90` |
+| Resolver model | `ATHENAEUM_RESOLVE_MODEL` | `resolve.model` | `claude-opus-4-7` |
+
+Env-var boolean values accept `true`/`false`, `1`/`0`, `yes`/`no` (case-insensitive). An invalid env value falls through to the yaml/default layers — auto-apply is a behavior knob, not a hard validation surface.
+
+Threshold values outside `[0.0, 1.0]` raise on read so a typo (e.g. `9.0` meant as `0.9`) surfaces immediately instead of silently turning auto-apply off for the rest of the run.
+
+A sample `athenaeum.yaml`:
+
+```yaml
+resolve:
+  model: claude-opus-4-7
+  auto_apply: true
+  auto_apply_threshold: 0.90
+```
+
+## Disabling
+
+Pick whichever scope matches the intent:
+
+- **One-off run:** `ATHENAEUM_RESOLVE_AUTO_APPLY=false athenaeum run ...`
+- **Persistent:** set `resolve.auto_apply: false` in `<knowledge_root>/athenaeum.yaml`.
+
+With auto-apply off, every flagged contradiction lands as an unchecked
+`[ ]` block exactly as in the pre-#156 era.
+
+## Lowering or raising the threshold
+
+The 0.90 default was picked to be conservative — the resolver has to be
+quite sure before the librarian acts on its own. To tolerate more borderline
+auto-resolutions for a single ingest:
+
+```bash
+ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD=0.75 athenaeum run
+```
+
+To require near-certainty across all runs, set the yaml path:
+
+```yaml
+resolve:
+  auto_apply_threshold: 0.98
+```
+
+Anything below the threshold continues to land as an unchecked block for
+human review.
+
+## Reversing an auto-resolution
+
+The auto-resolved block flows through the same `ingest-answers` lane as a
+hand-answered one, so the original block ends up in two durable places:
+
+- `raw/answers/{TS}-{slug}.md` — the raw intake file with the resolver's
+  answer paragraph and `Auto-resolved: true` carried in the body.
+- `_pending_questions_archive.md` — the original block verbatim, newest
+  first.
+
+To reverse:
+
+1. Open the raw answer file under `raw/answers/` and either delete it (if
+   the underlying memory should be left untouched) or edit the answer body
+   to reflect the correct resolution.
+2. If the librarian has already compiled the answer into wiki state, edit
+   the affected wiki page directly — the answer file is intake, not
+   binding state.
+3. The archive entry is append-only and should be left in place as the
+   historical record. If you want to flag the reversal, append a short
+   note under the original block in `_pending_questions_archive.md`.
+
+Because every auto-resolution carries the resolver model id and confidence
+in the answer body, a grep over `raw/answers/` is enough to audit the lane
+end-to-end:
+
+```bash
+grep -l "Auto-resolved" ~/knowledge/raw/answers/
+```
+
+## Related
+
+- [`docs/conflict-resolution.md`](conflict-resolution.md) — the source
+  precedence taxonomy the resolver applies.
+- [`docs/contradiction-detection.md`](contradiction-detection.md) — the
+  cheap detector that gates whether the resolver runs at all.
+- [`docs/provenance-shape.md`](provenance-shape.md) — how `source:` and
+  `field_sources:` feed the resolver's precedence comparison.

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -523,7 +523,14 @@ def process_one(
 
     # --- Tier 4: Escalation ---
     if escalations:
-        tier4_escalate(escalations, wiki_root / "_pending_questions.md")
+        # wiki_root is <knowledge_root>/wiki; the config sits at the
+        # knowledge_root level. Resolve config here so the auto-apply
+        # lane (issue #156) sees the operator's yaml settings.
+        tier4_escalate(
+            escalations,
+            wiki_root / "_pending_questions.md",
+            config=load_config(wiki_root.parent),
+        )
 
     return result
 

--- a/src/athenaeum/merge.py
+++ b/src/athenaeum/merge.py
@@ -778,6 +778,7 @@ def merge_clusters_to_wiki(
                 entity_name=entry.topic_slug,
                 conflict_type=result.conflict_type or "factual",
                 description=description,
+                proposal=proposal,
             )
         )
 
@@ -940,6 +941,10 @@ def merge_clusters_to_wiki(
         )
 
     if escalations:
-        tier4_escalate(escalations, wiki_root / "_pending_questions.md")
+        tier4_escalate(
+            escalations,
+            wiki_root / "_pending_questions.md",
+            config=resolved_config,
+        )
 
     return entries

--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -7,7 +7,7 @@ import re
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import ItemsView, Iterator
@@ -228,6 +228,14 @@ class EscalationItem:
     entity_name: str
     conflict_type: str  # "principled" | "ambiguous" | "classification_failed"
     description: str
+    # Optional resolver proposal threaded through from
+    # :func:`athenaeum.resolutions.propose_resolution`. When present and
+    # confidence >= the configured threshold, :func:`tier4_escalate`
+    # auto-applies the resolution to the rendered block. Typed as
+    # ``Any`` to avoid a circular import (resolutions.py imports
+    # AutoMemoryFile from this module). The runtime type is
+    # ``athenaeum.resolutions.ResolutionProposal | None``.
+    proposal: Any = None
 
 
 @dataclass

--- a/src/athenaeum/resolutions.py
+++ b/src/athenaeum/resolutions.py
@@ -75,6 +75,16 @@ DEFAULT_RESOLVE_MODEL = "claude-opus-4-7"
 # proposal (degraded mode). Keeps cost predictable on a noisy run.
 DEFAULT_RESOLVE_MAX_PER_RUN = 50
 
+# Auto-apply lane (issue #156): when the resolver returns a high-confidence
+# proposal, mark the pending-question block as resolved in-place so the
+# user doesn't have to act. Default ON — the whole point of the lane —
+# with a conservative 0.90 confidence floor.
+DEFAULT_AUTO_APPLY = True
+DEFAULT_AUTO_APPLY_THRESHOLD = 0.90
+
+_TRUTHY = frozenset(("true", "1", "yes"))
+_FALSY = frozenset(("false", "0", "no"))
+
 # Action taxonomy locked here — :mod:`athenaeum.merge` and the renderer
 # both branch on these literals.
 ResolverWinner = Literal["a", "b", "merge", "neither"]
@@ -196,8 +206,88 @@ _JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 # ---------------------------------------------------------------------------
 
 
-def _get_model() -> str:
-    return os.environ.get("ATHENAEUM_RESOLVE_MODEL", DEFAULT_RESOLVE_MODEL)
+def _get_model(config: dict[str, Any] | None = None) -> str:
+    """Resolve the resolver model from env > config > default.
+
+    Mirrors the env > yaml > default precedence used elsewhere. Env wins
+    so an operator can swap models for a single run without editing the
+    yaml.
+    """
+    env = os.environ.get("ATHENAEUM_RESOLVE_MODEL")
+    if env:
+        return env
+    if isinstance(config, dict):
+        resolve_cfg = config.get("resolve")
+        if isinstance(resolve_cfg, dict):
+            raw = resolve_cfg.get("model")
+            if isinstance(raw, str) and raw.strip():
+                return raw.strip()
+    return DEFAULT_RESOLVE_MODEL
+
+
+def resolve_auto_apply(config: dict[str, Any] | None = None) -> bool:
+    """Resolve the auto-apply toggle from env > config > default.
+
+    Env values accepted (case-insensitive): ``true``/``false``,
+    ``1``/``0``, ``yes``/``no``. Invalid env values fall through to the
+    yaml/default layers rather than raising — auto-apply is a behavior
+    knob, not a hard validation surface.
+    """
+    env = os.environ.get("ATHENAEUM_RESOLVE_AUTO_APPLY")
+    if env is not None:
+        norm = env.strip().lower()
+        if norm in _TRUTHY:
+            return True
+        if norm in _FALSY:
+            return False
+    if isinstance(config, dict):
+        resolve_cfg = config.get("resolve")
+        if isinstance(resolve_cfg, dict):
+            raw = resolve_cfg.get("auto_apply")
+            if isinstance(raw, bool):
+                return raw
+    return DEFAULT_AUTO_APPLY
+
+
+def resolve_auto_apply_threshold(config: dict[str, Any] | None = None) -> float:
+    """Resolve the auto-apply confidence threshold from env > config > default.
+
+    Must land in ``[0.0, 1.0]``. An out-of-range env or yaml value raises
+    :class:`ValueError` so operators get a loud signal — silently clamping
+    a typo (e.g. ``9.0`` meant as ``0.9``) would auto-apply nothing for the
+    rest of the run with no obvious cause.
+    """
+    env = os.environ.get("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD")
+    if env is not None:
+        try:
+            value = float(env)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD={env!r} "
+                f"out of range [0.0, 1.0]"
+            ) from exc
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(
+                f"ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD={env!r} "
+                f"out of range [0.0, 1.0]"
+            )
+        return value
+    if isinstance(config, dict):
+        resolve_cfg = config.get("resolve")
+        if isinstance(resolve_cfg, dict) and "auto_apply_threshold" in resolve_cfg:
+            raw = resolve_cfg.get("auto_apply_threshold")
+            try:
+                value = float(raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"resolve.auto_apply_threshold={raw!r} " f"out of range [0.0, 1.0]"
+                ) from exc
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(
+                    f"resolve.auto_apply_threshold={raw!r} " f"out of range [0.0, 1.0]"
+                )
+            return value
+    return DEFAULT_AUTO_APPLY_THRESHOLD
 
 
 def resolve_max_per_run(config: dict[str, Any] | None = None) -> int:
@@ -388,6 +478,7 @@ def propose_resolution(
     detector_result: ContradictionResult,
     members: list[AutoMemoryFile],
     client: "anthropic.Anthropic | None",
+    config: dict[str, Any] | None = None,
 ) -> ResolutionProposal:
     """Run one resolver call against a detected contradiction.
 
@@ -421,7 +512,7 @@ def propose_resolution(
 
     try:
         response = client.messages.create(
-            model=_get_model(),
+            model=_get_model(config),
             max_tokens=1024,
             system=_RESOLVE_SYSTEM,
             messages=[{"role": "user", "content": user_msg}],
@@ -473,3 +564,93 @@ def render_proposal_block(proposal: ResolutionProposal) -> str:
         f"**Rationale**: {proposal.rationale or '(none provided)'}\n"
         f"**Source precedence**: {precedence}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Auto-apply lane (issue #156)
+# ---------------------------------------------------------------------------
+
+
+# Matches an unchecked checkbox line written by ``tier4_escalate``.
+_UNCHECKED_RE = re.compile(r"^(?P<prefix>- \[) \](?P<rest>.*)$", re.MULTILINE)
+
+# Detects an already-auto-resolved block so re-applying is a no-op.
+_AUTO_RESOLVED_MARKER = "**Auto-resolved**: true"
+
+
+def apply_auto_resolution(
+    block_text: str,
+    proposal: ResolutionProposal,
+    *,
+    model: str | None = None,
+) -> str:
+    """Mark a pending-question block as auto-resolved in place.
+
+    Flips the leading ``- [ ]`` to ``- [x]`` and inserts an answer
+    paragraph between the checkbox and the ``**Conflict type**:`` line
+    so the existing :mod:`athenaeum.answers` parser sees it as a real
+    user answer body. The four ``**Proposed resolution**`` /
+    ``**Confidence**`` / ``**Rationale**`` / ``**Source precedence**``
+    keys already in the block are left untouched — this annotation is
+    additive.
+
+    Idempotent: if ``block_text`` already carries the auto-resolved
+    marker, the input is returned unchanged.
+
+    Args:
+        block_text: One pending-question block as written by
+            :func:`athenaeum.tiers.tier4_escalate`.
+        proposal: The :class:`ResolutionProposal` to attribute. Confidence
+            and rationale are surfaced verbatim.
+        model: Resolver model id used for the proposal. Defaults to the
+            currently configured model — callers in :mod:`athenaeum.tiers`
+            thread their resolved id through so the audit trail names
+            the actual model that was called, not a fresh ``_get_model``
+            lookup (which can differ when env state has changed).
+
+    Returns:
+        The rewritten block text.
+    """
+    if _AUTO_RESOLVED_MARKER in block_text:
+        return block_text
+
+    model_id = model or _get_model()
+    answer_block = (
+        f"**Answer:** {proposal.rationale or '(none provided)'}\n"
+        f"**Auto-resolved**: true\n"
+        f"**Resolver model**: {model_id}\n"
+        f"**Resolver confidence**: {proposal.confidence:.2f}"
+    )
+
+    lines = block_text.splitlines()
+    out: list[str] = []
+    inserted = False
+    flipped = False
+    for line in lines:
+        if not flipped:
+            m = _UNCHECKED_RE.match(line)
+            if m:
+                out.append(f"- [x]{m.group('rest')}")
+                flipped = True
+                continue
+        if not inserted and line.startswith("**Conflict type**:"):
+            out.append(answer_block)
+            out.append("")
+            out.append(line)
+            inserted = True
+            continue
+        out.append(line)
+
+    if not flipped:
+        # No `- [ ]` to flip — block was already answered or malformed.
+        # Return unchanged rather than corrupting it.
+        return block_text
+
+    if not inserted:
+        # No `**Conflict type**:` line — append the answer block at the
+        # end so the marker still lands in the file (the round-trip test
+        # exercises the standard case where Conflict type IS present).
+        out.append("")
+        out.append(answer_block)
+
+    return "\n".join(out)

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -15,6 +15,7 @@ import os
 import re
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import anthropic
 
@@ -518,16 +519,48 @@ def _question_from_description(
     return f"Resolve {conflict_type} conflict for {entity_name}"
 
 
-def tier4_escalate(items: list[EscalationItem], pending_path: Path) -> None:
+def tier4_escalate(
+    items: list[EscalationItem],
+    pending_path: Path,
+    *,
+    config: dict[str, Any] | None = None,
+) -> None:
     """Append escalation items to ``_pending_questions.md``.
 
     Each block is rendered with a leading checkbox line directly under the
     header so the user (or the ``resolve_question`` MCP tool) can flip
     ``[ ]`` -> ``[x]`` to mark an answer; ``athenaeum ingest-answers`` then
     converts the block to a raw intake file. See ``athenaeum.answers``.
+
+    Issue #156 — auto-apply lane: when ``config`` enables auto-apply and
+    an item carries a :class:`~athenaeum.resolutions.ResolutionProposal`
+    whose confidence meets the threshold, the rendered block is flipped
+    to ``- [x]`` with an answer paragraph attributing the resolver. The
+    deterministic-fallback proposal has ``confidence == 0.0`` so the
+    threshold gate naturally excludes it — no extra guard needed.
+    Callers that pass ``config=None`` (test fixtures, legacy callers)
+    get the pre-#156 behavior: every block is written as ``- [ ]``.
     """
     if not items:
         return
+
+    # Late-import to avoid a hard module-load cycle with resolutions.py
+    # (resolutions imports AutoMemoryFile from models, models is imported
+    # here at module load via the top-of-file import block).
+    from athenaeum.resolutions import _get_model as _resolver_model
+    from athenaeum.resolutions import (
+        apply_auto_resolution,
+        resolve_auto_apply,
+        resolve_auto_apply_threshold,
+    )
+
+    auto_apply_enabled = resolve_auto_apply(config) if config is not None else False
+    threshold = (
+        resolve_auto_apply_threshold(config)
+        if config is not None
+        else 1.1  # unreachable when config is None — disables auto-apply
+    )
+    resolver_model_id = _resolver_model(config) if config is not None else None
 
     today = date.today().isoformat()
     sections: list[str] = []
@@ -541,12 +574,26 @@ def tier4_escalate(items: list[EscalationItem], pending_path: Path) -> None:
         # should survive in storage untouched; the parser anchors to the
         # final ")\n" to tolerate parens inside refs.
         escaped_entity = item.entity_name.replace("\\", "\\\\").replace('"', '\\"')
-        sections.append(
+        block = (
             f'## [{today}] Entity: "{escaped_entity}" (from {item.raw_ref})\n'
             f"- [ ] {question}\n\n"
             f"**Conflict type**: {item.conflict_type}\n"
             f"**Description**: {item.description}\n"
         )
+        proposal = getattr(item, "proposal", None)
+        if (
+            auto_apply_enabled
+            and proposal is not None
+            and getattr(proposal, "confidence", 0.0) >= threshold
+        ):
+            block = apply_auto_resolution(block, proposal, model=resolver_model_id)
+            log.info(
+                "Auto-resolved escalation for entity=%s (confidence=%.2f >= %.2f)",
+                item.entity_name,
+                proposal.confidence,
+                threshold,
+            )
+        sections.append(block)
 
     new_content = "\n---\n\n".join(sections)
 

--- a/tests/test_auto_resolve.py
+++ b/tests/test_auto_resolve.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the issue #156 auto-apply lane.
+
+Covers:
+
+- ``resolve_auto_apply`` env > yaml > default precedence.
+- ``resolve_auto_apply_threshold`` env > yaml > default + range validation.
+- ``_get_model`` precedence (env > yaml > default).
+- ``apply_auto_resolution`` idempotency.
+- Round-trip: an auto-resolved block survives ``ingest_answers`` and the
+  ``Auto-resolved`` marker lands in the raw answer file.
+- Integration: ``tier4_escalate`` flips only high-confidence (>= threshold)
+  blocks; low-confidence stay ``- [ ]``. Exact-threshold matches are inclusive.
+- ``auto_apply=False`` short-circuits even at confidence 1.0.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athenaeum.answers import ingest_answers
+from athenaeum.models import EscalationItem
+from athenaeum.resolutions import (
+    DEFAULT_AUTO_APPLY,
+    DEFAULT_AUTO_APPLY_THRESHOLD,
+    DEFAULT_RESOLVE_MODEL,
+    ResolutionProposal,
+    _get_model,
+    apply_auto_resolution,
+    resolve_auto_apply,
+    resolve_auto_apply_threshold,
+)
+from athenaeum.tiers import tier4_escalate
+
+
+def _make_proposal(
+    confidence: float, rationale: str = "user > unsourced"
+) -> ResolutionProposal:
+    return ResolutionProposal(
+        recommended_winner="a",
+        action="keep_a",
+        rationale=rationale,
+        confidence=confidence,
+        source_precedence_used=["a:user > b:unsourced"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config resolution — resolve_auto_apply
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAutoApply:
+    def test_env_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY", "true")
+        assert resolve_auto_apply({"resolve": {"auto_apply": False}}) is True
+
+    def test_env_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY", "false")
+        assert resolve_auto_apply({"resolve": {"auto_apply": True}}) is False
+
+    def test_env_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY", "YES")
+        assert resolve_auto_apply(None) is True
+
+    def test_env_invalid_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY", "maybe")
+        # Falls through to yaml setting.
+        assert resolve_auto_apply({"resolve": {"auto_apply": False}}) is False
+
+    def test_yaml_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY", raising=False)
+        assert resolve_auto_apply({"resolve": {"auto_apply": True}}) is True
+
+    def test_yaml_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY", raising=False)
+        assert resolve_auto_apply({"resolve": {"auto_apply": False}}) is False
+
+    def test_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY", raising=False)
+        assert resolve_auto_apply(None) is DEFAULT_AUTO_APPLY is True
+
+
+# ---------------------------------------------------------------------------
+# Config resolution — resolve_auto_apply_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAutoApplyThreshold:
+    def test_env_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "0.95")
+        assert resolve_auto_apply_threshold(None) == 0.95
+
+    def test_env_out_of_range_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "1.5")
+        with pytest.raises(ValueError, match="ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD"):
+            resolve_auto_apply_threshold(None)
+
+    def test_env_non_numeric_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "abc")
+        with pytest.raises(ValueError, match="ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD"):
+            resolve_auto_apply_threshold(None)
+
+    def test_yaml_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", raising=False)
+        cfg = {"resolve": {"auto_apply_threshold": 0.85}}
+        assert resolve_auto_apply_threshold(cfg) == 0.85
+
+    def test_yaml_out_of_range_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", raising=False)
+        cfg = {"resolve": {"auto_apply_threshold": 2.0}}
+        with pytest.raises(ValueError, match="resolve.auto_apply_threshold"):
+            resolve_auto_apply_threshold(cfg)
+
+    def test_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", raising=False)
+        assert (
+            resolve_auto_apply_threshold(None) == DEFAULT_AUTO_APPLY_THRESHOLD == 0.90
+        )
+
+
+# ---------------------------------------------------------------------------
+# _get_model precedence
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelPrecedence:
+    def test_env_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_MODEL", "env-model")
+        cfg = {"resolve": {"model": "yaml-model"}}
+        assert _get_model(cfg) == "env-model"
+
+    def test_yaml_wins_over_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        cfg = {"resolve": {"model": "yaml-model"}}
+        assert _get_model(cfg) == "yaml-model"
+
+    def test_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        assert _get_model(None) == DEFAULT_RESOLVE_MODEL
+
+
+# ---------------------------------------------------------------------------
+# apply_auto_resolution idempotency + shape
+# ---------------------------------------------------------------------------
+
+
+_BLOCK = (
+    '## [2026-05-23] Entity: "Tristan" (from wiki/tristan.md)\n'
+    "- [ ] Is Tristan German or American?\n"
+    "\n"
+    "**Conflict type**: factual\n"
+    "**Description**: Snippet A says German; snippet B says American.\n"
+)
+
+
+class TestApplyAutoResolution:
+    def test_flips_checkbox(self) -> None:
+        out = apply_auto_resolution(_BLOCK, _make_proposal(0.93), model="m-1")
+        assert "- [x] Is Tristan German or American?" in out
+        assert "- [ ] Is Tristan German or American?" not in out
+
+    def test_inserts_answer_block_before_conflict_type(self) -> None:
+        out = apply_auto_resolution(_BLOCK, _make_proposal(0.93), model="m-1")
+        answer_pos = out.index("**Answer:**")
+        conflict_pos = out.index("**Conflict type**:")
+        assert answer_pos < conflict_pos
+        assert "**Auto-resolved**: true" in out
+        assert "**Resolver model**: m-1" in out
+        assert "**Resolver confidence**: 0.93" in out
+
+    def test_idempotent(self) -> None:
+        once = apply_auto_resolution(_BLOCK, _make_proposal(0.93), model="m-1")
+        twice = apply_auto_resolution(once, _make_proposal(0.93), model="m-1")
+        assert once == twice
+
+    def test_no_unchecked_returns_unchanged(self) -> None:
+        already = _BLOCK.replace("- [ ]", "- [x]")
+        out = apply_auto_resolution(already, _make_proposal(0.93), model="m-1")
+        assert out == already
+
+
+# ---------------------------------------------------------------------------
+# Round-trip through ingest_answers
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_auto_resolved_block_survives_ingest(self, tmp_path: Path) -> None:
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        pending = wiki / "_pending_questions.md"
+
+        item = EscalationItem(
+            raw_ref="wiki/tristan.md",
+            entity_name="Tristan",
+            conflict_type="factual",
+            description="A says German; B says American.",
+            proposal=_make_proposal(0.95, rationale="user direct overrides unsourced"),
+        )
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
+        tier4_escalate([item], pending, config=cfg)
+
+        written = pending.read_text(encoding="utf-8")
+        assert "- [x]" in written
+        assert "**Auto-resolved**: true" in written
+
+        # Now ingest — the [x] block should be archived and a raw answer
+        # file should be written.
+        raw_root = tmp_path / "raw"
+        n = ingest_answers(pending, raw_root)
+        assert n == 1
+
+        answer_files = list((raw_root / "answers").glob("*.md"))
+        assert len(answer_files) == 1
+        body = answer_files[0].read_text(encoding="utf-8")
+        assert "Auto-resolved" in body
+        assert "Resolver confidence" in body
+
+        # Archive carries the original block.
+        archive = (pending.parent / "_pending_questions_archive.md").read_text(
+            encoding="utf-8"
+        )
+        assert "Auto-resolved" in archive
+
+
+# ---------------------------------------------------------------------------
+# tier4_escalate integration — high-conf flipped, low-conf untouched
+# ---------------------------------------------------------------------------
+
+
+class TestTier4Integration:
+    def test_mixed_confidence(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
+        items = [
+            EscalationItem(
+                raw_ref="wiki/high.md",
+                entity_name="HighConfEntity",
+                conflict_type="factual",
+                description="conflict A vs B",
+                proposal=_make_proposal(0.95),
+            ),
+            EscalationItem(
+                raw_ref="wiki/low.md",
+                entity_name="LowConfEntity",
+                conflict_type="factual",
+                description="conflict C vs D",
+                proposal=_make_proposal(0.50),
+            ),
+        ]
+        tier4_escalate(items, pending, config=cfg)
+        text = pending.read_text(encoding="utf-8")
+
+        # High-conf block flipped.
+        high_idx = text.index("HighConfEntity")
+        low_idx = text.index("LowConfEntity")
+        high_block = text[high_idx:low_idx]
+        low_block = text[low_idx:]
+        assert "- [x]" in high_block
+        assert "**Auto-resolved**: true" in high_block
+
+        # Low-conf untouched.
+        assert "- [ ]" in low_block
+        assert "**Auto-resolved**" not in low_block
+
+    def test_exact_threshold_inclusive(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
+        item = EscalationItem(
+            raw_ref="wiki/edge.md",
+            entity_name="EdgeEntity",
+            conflict_type="factual",
+            description="exactly at threshold",
+            proposal=_make_proposal(0.90),
+        )
+        tier4_escalate([item], pending, config=cfg)
+        text = pending.read_text(encoding="utf-8")
+        assert "- [x]" in text
+        assert "**Auto-resolved**: true" in text
+
+    def test_auto_apply_disabled_short_circuit(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": False, "auto_apply_threshold": 0.90}}
+        item = EscalationItem(
+            raw_ref="wiki/highest.md",
+            entity_name="HighestEntity",
+            conflict_type="factual",
+            description="confidence one point oh",
+            proposal=_make_proposal(1.0),
+        )
+        tier4_escalate([item], pending, config=cfg)
+        text = pending.read_text(encoding="utf-8")
+        assert "- [ ]" in text
+        assert "**Auto-resolved**" not in text
+
+    def test_no_config_no_auto_apply(self, tmp_path: Path) -> None:
+        """Legacy callers (config=None) get pre-#156 behavior."""
+        pending = tmp_path / "_pending_questions.md"
+        item = EscalationItem(
+            raw_ref="wiki/legacy.md",
+            entity_name="LegacyEntity",
+            conflict_type="factual",
+            description="d",
+            proposal=_make_proposal(0.99),
+        )
+        tier4_escalate([item], pending)
+        text = pending.read_text(encoding="utf-8")
+        assert "- [ ]" in text
+        assert "**Auto-resolved**" not in text


### PR DESCRIPTION
## Summary

Closes #156.

Closes the loop on the Opus-backed contradiction resolver: when a proposal's confidence meets the configured threshold, `tier4_escalate` now flips the pending-question block to answered in place, leaves an `Auto-resolved` audit trail, and lets the standard `ingest-answers` lane archive it. Low-confidence proposals, the deterministic fallback (`confidence == 0.0`), and budget-exhausted items continue to land as unchecked blocks for human review.

## What was added

**Config (`src/athenaeum/resolutions.py`)** — three new knobs under a top-level `resolve:` block in `athenaeum.yaml`, resolved as **env > yaml > default**:

| Setting | Env var | YAML | Default |
|---|---|---|---|
| Enable auto-apply | `ATHENAEUM_RESOLVE_AUTO_APPLY` | `resolve.auto_apply` | `true` |
| Confidence threshold | `ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD` | `resolve.auto_apply_threshold` | `0.90` |
| Resolver model | `ATHENAEUM_RESOLVE_MODEL` | `resolve.model` | `claude-opus-4-7` |

The legacy `contradiction.resolve_max_per_run` key is untouched for back-compat.

**Block primitive (`resolutions.apply_auto_resolution`)** — flips `- [ ]` → `- [x]`, inserts the `**Answer:** / **Auto-resolved**: true / **Resolver model** / **Resolver confidence**` paragraph between the checkbox and `**Conflict type**:` so the existing `answers.py` parser sees it as a real user answer body. Idempotent.

**Wiring (`merge.py`, `librarian.py`, `tiers.py`)** — `EscalationItem` carries an optional `proposal` (typed `Any` to dodge a circular import with `resolutions.py`); both `tier4_escalate` call sites pass `config=` so the auto-apply lane sees operator yaml settings. Legacy callers that pass `config=None` get pre-#156 behavior.

**Docs** — new `docs/auto-resolve.md` covers lane overview, configuration, disable/threshold/reversal recipes. README gains a Configuration section and three new env-var rows.

## Design choice — block primitive lives in `resolutions.py`

`apply_auto_resolution` sits alongside `render_proposal_block` rather than in a new `auto_resolve.py` module — both are rendering helpers tightly coupled to `ResolutionProposal` and the locked pending-question block format already documented in the module docstring. A new module would have meant a one-function file with a circular import on `ResolutionProposal`.

## Default-ON rationale

The whole point of the lane is to stop parking high-confidence Opus verdicts in a queue nobody reads. The 0.90 floor keeps the resolver conservative; operators who want to opt out can flip a single yaml line or set the env var per-run.

## Test plan

- [x] `pytest tests/test_auto_resolve.py -v` — 25/25 pass (config precedence × 16, idempotency × 4, round-trip × 1, integration × 4)
- [x] `pytest tests/test_resolutions.py tests/test_tiers.py tests/test_answers.py -v` — 102/102 pass (no regressions on existing tier4/resolver/answers coverage)
- [x] Full suite — 710 passed, 1 skipped
- [x] `ruff check src/ tests/` — clean
