### PR TITLE
fix(tier4): dedupe escalations by source-memory pair (#157)

### DIFF
--- a/src/athenaeum/answers.py
+++ b/src/athenaeum/answers.py
@@ -36,7 +36,7 @@ import hashlib
 import logging
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -81,6 +81,8 @@ def _unescape_entity(raw: str) -> str:
             out.append(ch)
             i += 1
     return "".join(out)
+
+
 # Checkbox grammar — ``- [ ]`` or ``- [x]`` (case-insensitive on ``x``).
 _CHECKBOX_RE = re.compile(r"^- \[(?P<state>[ xX])\]\s*(?P<question>.*)$")
 # Lines we strip when extracting the user's answer body.
@@ -107,6 +109,11 @@ class PendingQuestion:
     answered: bool
     answer_lines: list[str]
     raw_block: str
+    # Issue #157: entities sharing the same source-memory pair that
+    # got merged into this block instead of getting their own. The
+    # primary entity (header) is NOT included here. Empty by default
+    # — only populated when the dedup path in tier4_escalate fires.
+    also_affects: list[str] = field(default_factory=list)
 
 
 def _make_id(header_line: str, question_text: str) -> str:
@@ -189,9 +196,7 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
         break
 
     if checkbox_idx is None:
-        log.warning(
-            "Skipping block without checkbox line: %r", lines[0][:80]
-        )
+        log.warning("Skipping block without checkbox line: %r", lines[0][:80])
         print(
             f"[warn] skipping pending-question block without `- [ ]` line: "
             f"{lines[0][:80]!r}",
@@ -208,6 +213,7 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
     conflict_type = ""
     description = ""
     answer_lines: list[str] = []
+    also_affects: list[str] = []
 
     # Tracks whether we're still accumulating continuation lines into the
     # description field. A **Description**: line opens the window; the next
@@ -227,6 +233,15 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
             in_description = True
             description = stripped.removeprefix("**Description**:").strip()
             continue
+        if stripped.startswith("**Also affects**:"):
+            # Issue #157: dedup-merge tag. Comma-separated entity names
+            # that share the source-memory pair with this block's primary
+            # entity. Recognized as metadata so it does NOT leak into
+            # answer_lines (which would forge a phantom user answer).
+            in_description = False
+            payload = stripped.removeprefix("**Also affects**:").strip()
+            also_affects = [name.strip() for name in payload.split(",") if name.strip()]
+            continue
         if in_description:
             # Continuation: consume into description until we hit a terminator.
             # Blank line or another ``**Key**:`` tag closes the window.
@@ -240,9 +255,13 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
                 # **Conflict type**, already handled). For unknown keys, treat
                 # the line as answer body.
                 if stripped.startswith("**Conflict type**:"):
-                    conflict_type = stripped.removeprefix(
-                        "**Conflict type**:"
-                    ).strip()
+                    conflict_type = stripped.removeprefix("**Conflict type**:").strip()
+                    continue
+                if stripped.startswith("**Also affects**:"):
+                    payload = stripped.removeprefix("**Also affects**:").strip()
+                    also_affects = [
+                        name.strip() for name in payload.split(",") if name.strip()
+                    ]
                     continue
                 # Unknown **Key**: — treat as answer body.
                 answer_lines.append(raw_line)
@@ -270,6 +289,7 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
         answered=answered,
         answer_lines=answer_lines,
         raw_block=block_text,
+        also_affects=also_affects,
     )
 
 
@@ -302,10 +322,7 @@ def _render_archive_block(pq: PendingQuestion, archived_at: str) -> str:
     Includes the original raw block verbatim plus a trailer noting when the
     answer was ingested. Newest-first is handled by the caller.
     """
-    return (
-        f"{pq.raw_block}\n\n"
-        f"**Archived**: {archived_at}\n"
-    )
+    return f"{pq.raw_block}\n\n" f"**Archived**: {archived_at}\n"
 
 
 def _render_answer_raw_file(pq: PendingQuestion, resolved_at: str) -> str:
@@ -436,9 +453,7 @@ def ingest_answers(pending_path: Path, raw_root: Path) -> int:
                 f"[warn] skipping duplicate archive entry for entity={entity}",
                 file=sys.stderr,
             )
-            log.info(
-                "Skipping duplicate archive entry for entity=%s", entity
-            )
+            log.info("Skipping duplicate archive entry for entity=%s", entity)
             continue
         filtered_archived.append(rendered)
 
@@ -458,10 +473,7 @@ def ingest_answers(pending_path: Path, raw_root: Path) -> int:
             # Split off the header so we can prepend under it.
             _, _, rest = existing_archive.partition("\n")
             combined = (
-                "# Answered Questions\n\n"
-                + new_section
-                + "\n\n---\n\n"
-                + rest.lstrip()
+                "# Answered Questions\n\n" + new_section + "\n\n---\n\n" + rest.lstrip()
             )
         else:
             combined = (
@@ -475,9 +487,7 @@ def ingest_answers(pending_path: Path, raw_root: Path) -> int:
 
     archive_path.write_text(combined, encoding="utf-8")
 
-    log.info(
-        "Ingested %d pending-question answer(s) from %s", ingested, pending_path
-    )
+    log.info("Ingested %d pending-question answer(s) from %s", ingested, pending_path)
     return ingested
 
 

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -9,6 +9,7 @@ Tier 4: Human escalation
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -519,6 +520,108 @@ def _question_from_description(
     return f"Resolve {conflict_type} conflict for {entity_name}"
 
 
+def _pair_key_from_description(description: str) -> tuple[str, ...] | None:
+    """Compute the dedup key for an escalation description (issue #157).
+
+    Primary key: sorted tuple of members from a ``Members involved:`` line
+    (works for ``contradictions`` runs over sourced auto-memory passages).
+
+    Fallback key: SHA-1 prefix over the two ``Passage N:`` blobs from the
+    description (works for runs where the detector lacked source attribution).
+
+    Returns ``None`` when neither key can be derived — caller should always
+    append in that case (no dedup possible without a stable key).
+    """
+    members: list[str] | None = None
+    passages: list[str] = []
+    for raw in description.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("Members involved:"):
+            payload = stripped.removeprefix("Members involved:").strip()
+            members = [m.strip() for m in payload.split(",") if m.strip()]
+        elif stripped.startswith("Passage ") and ":" in stripped:
+            # Capture body after the first colon, regardless of digit.
+            _, _, body = stripped.partition(":")
+            body = body.strip()
+            if body:
+                passages.append(body)
+    if members and len(members) >= 2:
+        return tuple(sorted(set(members)))
+    if len(passages) >= 2:
+        # Use the first two passages (typical contradiction shape); join
+        # with a stable separator so passage order does NOT change the key
+        # — sort to make (P1,P2) and (P2,P1) collapse.
+        norm = sorted(p.strip() for p in passages[:2])
+        h = hashlib.sha1((norm[0] + "\n---\n" + norm[1]).encode("utf-8")).hexdigest()[
+            :16
+        ]
+        return ("__passage_hash__", h)
+    return None
+
+
+def _append_also_affects(block: str, entity_name: str) -> str:
+    """Merge ``entity_name`` into a block's ``**Also affects**:`` line.
+
+    Creates the line immediately AFTER the ``**Description**:`` block (or
+    after ``**Conflict type**:`` if no description) when missing. Idempotent
+    — never lists the same entity twice and never lists the primary entity.
+    Preserves all other content (proposal block, auto-resolved checkbox,
+    answer body) verbatim.
+    """
+    # Extract primary entity from the header to avoid self-listing.
+    lines = block.splitlines()
+    primary_entity = ""
+    if lines and lines[0].startswith("## "):
+        m = re.search(r'Entity:\s*"((?:[^"\\]|\\.)*)"', lines[0])
+        if m:
+            primary_entity = m.group(1).replace("\\\\", "\\").replace('\\"', '"')
+    if entity_name == primary_entity:
+        return block
+
+    # Find existing **Also affects** line.
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("**Also affects**:"):
+            payload = line.split(":", 1)[1].strip()
+            existing = [n.strip() for n in payload.split(",") if n.strip()]
+            if entity_name in existing or entity_name == primary_entity:
+                return block
+            existing.append(entity_name)
+            lines[idx] = "**Also affects**: " + ", ".join(existing)
+            return "\n".join(lines) + ("\n" if block.endswith("\n") else "")
+
+    # No existing line — insert after the description block. The description
+    # may span multiple lines; we insert right before the FIRST blank line
+    # that follows **Description**:, OR before the proposal block / answer
+    # body if there is no blank gap. Falling back: append at end-of-block.
+    desc_idx: int | None = None
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("**Description**:"):
+            desc_idx = idx
+            break
+    insert_at = len(lines)
+    if desc_idx is not None:
+        # Walk forward through continuation lines until blank or **Key**.
+        i = desc_idx + 1
+        while i < len(lines):
+            s = lines[i].strip()
+            if s == "" or s.startswith("**"):
+                insert_at = i
+                break
+            i += 1
+        else:
+            insert_at = i
+    else:
+        # No description — insert after conflict type if present, else end.
+        for idx, line in enumerate(lines):
+            if line.strip().startswith("**Conflict type**:"):
+                insert_at = idx + 1
+                break
+
+    new_line = f"**Also affects**: {entity_name}"
+    lines.insert(insert_at, new_line)
+    return "\n".join(lines) + ("\n" if block.endswith("\n") else "")
+
+
 def tier4_escalate(
     items: list[EscalationItem],
     pending_path: Path,
@@ -562,17 +665,56 @@ def tier4_escalate(
     )
     resolver_model_id = _resolver_model(config) if config is not None else None
 
+    # Issue #157: dedup escalations by source-memory pair (Members involved
+    # tuple, or sha1(passages) fallback). Default ON; escape hatch via the
+    # ATHENAEUM_TIER4_DEDUP env var so a downstream user can force the
+    # legacy always-append behavior.
+    dedup_enabled = os.environ.get(
+        "ATHENAEUM_TIER4_DEDUP", "true"
+    ).strip().lower() not in ("false", "0", "no", "off")
+
+    # Build the open-pair index from the file's currently-open ([ ]) blocks.
+    # Archived/[x] blocks are deliberately excluded — a previously-answered
+    # pair that re-fires deserves a fresh block (resurrection case).
+    from athenaeum.answers import parse_pending_questions
+
+    open_index: dict[tuple[str, ...], str] = {}
+    if dedup_enabled and pending_path.exists():
+        for pq in parse_pending_questions(pending_path):
+            if pq.answered:
+                continue
+            key = _pair_key_from_description(pq.description)
+            if key is not None and key not in open_index:
+                # First-seen wins — if the file already has duplicates from a
+                # pre-#157 run, only the first is merged into.
+                open_index[key] = pq.raw_block
+
     today = date.today().isoformat()
     sections: list[str] = []
+    # In-batch pair index: key -> position in `sections`. Items in the same
+    # batch sharing a key collapse before the file write happens.
+    batch_index: dict[tuple[str, ...], int] = {}
+    # File-merge plan: original raw_block -> list of entity names to append.
+    file_merges: dict[str, list[str]] = {}
+
     for item in items:
+        key = _pair_key_from_description(item.description) if dedup_enabled else None
+
+        # Path A: pair already lives in the file as an open block.
+        if key is not None and key in open_index:
+            file_merges.setdefault(open_index[key], []).append(item.entity_name)
+            continue
+
+        # Path B: pair already rendered earlier in THIS batch.
+        if key is not None and key in batch_index:
+            slot = batch_index[key]
+            sections[slot] = _append_also_affects(sections[slot], item.entity_name)
+            continue
+
+        # Path C: brand new — render and append.
         question = _question_from_description(
             item.description, item.entity_name, item.conflict_type
         )
-        # Escape backslashes first, then quotes — paired with the parser's
-        # unescape logic in athenaeum.answers so entity names containing
-        # double quotes round-trip cleanly. raw_ref is NOT escaped: paths
-        # should survive in storage untouched; the parser anchors to the
-        # final ")\n" to tolerate parens inside refs.
         escaped_entity = item.entity_name.replace("\\", "\\\\").replace('"', '\\"')
         block = (
             f'## [{today}] Entity: "{escaped_entity}" (from {item.raw_ref})\n'
@@ -593,18 +735,53 @@ def tier4_escalate(
                 proposal.confidence,
                 threshold,
             )
+        if key is not None:
+            batch_index[key] = len(sections)
         sections.append(block)
 
-    new_content = "\n---\n\n".join(sections)
-
+    # Apply file-merges to the existing pending text (if any).
     if pending_path.exists():
-        existing = pending_path.read_text(encoding="utf-8")
-        if existing.strip():
-            new_content = existing.rstrip() + "\n\n---\n\n" + new_content
-        else:
-            new_content = "# Pending Questions\n\n" + new_content
+        existing_text = pending_path.read_text(encoding="utf-8")
     else:
-        new_content = "# Pending Questions\n\n" + new_content
+        existing_text = ""
 
-    pending_path.write_text(new_content + "\n", encoding="utf-8")
-    log.info("Escalated %d items to %s", len(items), pending_path)
+    if file_merges:
+        for original_block, new_entities in file_merges.items():
+            updated_block = original_block
+            for ent in new_entities:
+                updated_block = _append_also_affects(updated_block, ent)
+            # Replace verbatim — raw_block came from parse, so it lives
+            # inside existing_text byte-for-byte. Guard with `count=1` to
+            # avoid clobbering text that happens to repeat.
+            if original_block in existing_text:
+                existing_text = existing_text.replace(original_block, updated_block, 1)
+            else:
+                # Should not happen — log and skip the merge for this pair.
+                log.warning(
+                    "tier4 dedup: open block disappeared between parse and "
+                    "rewrite; dropping merge for entities=%s",
+                    new_entities,
+                )
+
+    # Assemble the final file content.
+    if sections:
+        new_section_text = "\n---\n\n".join(sections)
+        if existing_text.strip():
+            new_content = existing_text.rstrip() + "\n\n---\n\n" + new_section_text
+        else:
+            new_content = "# Pending Questions\n\n" + new_section_text
+        pending_path.write_text(new_content + "\n", encoding="utf-8")
+    elif file_merges:
+        # Only file-merges happened — rewrite existing text in place.
+        pending_path.write_text(
+            existing_text if existing_text.endswith("\n") else existing_text + "\n",
+            encoding="utf-8",
+        )
+
+    log.info(
+        "Escalated %d item(s) to %s (new_blocks=%d, file_merges=%d)",
+        len(items),
+        pending_path,
+        len(sections),
+        sum(len(v) for v in file_merges.values()),
+    )

--- a/tests/test_tier4_dedup.py
+++ b/tests/test_tier4_dedup.py
@@ -1,0 +1,354 @@
+"""Tests for tier4 source-memory-pair dedup (issue #157).
+
+`tier4_escalate` collapses escalations that share a source-memory pair
+(``Members involved:`` tuple or, when absent, a passage-hash fallback)
+into a single block annotated with ``**Also affects**: ...``. Archived
+blocks are NOT in the open set, so a previously-resolved pair that
+re-fires gets a fresh block (resurrection).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athenaeum.answers import ingest_answers, parse_pending_questions
+from athenaeum.models import EscalationItem
+from athenaeum.tiers import (
+    _append_also_affects,
+    _pair_key_from_description,
+    tier4_escalate,
+)
+
+
+def _desc_with_members(a: str, b: str, extra: str = "") -> str:
+    """Build a description that mimics merge.py's contradictions output."""
+    parts = []
+    if extra:
+        parts.append(extra)
+    parts.append("Passage 1: foo")
+    parts.append("Passage 2: bar")
+    parts.append(f"Members involved: {a}, {b}")
+    return "\n".join(parts)
+
+
+def _desc_unsourced(p1: str, p2: str) -> str:
+    """Description with passages but no Members involved line."""
+    return f"Rationale text.\nPassage 1: {p1}\nPassage 2: {p2}"
+
+
+def _item(entity: str, description: str, raw_ref: str = "wiki/x.md") -> EscalationItem:
+    return EscalationItem(
+        raw_ref=raw_ref,
+        entity_name=entity,
+        conflict_type="principled",
+        description=description,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pair-key helper
+# ---------------------------------------------------------------------------
+
+
+class TestPairKey:
+    def test_members_order_independent(self) -> None:
+        k1 = _pair_key_from_description(_desc_with_members("a.md", "b.md"))
+        k2 = _pair_key_from_description(_desc_with_members("b.md", "a.md"))
+        assert k1 == k2
+        assert k1 == ("a.md", "b.md")
+
+    def test_no_members_uses_passage_hash(self) -> None:
+        d = _desc_unsourced("foo", "bar")
+        k = _pair_key_from_description(d)
+        assert k is not None
+        assert k[0] == "__passage_hash__"
+
+    def test_passage_hash_stable(self) -> None:
+        k1 = _pair_key_from_description(_desc_unsourced("foo", "bar"))
+        k2 = _pair_key_from_description(_desc_unsourced("foo", "bar"))
+        assert k1 == k2
+
+    def test_passage_hash_order_independent(self) -> None:
+        # swapped passage order should collapse to the same key.
+        k1 = _pair_key_from_description(_desc_unsourced("foo", "bar"))
+        k2 = _pair_key_from_description(_desc_unsourced("bar", "foo"))
+        assert k1 == k2
+
+    def test_passage_hash_distinguishes_content(self) -> None:
+        k1 = _pair_key_from_description(_desc_unsourced("foo", "bar"))
+        k2 = _pair_key_from_description(_desc_unsourced("baz", "qux"))
+        assert k1 != k2
+
+    def test_returns_none_for_unkeyable(self) -> None:
+        # Single member, single passage — cannot form a stable key.
+        assert _pair_key_from_description("Members involved: solo.md") is None
+        assert _pair_key_from_description("Passage 1: only") is None
+        assert _pair_key_from_description("plain text only") is None
+
+
+# ---------------------------------------------------------------------------
+# Helper: _append_also_affects
+# ---------------------------------------------------------------------------
+
+
+class TestAppendAlsoAffects:
+    def test_inserts_after_description(self) -> None:
+        block = (
+            '## [2026-05-23] Entity: "Alpha" (from wiki/x.md)\n'
+            "- [ ] q?\n\n"
+            "**Conflict type**: principled\n"
+            "**Description**: line1\n"
+        )
+        out = _append_also_affects(block, "Beta")
+        assert "**Also affects**: Beta" in out
+        # Order: description before also affects.
+        assert out.index("**Description**:") < out.index("**Also affects**:")
+
+    def test_idempotent_for_same_entity(self) -> None:
+        block = (
+            '## [2026-05-23] Entity: "Alpha" (from wiki/x.md)\n'
+            "- [ ] q?\n\n"
+            "**Conflict type**: principled\n"
+            "**Description**: d\n"
+            "**Also affects**: Beta\n"
+        )
+        out = _append_also_affects(block, "Beta")
+        # Only one occurrence of "Beta" on the also-affects line.
+        affects_line = next(
+            ln for ln in out.splitlines() if ln.startswith("**Also affects**:")
+        )
+        assert affects_line.count("Beta") == 1
+
+    def test_skips_primary_entity(self) -> None:
+        block = (
+            '## [2026-05-23] Entity: "Alpha" (from wiki/x.md)\n'
+            "- [ ] q?\n\n"
+            "**Conflict type**: principled\n"
+            "**Description**: d\n"
+        )
+        out = _append_also_affects(block, "Alpha")
+        assert "**Also affects**" not in out
+
+    def test_appends_to_existing_line(self) -> None:
+        block = (
+            '## [2026-05-23] Entity: "Alpha" (from wiki/x.md)\n'
+            "- [ ] q?\n\n"
+            "**Conflict type**: principled\n"
+            "**Description**: d\n"
+            "**Also affects**: Beta\n"
+        )
+        out = _append_also_affects(block, "Gamma")
+        assert "**Also affects**: Beta, Gamma" in out
+
+
+# ---------------------------------------------------------------------------
+# tier4_escalate dedup behavior
+# ---------------------------------------------------------------------------
+
+
+class TestTier4Dedup:
+    def test_dedup_happy_path(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        # One block, not two.
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta" in content
+        # Primary entity stays Alpha.
+        assert 'Entity: "Alpha"' in content
+        assert 'Entity: "Beta"' not in content
+
+    def test_no_dedup_for_distinct_pairs(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Gamma", _desc_with_members("c.md", "d.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 2
+        assert "**Also affects**" not in content
+
+    def test_order_independent_pair_collapse(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("b.md", "a.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta" in content
+
+    def test_triple_collapse(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+            _item("Gamma", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta, Gamma" in content
+        # Primary never repeats in the list.
+        affects_line = next(
+            ln for ln in content.splitlines() if ln.startswith("**Also affects**:")
+        )
+        assert "Alpha" not in affects_line
+
+    def test_idempotent_same_entity_twice(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        affects_line = next(
+            ln for ln in content.splitlines() if ln.startswith("**Also affects**:")
+        )
+        # Beta listed exactly once.
+        assert affects_line.count("Beta") == 1
+
+    def test_cross_batch_file_merge(self, tmp_path: Path) -> None:
+        """Batch 2 with the same pair as an open block in the file merges in-place."""
+        pending = tmp_path / "_pending_questions.md"
+        tier4_escalate([_item("Alpha", _desc_with_members("a.md", "b.md"))], pending)
+        # New batch — same pair, different entity.
+        tier4_escalate([_item("Beta", _desc_with_members("a.md", "b.md"))], pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta" in content
+
+    def test_resurrection_creates_new_block(self, tmp_path: Path) -> None:
+        """Once a block is archived ([x]), the same pair re-firing makes a NEW block."""
+        pending = tmp_path / "_pending_questions.md"
+        raw_root = tmp_path / "raw"
+
+        tier4_escalate([_item("Alpha", _desc_with_members("a.md", "b.md"))], pending)
+        # Flip the checkbox to [x] and let ingest archive the block.
+        text = pending.read_text().replace("- [ ]", "- [x]", 1)
+        # Add an answer body so the archive writer is happy.
+        text = text.replace("- [x]", "- [x]\n\nresolved by hand\n", 1)
+        pending.write_text(text)
+        ingested = ingest_answers(pending, raw_root)
+        assert ingested == 1
+        # Open file should now be just the header.
+        assert "## [" not in pending.read_text()
+
+        # Same pair re-fires — must produce a fresh block.
+        tier4_escalate([_item("Alpha", _desc_with_members("a.md", "b.md"))], pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**" not in content
+
+    def test_unsourced_fallback_dedup(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_unsourced("payload-X", "payload-Y")),
+            _item("Beta", _desc_unsourced("payload-X", "payload-Y")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta" in content
+
+    def test_unsourced_distinct_passages_no_dedup(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_unsourced("payload-X", "payload-Y")),
+            _item("Beta", _desc_unsourced("other-A", "other-B")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 2
+
+    def test_disable_via_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATHENAEUM_TIER4_DEDUP", "false")
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        # Disabled — two blocks, no Also affects line.
+        assert content.count("## [") == 2
+        assert "**Also affects**" not in content
+
+    def test_deduped_block_round_trips_through_parser(self, tmp_path: Path) -> None:
+        """The **Also affects**: line must NOT leak into answer_lines."""
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        pqs = parse_pending_questions(pending)
+        assert len(pqs) == 1
+        pq = pqs[0]
+        assert pq.answered is False
+        assert pq.answer_lines == []
+        assert pq.also_affects == ["Beta"]
+
+
+# ---------------------------------------------------------------------------
+# Auto-apply (#156) interaction
+# ---------------------------------------------------------------------------
+
+
+class _StubProposal:
+    """Minimal proposal stand-in for the auto-apply gate."""
+
+    def __init__(self, confidence: float = 0.95) -> None:
+        self.confidence = confidence
+        self.action = "prefer_left"
+        self.rationale = "stub rationale"
+        self.winning_uid = "uid_alpha"
+
+
+class TestTier4DedupAutoApply:
+    def test_also_affects_survives_auto_apply(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stub out apply_auto_resolution to keep the test independent of
+        # the resolutions module's exact rendering — we only care that
+        # the **Also affects** line survives the rewrite pass.
+        from athenaeum import resolutions
+
+        def fake_apply(block: str, proposal, model=None):  # noqa: ANN001
+            # Flip checkbox + tack on a marker line — that's what the
+            # real auto-apply does in spirit, and it's enough to exercise
+            # the interaction with _append_also_affects.
+            block = block.replace("- [ ]", "- [x]", 1)
+            return block + "\n_auto-resolved_\n"
+
+        monkeypatch.setattr(resolutions, "apply_auto_resolution", fake_apply)
+        monkeypatch.setattr(resolutions, "resolve_auto_apply", lambda c: True)
+        monkeypatch.setattr(resolutions, "resolve_auto_apply_threshold", lambda c: 0.5)
+
+        pending = tmp_path / "_pending_questions.md"
+        proposal = _StubProposal(confidence=0.95)
+        a = _item("Alpha", _desc_with_members("a.md", "b.md"))
+        a.proposal = proposal
+        b = _item("Beta", _desc_with_members("a.md", "b.md"))
+        b.proposal = proposal
+        tier4_escalate([a, b], pending, config={})
+
+        content = pending.read_text()
+        assert "_auto-resolved_" in content
+        assert "**Also affects**: Beta" in content
+        # Survives parser.
+        pqs = parse_pending_questions(pending)
+        assert len(pqs) == 1
+        assert pqs[0].also_affects == ["Beta"]


### PR DESCRIPTION
Closes #157.

## Summary

When the contradiction detector flagged the same source-memory pair (e.g. `feedback_open_files_in_sublime.md` vs `feedback_open_csv_in_numbers.md`) across N destination entities, `tier4_escalate` appended N near-identical blocks to `_pending_questions.md`. On the 2026-05-23 sweep this produced 192 dup blocks for one source pair and 63 for another — 92% of the backlog came from three source-pair conflicts.

This change collapses same-pair escalations into a single block annotated with `**Also affects**: entity_b, entity_c`, capping the daily backlog at one question per real source-pair conflict.

Pairs with #158 (auto-resolver): together they cap daily human review at one question per real source-pair conflict, with auto-apply handling the high-confidence cases.

## What was added

- `_pair_key_from_description`: primary key from the `Members involved:` sorted tuple; fallback to `sha1(passage1 + '\n---\n' + passage2)` (sorted, first 16 hex chars) when the detector ran on unsourced raw passages.
- `_append_also_affects`: idempotent block-text editor — skips the primary entity, inserts the line after the description block when missing, appends to an existing list when present.
- `tier4_escalate` keeps an **open-pair index** of currently-OPEN (`[ ]`) blocks in the file PLUS an **in-batch index**, so a same-pair item collapses whether the matching block is already in the file or is being rendered in the same call. Archived (`[x]`) blocks are deliberately excluded — a previously resolved pair that re-fires gets a fresh block (the resurrection case from the issue's test list).
- `answers.py` parser teaches `_parse_block` that `**Also affects**:` is metadata, **not** user answer body. `PendingQuestion` gains an `also_affects: list[str]` field. Without this fix the line would forge a phantom `answer_lines` entry that `ingest_answers` would mistake for a user answer.
- `ATHENAEUM_TIER4_DEDUP=false` env var disables the merging (always-append, pre-#157 semantics) as a defensive escape hatch.

## Files touched

- `src/athenaeum/tiers.py` — new helpers + rewrite of `tier4_escalate` body.
- `src/athenaeum/answers.py` — parser recognizes `**Also affects**:`, dataclass gains `also_affects`.
- `tests/test_tier4_dedup.py` — new test file (22 tests).

## Test results

```
tests/test_tier4_dedup.py ... 22 passed in 0.42s
tests/test_tiers.py tests/test_resolutions.py tests/test_answers.py tests/test_auto_resolve.py ... 127 passed in 0.60s
ruff check src/ tests/ ... All checks passed!
```

Coverage matches the issue's test list:

- Dedup happy path / no dedup / order-independent pair / triple+ / idempotent re-append
- Cross-batch file merge (batch 2 collapses into batch 1's block in the file)
- Resurrection (archived `[x]` block does not block a fresh re-fire)
- Unsourced fallback (identical passages collapse; distinct passages do not)
- Parser round-trip — deduped block parses with `answered=False` AND `answer_lines == []` AND `also_affects == ["Beta"]`
- Env-var disable path
- Auto-apply (#156) interaction — `**Also affects**:` survives the auto-resolution edit

## Notes

- The "first-seen wins" rule on the open-pair index: if a pre-#157 file already has duplicates, only the first becomes the merge target — subsequent open dupes are untouched. They will collapse on the next escalation cycle for that pair.
- `_pair_key_from_description` returns `None` when neither a `Members involved:` pair nor two passages are present; the caller always appends in that case (no dedup possible without a stable key).
- For unsourced passage-hash fallback, I use the first two `Passage N:` blobs sorted before hashing — keeps `(P1,P2)` and `(P2,P1)` collapsing to the same key.
