### PR TITLE
chore: promote develop → main for release 0.5.0

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,7 +11,23 @@ jobs:
     name: Add to Internal Platform project
     runs-on: ubuntu-latest
     steps:
+      - name: Load workflow-bot App credentials from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          KROMATIC_WORKFLOW_BOT_APP_ID: op://Infrastructure/kromatic-workflow-bot/app-id
+          KROMATIC_WORKFLOW_BOT_PRIVATE_KEY: op://Infrastructure/kromatic-workflow-bot/private-key
+
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ env.KROMATIC_WORKFLOW_BOT_APP_ID }}
+          private-key: ${{ env.KROMATIC_WORKFLOW_BOT_PRIVATE_KEY }}
+
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/Kromatic-Innovation/projects/4
-          github-token: ${{ secrets.PROMOTION_BOT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/promote-main.yml
+++ b/.github/workflows/promote-main.yml
@@ -43,6 +43,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Load workflow-bot App credentials from 1Password
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          KROMATIC_WORKFLOW_BOT_APP_ID: op://Infrastructure/kromatic-workflow-bot/app-id
+          KROMATIC_WORKFLOW_BOT_PRIVATE_KEY: op://Infrastructure/kromatic-workflow-bot/private-key
+
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ env.KROMATIC_WORKFLOW_BOT_APP_ID }}
+          private-key: ${{ env.KROMATIC_WORKFLOW_BOT_PRIVATE_KEY }}
+
       - name: Validate promotion inputs and fast-forward precondition
         run: |
           set -euo pipefail
@@ -101,16 +117,15 @@ jobs:
 
       - name: Push fast-forward promotion via refs API
         env:
-          # PROMOTION_BOT_TOKEN is required because main's branch protection
-          # (required_pull_request_reviews) rejects direct ref writes by the
-          # default GITHUB_TOKEN with HTTP 422. The bot token has the App
-          # bypass for promotion refs.
-          GH_TOKEN: ${{ secrets.PROMOTION_BOT_TOKEN }}
+          # App-minted token required because main's branch protection
+          # rejects direct ref writes by the default GITHUB_TOKEN with HTTP 422.
+          # The kromatic-workflow-bot App has the bypass for promotion refs.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::PROMOTION_BOT_TOKEN secret is not available to this workflow. Configure it at the org level or the repo secrets."
+            echo "::error::App-minted promotion token is empty; GitHub App token minting likely failed."
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ htmlcov/
 # Workspace agent overrides
 .codex/
 .zenodotus/
+
+# Derived from ~/Code/docs/project-registry.yaml by
+# scripts/derive_repo_configs.py — local artifacts, never committed.
+.agents/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-23
+
+Closes the daily-backlog problem in the pending-questions queue. The Opus
+resolver shipped in 0.4.x drafted proposals but never applied them; the
+detector wrote one block per destination entity even when the underlying
+source-memory pair was the same. On a 2026-05-23 sweep the queue carried
+323 unanswered questions, 92% of which were duplicate firings of three
+source-pair conflicts. This release adds the structural fix: auto-apply
+high-confidence resolutions and dedupe escalations by source pair.
+
+### Added
+
+- **Auto-apply lane for high-confidence resolutions** (#156, PR #158) —
+  when `auto_apply` is enabled and a `ResolutionProposal` reaches the
+  threshold, `tier4_escalate` writes the question block as already
+  answered (`- [x]`) with an `**Answer:** <rationale>` paragraph and an
+  `**Auto-resolved**: true` audit tag. The annotation is additive — the
+  resolver's `**Proposed resolution**` / `**Confidence**` /
+  `**Rationale**` / `**Source precedence**` block is preserved. The
+  rewrite is idempotent and round-trips through `ingest-answers` into
+  both `raw/answers/` and `_pending_questions_archive.md`.
+- **Configurable model and threshold** (#156) — all three config
+  surfaces are honored with precedence env > yaml > defaults:
+  - Env: `ATHENAEUM_RESOLVE_MODEL`, `ATHENAEUM_RESOLVE_AUTO_APPLY`,
+    `ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD`.
+  - YAML: `resolve.model`, `resolve.auto_apply`,
+    `resolve.auto_apply_threshold`.
+  - Defaults: `claude-opus-4-7`, `auto_apply: true`,
+    `auto_apply_threshold: 0.90`. Out-of-range threshold raises with
+    the source named (`env` vs `yaml`).
+- **Source-pair dedup at escalation time** (#157, PRs #159 and #160) —
+  before appending a new question block, `tier4_escalate` checks whether
+  the same source-memory pair already has an open block in the file (or
+  another item in the current batch). If so, the destination entity is
+  appended to a `**Also affects**: a, b, c` line instead of creating a
+  duplicate block. Falls back to a normalized passage-hash key when
+  `Members involved:` is unsourced. Auto-resolved (`[x]`) blocks are
+  excluded from the open-pair index so a resurrected conflict still
+  produces a fresh question.
+- **Highest-confidence-wins auto-apply on merge** (PR #160) — when items
+  collapse into an existing block, auto-apply is evaluated against the
+  highest-confidence proposal seen for the source-pair key in the
+  current batch, not just the first. Prevents a low-confidence primary
+  item from suppressing a high-confidence sibling that would have
+  triggered auto-apply on its own. Cross-batch case is also covered:
+  an existing open block can be auto-resolved when a fresh batch brings
+  a high-confidence proposal for the same pair.
+- **Dedup escape hatch** (#157) — `ATHENAEUM_TIER4_DEDUP=false` reverts
+  to pre-#157 always-append behavior. Default is ON.
+- **`docs/auto-resolve.md`** — explains the audit trail, how to disable
+  auto-apply (env or yaml), how to tune the threshold, and how to
+  reverse an auto-resolution.
+- **`README.md` Configuration section** — documents the three precedence
+  layers and lists all three new keys with defaults.
+
+### Changed
+
+- `tier4_escalate` signature accepts a `config: dict | None = None`
+  argument so the auto-apply gate can read the resolved model and
+  threshold. Pre-#156 callers passing `config=None` retain the prior
+  always-append behavior — no auto-apply, no dedup.
+- `EscalationItem.proposal` is a new optional attribute carrying the
+  resolver's verdict through to `tier4_escalate`. Legacy callers that
+  do not populate it are unaffected.
+- `PendingQuestion.also_affects: list[str]` exposes the merged-entity
+  list to `answers.parse_pending_questions` consumers.
+
+### Internal
+
+- 50 new tests across `tests/test_auto_resolve.py` (25) and
+  `tests/test_tier4_dedup.py` (25), including real-`ResolutionProposal`
+  integration tests for the highest-confidence-wins rule on both
+  in-batch (Path B) and cross-batch (Path A) merge paths. Round-trip
+  preservation of `**Also affects**:` through `apply_auto_resolution`
+  and `ingest_answers` is asserted explicitly.
+
 ## [0.4.1] - 2026-05-22
 
 A patch release hardening the auto-memory contradiction pipeline shipped

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ silently to the regex extractor if the API key or CLI is unavailable.
 | `ANTHROPIC_API_KEY` | Yes (unless `--dry-run`) | API key for Tier 2/3 LLM calls |
 | `ATHENAEUM_CLASSIFY_MODEL` | No | Override Tier 2 model (default: `claude-haiku-4-5-20251001`) |
 | `ATHENAEUM_WRITE_MODEL` | No | Override Tier 3 model (default: `claude-sonnet-4-6`) |
+| `ATHENAEUM_RESOLVE_MODEL` | No | Override the contradiction-resolver model (default: `claude-opus-4-7`) |
+| `ATHENAEUM_RESOLVE_MAX_PER_RUN` | No | Cap resolver calls per ingest run (default: `50`) |
+| `ATHENAEUM_RESOLVE_AUTO_APPLY` | No | Auto-apply high-confidence resolutions (default: `true`). See [`docs/auto-resolve.md`](docs/auto-resolve.md) |
+| `ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD` | No | Confidence floor for auto-apply, in `[0.0, 1.0]` (default: `0.90`) |
 | `ATHENAEUM_TOPIC_MODEL` | No | Override query-topic model (default: `claude-haiku-4-5-20251001`) |
 | `ATHENAEUM_OP_KEY_PATH` | No | 1Password path for the session-start `ANTHROPIC_API_KEY` bootstrap (default: `op://Agent Tools/Anthropic API Key/credential`) |
 | `AUTO_RECALL` | No | Per-turn recall on/off (hook shell env; overrides `athenaeum.yaml`'s `auto_recall`). Default: `true` |
@@ -253,6 +257,19 @@ with `401 OAuth authentication is currently not supported`. The pipeline and
 example hooks need a separate console API key — see
 [`docs/recall-architecture.md`](docs/recall-architecture.md#anthropic_api_key-bootstrap-sessionstart)
 for the 1Password bootstrap pattern.
+
+## Configuration
+
+Settings are resolved in the order **env var > `<knowledge_root>/athenaeum.yaml` > built-in default**, so a one-off shell export beats the yaml without requiring an edit. The contradiction-resolver knobs live under a top-level `resolve:` block:
+
+```yaml
+resolve:
+  model: claude-opus-4-7          # ATHENAEUM_RESOLVE_MODEL
+  auto_apply: true                # ATHENAEUM_RESOLVE_AUTO_APPLY (default: true)
+  auto_apply_threshold: 0.90      # ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD, [0.0, 1.0]
+```
+
+When `auto_apply` is on and a proposal's confidence meets or exceeds `auto_apply_threshold`, the pending-question block is auto-flipped to answered with an `Auto-resolved: true` audit-trail tag. See [`docs/auto-resolve.md`](docs/auto-resolve.md) for the full lane, including how to disable, lower the threshold, or reverse an auto-resolution.
 
 ## Data formats
 

--- a/docs/auto-resolve.md
+++ b/docs/auto-resolve.md
@@ -1,0 +1,130 @@
+# Auto-resolving high-confidence contradictions
+
+When the librarian's cheap detector flags two memory snippets as
+contradictory, an Opus-backed resolver weighs them under a source-precedence
+taxonomy and writes a proposal block onto `wiki/_pending_questions.md`.
+Historically every proposal — even at 0.99 confidence — sat in the queue
+until a human flipped the checkbox. The auto-resolve lane (issue #156)
+closes that loop: when the resolver is confident enough, the librarian
+marks the block as answered itself, leaving a clean audit trail.
+
+## What auto-resolve does
+
+For each detected contradiction:
+
+1. The cheap detector flags a pair of snippets.
+2. The resolver (default `claude-opus-4-7`) proposes a winner, action,
+   rationale, and confidence under the precedence taxonomy documented
+   in `docs/conflict-resolution.md`.
+3. If auto-apply is enabled **and** the proposal's confidence is `>=` the
+   configured threshold, the rendered pending-question block is rewritten:
+
+   - `- [ ]` becomes `- [x]`.
+   - An **Answer:** paragraph is inserted with the resolver's rationale.
+   - `**Auto-resolved**: true`, `**Resolver model**: <id>`, and
+     `**Resolver confidence**: <0.NN>` lines follow as the audit trail.
+   - The original `**Proposed resolution** / **Confidence** / **Rationale** /
+     **Source precedence**` block is left in place — the annotation is
+     additive, never destructive.
+
+4. On the next `athenaeum ingest-answers` run, the `[x]` block flows
+   through the standard archive lane: a raw intake file is written to
+   `raw/answers/{TS}-{slug}.md` with `Auto-resolved` carried in the body,
+   and the original block is appended to `_pending_questions_archive.md`.
+
+Low-confidence proposals (below the threshold), the deterministic
+fallback proposal (`confidence == 0.0`), and items the resolver budget
+already exhausted continue to ship as unchecked `[ ]` blocks for human
+review — exactly as before.
+
+## Configuration
+
+Three precedence layers, resolved as **env > yaml > default**:
+
+| Setting | Env var | YAML path | Default |
+|---|---|---|---|
+| Enable auto-apply | `ATHENAEUM_RESOLVE_AUTO_APPLY` | `resolve.auto_apply` | `true` |
+| Confidence threshold | `ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD` | `resolve.auto_apply_threshold` | `0.90` |
+| Resolver model | `ATHENAEUM_RESOLVE_MODEL` | `resolve.model` | `claude-opus-4-7` |
+
+Env-var boolean values accept `true`/`false`, `1`/`0`, `yes`/`no` (case-insensitive). An invalid env value falls through to the yaml/default layers — auto-apply is a behavior knob, not a hard validation surface.
+
+Threshold values outside `[0.0, 1.0]` raise on read so a typo (e.g. `9.0` meant as `0.9`) surfaces immediately instead of silently turning auto-apply off for the rest of the run.
+
+A sample `athenaeum.yaml`:
+
+```yaml
+resolve:
+  model: claude-opus-4-7
+  auto_apply: true
+  auto_apply_threshold: 0.90
+```
+
+## Disabling
+
+Pick whichever scope matches the intent:
+
+- **One-off run:** `ATHENAEUM_RESOLVE_AUTO_APPLY=false athenaeum run ...`
+- **Persistent:** set `resolve.auto_apply: false` in `<knowledge_root>/athenaeum.yaml`.
+
+With auto-apply off, every flagged contradiction lands as an unchecked
+`[ ]` block exactly as in the pre-#156 era.
+
+## Lowering or raising the threshold
+
+The 0.90 default was picked to be conservative — the resolver has to be
+quite sure before the librarian acts on its own. To tolerate more borderline
+auto-resolutions for a single ingest:
+
+```bash
+ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD=0.75 athenaeum run
+```
+
+To require near-certainty across all runs, set the yaml path:
+
+```yaml
+resolve:
+  auto_apply_threshold: 0.98
+```
+
+Anything below the threshold continues to land as an unchecked block for
+human review.
+
+## Reversing an auto-resolution
+
+The auto-resolved block flows through the same `ingest-answers` lane as a
+hand-answered one, so the original block ends up in two durable places:
+
+- `raw/answers/{TS}-{slug}.md` — the raw intake file with the resolver's
+  answer paragraph and `Auto-resolved: true` carried in the body.
+- `_pending_questions_archive.md` — the original block verbatim, newest
+  first.
+
+To reverse:
+
+1. Open the raw answer file under `raw/answers/` and either delete it (if
+   the underlying memory should be left untouched) or edit the answer body
+   to reflect the correct resolution.
+2. If the librarian has already compiled the answer into wiki state, edit
+   the affected wiki page directly — the answer file is intake, not
+   binding state.
+3. The archive entry is append-only and should be left in place as the
+   historical record. If you want to flag the reversal, append a short
+   note under the original block in `_pending_questions_archive.md`.
+
+Because every auto-resolution carries the resolver model id and confidence
+in the answer body, a grep over `raw/answers/` is enough to audit the lane
+end-to-end:
+
+```bash
+grep -l "Auto-resolved" ~/knowledge/raw/answers/
+```
+
+## Related
+
+- [`docs/conflict-resolution.md`](conflict-resolution.md) — the source
+  precedence taxonomy the resolver applies.
+- [`docs/contradiction-detection.md`](contradiction-detection.md) — the
+  cheap detector that gates whether the resolver runs at all.
+- [`docs/provenance-shape.md`](provenance-shape.md) — how `source:` and
+  `field_sources:` feed the resolver's precedence comparison.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "athenaeum"
-version = "0.4.1"
+version = "0.5.0"
 description = "Open source knowledge management pipeline — append-only intake, tiered compilation, configurable schemas"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/athenaeum/__init__.py
+++ b/src/athenaeum/__init__.py
@@ -12,7 +12,7 @@ for the full subcommand list. Internal modules (``contradictions``,
 public surface; their signatures may change between minor releases.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 from athenaeum.init import init_knowledge_dir
 from athenaeum.librarian import discover_raw_files, process_one, rebuild_index, run

--- a/src/athenaeum/answers.py
+++ b/src/athenaeum/answers.py
@@ -36,7 +36,7 @@ import hashlib
 import logging
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -81,6 +81,8 @@ def _unescape_entity(raw: str) -> str:
             out.append(ch)
             i += 1
     return "".join(out)
+
+
 # Checkbox grammar — ``- [ ]`` or ``- [x]`` (case-insensitive on ``x``).
 _CHECKBOX_RE = re.compile(r"^- \[(?P<state>[ xX])\]\s*(?P<question>.*)$")
 # Lines we strip when extracting the user's answer body.
@@ -107,6 +109,11 @@ class PendingQuestion:
     answered: bool
     answer_lines: list[str]
     raw_block: str
+    # Issue #157: entities sharing the same source-memory pair that
+    # got merged into this block instead of getting their own. The
+    # primary entity (header) is NOT included here. Empty by default
+    # — only populated when the dedup path in tier4_escalate fires.
+    also_affects: list[str] = field(default_factory=list)
 
 
 def _make_id(header_line: str, question_text: str) -> str:
@@ -189,9 +196,7 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
         break
 
     if checkbox_idx is None:
-        log.warning(
-            "Skipping block without checkbox line: %r", lines[0][:80]
-        )
+        log.warning("Skipping block without checkbox line: %r", lines[0][:80])
         print(
             f"[warn] skipping pending-question block without `- [ ]` line: "
             f"{lines[0][:80]!r}",
@@ -208,6 +213,7 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
     conflict_type = ""
     description = ""
     answer_lines: list[str] = []
+    also_affects: list[str] = []
 
     # Tracks whether we're still accumulating continuation lines into the
     # description field. A **Description**: line opens the window; the next
@@ -227,6 +233,15 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
             in_description = True
             description = stripped.removeprefix("**Description**:").strip()
             continue
+        if stripped.startswith("**Also affects**:"):
+            # Issue #157: dedup-merge tag. Comma-separated entity names
+            # that share the source-memory pair with this block's primary
+            # entity. Recognized as metadata so it does NOT leak into
+            # answer_lines (which would forge a phantom user answer).
+            in_description = False
+            payload = stripped.removeprefix("**Also affects**:").strip()
+            also_affects = [name.strip() for name in payload.split(",") if name.strip()]
+            continue
         if in_description:
             # Continuation: consume into description until we hit a terminator.
             # Blank line or another ``**Key**:`` tag closes the window.
@@ -240,9 +255,13 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
                 # **Conflict type**, already handled). For unknown keys, treat
                 # the line as answer body.
                 if stripped.startswith("**Conflict type**:"):
-                    conflict_type = stripped.removeprefix(
-                        "**Conflict type**:"
-                    ).strip()
+                    conflict_type = stripped.removeprefix("**Conflict type**:").strip()
+                    continue
+                if stripped.startswith("**Also affects**:"):
+                    payload = stripped.removeprefix("**Also affects**:").strip()
+                    also_affects = [
+                        name.strip() for name in payload.split(",") if name.strip()
+                    ]
                     continue
                 # Unknown **Key**: — treat as answer body.
                 answer_lines.append(raw_line)
@@ -270,6 +289,7 @@ def _parse_block(block_text: str) -> PendingQuestion | None:
         answered=answered,
         answer_lines=answer_lines,
         raw_block=block_text,
+        also_affects=also_affects,
     )
 
 
@@ -302,10 +322,7 @@ def _render_archive_block(pq: PendingQuestion, archived_at: str) -> str:
     Includes the original raw block verbatim plus a trailer noting when the
     answer was ingested. Newest-first is handled by the caller.
     """
-    return (
-        f"{pq.raw_block}\n\n"
-        f"**Archived**: {archived_at}\n"
-    )
+    return f"{pq.raw_block}\n\n" f"**Archived**: {archived_at}\n"
 
 
 def _render_answer_raw_file(pq: PendingQuestion, resolved_at: str) -> str:
@@ -436,9 +453,7 @@ def ingest_answers(pending_path: Path, raw_root: Path) -> int:
                 f"[warn] skipping duplicate archive entry for entity={entity}",
                 file=sys.stderr,
             )
-            log.info(
-                "Skipping duplicate archive entry for entity=%s", entity
-            )
+            log.info("Skipping duplicate archive entry for entity=%s", entity)
             continue
         filtered_archived.append(rendered)
 
@@ -458,10 +473,7 @@ def ingest_answers(pending_path: Path, raw_root: Path) -> int:
             # Split off the header so we can prepend under it.
             _, _, rest = existing_archive.partition("\n")
             combined = (
-                "# Answered Questions\n\n"
-                + new_section
-                + "\n\n---\n\n"
-                + rest.lstrip()
+                "# Answered Questions\n\n" + new_section + "\n\n---\n\n" + rest.lstrip()
             )
         else:
             combined = (
@@ -475,9 +487,7 @@ def ingest_answers(pending_path: Path, raw_root: Path) -> int:
 
     archive_path.write_text(combined, encoding="utf-8")
 
-    log.info(
-        "Ingested %d pending-question answer(s) from %s", ingested, pending_path
-    )
+    log.info("Ingested %d pending-question answer(s) from %s", ingested, pending_path)
     return ingested
 
 

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -523,7 +523,14 @@ def process_one(
 
     # --- Tier 4: Escalation ---
     if escalations:
-        tier4_escalate(escalations, wiki_root / "_pending_questions.md")
+        # wiki_root is <knowledge_root>/wiki; the config sits at the
+        # knowledge_root level. Resolve config here so the auto-apply
+        # lane (issue #156) sees the operator's yaml settings.
+        tier4_escalate(
+            escalations,
+            wiki_root / "_pending_questions.md",
+            config=load_config(wiki_root.parent),
+        )
 
     return result
 

--- a/src/athenaeum/merge.py
+++ b/src/athenaeum/merge.py
@@ -778,6 +778,7 @@ def merge_clusters_to_wiki(
                 entity_name=entry.topic_slug,
                 conflict_type=result.conflict_type or "factual",
                 description=description,
+                proposal=proposal,
             )
         )
 
@@ -940,6 +941,10 @@ def merge_clusters_to_wiki(
         )
 
     if escalations:
-        tier4_escalate(escalations, wiki_root / "_pending_questions.md")
+        tier4_escalate(
+            escalations,
+            wiki_root / "_pending_questions.md",
+            config=resolved_config,
+        )
 
     return entries

--- a/src/athenaeum/models.py
+++ b/src/athenaeum/models.py
@@ -7,7 +7,7 @@ import re
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import ItemsView, Iterator
@@ -228,6 +228,14 @@ class EscalationItem:
     entity_name: str
     conflict_type: str  # "principled" | "ambiguous" | "classification_failed"
     description: str
+    # Optional resolver proposal threaded through from
+    # :func:`athenaeum.resolutions.propose_resolution`. When present and
+    # confidence >= the configured threshold, :func:`tier4_escalate`
+    # auto-applies the resolution to the rendered block. Typed as
+    # ``Any`` to avoid a circular import (resolutions.py imports
+    # AutoMemoryFile from this module). The runtime type is
+    # ``athenaeum.resolutions.ResolutionProposal | None``.
+    proposal: Any = None
 
 
 @dataclass

--- a/src/athenaeum/resolutions.py
+++ b/src/athenaeum/resolutions.py
@@ -75,6 +75,16 @@ DEFAULT_RESOLVE_MODEL = "claude-opus-4-7"
 # proposal (degraded mode). Keeps cost predictable on a noisy run.
 DEFAULT_RESOLVE_MAX_PER_RUN = 50
 
+# Auto-apply lane (issue #156): when the resolver returns a high-confidence
+# proposal, mark the pending-question block as resolved in-place so the
+# user doesn't have to act. Default ON — the whole point of the lane —
+# with a conservative 0.90 confidence floor.
+DEFAULT_AUTO_APPLY = True
+DEFAULT_AUTO_APPLY_THRESHOLD = 0.90
+
+_TRUTHY = frozenset(("true", "1", "yes"))
+_FALSY = frozenset(("false", "0", "no"))
+
 # Action taxonomy locked here — :mod:`athenaeum.merge` and the renderer
 # both branch on these literals.
 ResolverWinner = Literal["a", "b", "merge", "neither"]
@@ -196,8 +206,88 @@ _JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 # ---------------------------------------------------------------------------
 
 
-def _get_model() -> str:
-    return os.environ.get("ATHENAEUM_RESOLVE_MODEL", DEFAULT_RESOLVE_MODEL)
+def _get_model(config: dict[str, Any] | None = None) -> str:
+    """Resolve the resolver model from env > config > default.
+
+    Mirrors the env > yaml > default precedence used elsewhere. Env wins
+    so an operator can swap models for a single run without editing the
+    yaml.
+    """
+    env = os.environ.get("ATHENAEUM_RESOLVE_MODEL")
+    if env:
+        return env
+    if isinstance(config, dict):
+        resolve_cfg = config.get("resolve")
+        if isinstance(resolve_cfg, dict):
+            raw = resolve_cfg.get("model")
+            if isinstance(raw, str) and raw.strip():
+                return raw.strip()
+    return DEFAULT_RESOLVE_MODEL
+
+
+def resolve_auto_apply(config: dict[str, Any] | None = None) -> bool:
+    """Resolve the auto-apply toggle from env > config > default.
+
+    Env values accepted (case-insensitive): ``true``/``false``,
+    ``1``/``0``, ``yes``/``no``. Invalid env values fall through to the
+    yaml/default layers rather than raising — auto-apply is a behavior
+    knob, not a hard validation surface.
+    """
+    env = os.environ.get("ATHENAEUM_RESOLVE_AUTO_APPLY")
+    if env is not None:
+        norm = env.strip().lower()
+        if norm in _TRUTHY:
+            return True
+        if norm in _FALSY:
+            return False
+    if isinstance(config, dict):
+        resolve_cfg = config.get("resolve")
+        if isinstance(resolve_cfg, dict):
+            raw = resolve_cfg.get("auto_apply")
+            if isinstance(raw, bool):
+                return raw
+    return DEFAULT_AUTO_APPLY
+
+
+def resolve_auto_apply_threshold(config: dict[str, Any] | None = None) -> float:
+    """Resolve the auto-apply confidence threshold from env > config > default.
+
+    Must land in ``[0.0, 1.0]``. An out-of-range env or yaml value raises
+    :class:`ValueError` so operators get a loud signal — silently clamping
+    a typo (e.g. ``9.0`` meant as ``0.9``) would auto-apply nothing for the
+    rest of the run with no obvious cause.
+    """
+    env = os.environ.get("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD")
+    if env is not None:
+        try:
+            value = float(env)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD={env!r} "
+                f"out of range [0.0, 1.0]"
+            ) from exc
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(
+                f"ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD={env!r} "
+                f"out of range [0.0, 1.0]"
+            )
+        return value
+    if isinstance(config, dict):
+        resolve_cfg = config.get("resolve")
+        if isinstance(resolve_cfg, dict) and "auto_apply_threshold" in resolve_cfg:
+            raw = resolve_cfg.get("auto_apply_threshold")
+            try:
+                value = float(raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"resolve.auto_apply_threshold={raw!r} " f"out of range [0.0, 1.0]"
+                ) from exc
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(
+                    f"resolve.auto_apply_threshold={raw!r} " f"out of range [0.0, 1.0]"
+                )
+            return value
+    return DEFAULT_AUTO_APPLY_THRESHOLD
 
 
 def resolve_max_per_run(config: dict[str, Any] | None = None) -> int:
@@ -388,6 +478,7 @@ def propose_resolution(
     detector_result: ContradictionResult,
     members: list[AutoMemoryFile],
     client: "anthropic.Anthropic | None",
+    config: dict[str, Any] | None = None,
 ) -> ResolutionProposal:
     """Run one resolver call against a detected contradiction.
 
@@ -421,7 +512,7 @@ def propose_resolution(
 
     try:
         response = client.messages.create(
-            model=_get_model(),
+            model=_get_model(config),
             max_tokens=1024,
             system=_RESOLVE_SYSTEM,
             messages=[{"role": "user", "content": user_msg}],
@@ -473,3 +564,93 @@ def render_proposal_block(proposal: ResolutionProposal) -> str:
         f"**Rationale**: {proposal.rationale or '(none provided)'}\n"
         f"**Source precedence**: {precedence}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Auto-apply lane (issue #156)
+# ---------------------------------------------------------------------------
+
+
+# Matches an unchecked checkbox line written by ``tier4_escalate``.
+_UNCHECKED_RE = re.compile(r"^(?P<prefix>- \[) \](?P<rest>.*)$", re.MULTILINE)
+
+# Detects an already-auto-resolved block so re-applying is a no-op.
+_AUTO_RESOLVED_MARKER = "**Auto-resolved**: true"
+
+
+def apply_auto_resolution(
+    block_text: str,
+    proposal: ResolutionProposal,
+    *,
+    model: str | None = None,
+) -> str:
+    """Mark a pending-question block as auto-resolved in place.
+
+    Flips the leading ``- [ ]`` to ``- [x]`` and inserts an answer
+    paragraph between the checkbox and the ``**Conflict type**:`` line
+    so the existing :mod:`athenaeum.answers` parser sees it as a real
+    user answer body. The four ``**Proposed resolution**`` /
+    ``**Confidence**`` / ``**Rationale**`` / ``**Source precedence**``
+    keys already in the block are left untouched — this annotation is
+    additive.
+
+    Idempotent: if ``block_text`` already carries the auto-resolved
+    marker, the input is returned unchanged.
+
+    Args:
+        block_text: One pending-question block as written by
+            :func:`athenaeum.tiers.tier4_escalate`.
+        proposal: The :class:`ResolutionProposal` to attribute. Confidence
+            and rationale are surfaced verbatim.
+        model: Resolver model id used for the proposal. Defaults to the
+            currently configured model — callers in :mod:`athenaeum.tiers`
+            thread their resolved id through so the audit trail names
+            the actual model that was called, not a fresh ``_get_model``
+            lookup (which can differ when env state has changed).
+
+    Returns:
+        The rewritten block text.
+    """
+    if _AUTO_RESOLVED_MARKER in block_text:
+        return block_text
+
+    model_id = model or _get_model()
+    answer_block = (
+        f"**Answer:** {proposal.rationale or '(none provided)'}\n"
+        f"**Auto-resolved**: true\n"
+        f"**Resolver model**: {model_id}\n"
+        f"**Resolver confidence**: {proposal.confidence:.2f}"
+    )
+
+    lines = block_text.splitlines()
+    out: list[str] = []
+    inserted = False
+    flipped = False
+    for line in lines:
+        if not flipped:
+            m = _UNCHECKED_RE.match(line)
+            if m:
+                out.append(f"- [x]{m.group('rest')}")
+                flipped = True
+                continue
+        if not inserted and line.startswith("**Conflict type**:"):
+            out.append(answer_block)
+            out.append("")
+            out.append(line)
+            inserted = True
+            continue
+        out.append(line)
+
+    if not flipped:
+        # No `- [ ]` to flip — block was already answered or malformed.
+        # Return unchanged rather than corrupting it.
+        return block_text
+
+    if not inserted:
+        # No `**Conflict type**:` line — append the answer block at the
+        # end so the marker still lands in the file (the round-trip test
+        # exercises the standard case where Conflict type IS present).
+        out.append("")
+        out.append(answer_block)
+
+    return "\n".join(out)

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -15,6 +15,7 @@ import os
 import re
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import anthropic
 
@@ -518,16 +519,48 @@ def _question_from_description(
     return f"Resolve {conflict_type} conflict for {entity_name}"
 
 
-def tier4_escalate(items: list[EscalationItem], pending_path: Path) -> None:
+def tier4_escalate(
+    items: list[EscalationItem],
+    pending_path: Path,
+    *,
+    config: dict[str, Any] | None = None,
+) -> None:
     """Append escalation items to ``_pending_questions.md``.
 
     Each block is rendered with a leading checkbox line directly under the
     header so the user (or the ``resolve_question`` MCP tool) can flip
     ``[ ]`` -> ``[x]`` to mark an answer; ``athenaeum ingest-answers`` then
     converts the block to a raw intake file. See ``athenaeum.answers``.
+
+    Issue #156 — auto-apply lane: when ``config`` enables auto-apply and
+    an item carries a :class:`~athenaeum.resolutions.ResolutionProposal`
+    whose confidence meets the threshold, the rendered block is flipped
+    to ``- [x]`` with an answer paragraph attributing the resolver. The
+    deterministic-fallback proposal has ``confidence == 0.0`` so the
+    threshold gate naturally excludes it — no extra guard needed.
+    Callers that pass ``config=None`` (test fixtures, legacy callers)
+    get the pre-#156 behavior: every block is written as ``- [ ]``.
     """
     if not items:
         return
+
+    # Late-import to avoid a hard module-load cycle with resolutions.py
+    # (resolutions imports AutoMemoryFile from models, models is imported
+    # here at module load via the top-of-file import block).
+    from athenaeum.resolutions import _get_model as _resolver_model
+    from athenaeum.resolutions import (
+        apply_auto_resolution,
+        resolve_auto_apply,
+        resolve_auto_apply_threshold,
+    )
+
+    auto_apply_enabled = resolve_auto_apply(config) if config is not None else False
+    threshold = (
+        resolve_auto_apply_threshold(config)
+        if config is not None
+        else 1.1  # unreachable when config is None — disables auto-apply
+    )
+    resolver_model_id = _resolver_model(config) if config is not None else None
 
     today = date.today().isoformat()
     sections: list[str] = []
@@ -541,12 +574,26 @@ def tier4_escalate(items: list[EscalationItem], pending_path: Path) -> None:
         # should survive in storage untouched; the parser anchors to the
         # final ")\n" to tolerate parens inside refs.
         escaped_entity = item.entity_name.replace("\\", "\\\\").replace('"', '\\"')
-        sections.append(
+        block = (
             f'## [{today}] Entity: "{escaped_entity}" (from {item.raw_ref})\n'
             f"- [ ] {question}\n\n"
             f"**Conflict type**: {item.conflict_type}\n"
             f"**Description**: {item.description}\n"
         )
+        proposal = getattr(item, "proposal", None)
+        if (
+            auto_apply_enabled
+            and proposal is not None
+            and getattr(proposal, "confidence", 0.0) >= threshold
+        ):
+            block = apply_auto_resolution(block, proposal, model=resolver_model_id)
+            log.info(
+                "Auto-resolved escalation for entity=%s (confidence=%.2f >= %.2f)",
+                item.entity_name,
+                proposal.confidence,
+                threshold,
+            )
+        sections.append(block)
 
     new_content = "\n---\n\n".join(sections)
 

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -696,9 +696,27 @@ def tier4_escalate(
     batch_index: dict[tuple[str, ...], int] = {}
     # File-merge plan: original raw_block -> list of entity names to append.
     file_merges: dict[str, list[str]] = {}
+    # Per-key best proposal accumulator. auto-apply uses the
+    # highest-confidence proposal seen for this source-pair key in this batch
+    # (regression fix: previously a low-conf primary item could swallow a
+    # later high-conf collapsing item's proposal and leave the block [ ]).
+    best_proposal: dict[tuple[str, ...], Any] = {}
+
+    def _consider_proposal(k: tuple[str, ...] | None, item_obj: Any) -> None:
+        if k is None:
+            return
+        prop = getattr(item_obj, "proposal", None)
+        if prop is None:
+            return
+        current = best_proposal.get(k)
+        if current is None or getattr(prop, "confidence", 0.0) > getattr(
+            current, "confidence", 0.0
+        ):
+            best_proposal[k] = prop
 
     for item in items:
         key = _pair_key_from_description(item.description) if dedup_enabled else None
+        _consider_proposal(key, item)
 
         # Path A: pair already lives in the file as an open block.
         if key is not None and key in open_index:
@@ -739,6 +757,31 @@ def tier4_escalate(
             batch_index[key] = len(sections)
         sections.append(block)
 
+    # Path B post-pass: any in-batch section that collapsed siblings needs an
+    # auto-apply consideration using the best proposal for its key (the
+    # primary item's proposal may have been below threshold while a later
+    # collapsing item's was above). apply_auto_resolution is idempotent via
+    # its _AUTO_RESOLVED_MARKER check, so already-applied blocks are no-ops.
+    if auto_apply_enabled:
+        for key, slot in batch_index.items():
+            best = best_proposal.get(key)
+            if best is None:
+                continue
+            if getattr(best, "confidence", 0.0) < threshold:
+                continue
+            updated = apply_auto_resolution(
+                sections[slot], best, model=resolver_model_id
+            )
+            if updated != sections[slot]:
+                log.info(
+                    "Auto-resolved batched escalation key=%s "
+                    "(best confidence=%.2f >= %.2f)",
+                    key,
+                    best.confidence,
+                    threshold,
+                )
+            sections[slot] = updated
+
     # Apply file-merges to the existing pending text (if any).
     if pending_path.exists():
         existing_text = pending_path.read_text(encoding="utf-8")
@@ -746,10 +789,34 @@ def tier4_escalate(
         existing_text = ""
 
     if file_merges:
+        # Build a reverse map: raw_block -> key, so we can look up the
+        # best proposal for each block being merged into.
+        block_to_key: dict[str, tuple[str, ...]] = {
+            raw_block: k for k, raw_block in open_index.items()
+        }
         for original_block, new_entities in file_merges.items():
             updated_block = original_block
             for ent in new_entities:
                 updated_block = _append_also_affects(updated_block, ent)
+            # Path A auto-apply: if the open block is still [ ] and this
+            # batch carries a best proposal that meets the threshold,
+            # rewrite it as [x]. Cross-batch case.
+            if auto_apply_enabled:
+                key_for_block = block_to_key.get(original_block)
+                best = best_proposal.get(key_for_block) if key_for_block else None
+                if best is not None and getattr(best, "confidence", 0.0) >= threshold:
+                    rewritten = apply_auto_resolution(
+                        updated_block, best, model=resolver_model_id
+                    )
+                    if rewritten != updated_block:
+                        log.info(
+                            "Auto-resolved cross-batch escalation key=%s "
+                            "(best confidence=%.2f >= %.2f)",
+                            key_for_block,
+                            best.confidence,
+                            threshold,
+                        )
+                    updated_block = rewritten
             # Replace verbatim — raw_block came from parse, so it lives
             # inside existing_text byte-for-byte. Guard with `count=1` to
             # avoid clobbering text that happens to repeat.

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -9,6 +9,7 @@ Tier 4: Human escalation
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -519,6 +520,108 @@ def _question_from_description(
     return f"Resolve {conflict_type} conflict for {entity_name}"
 
 
+def _pair_key_from_description(description: str) -> tuple[str, ...] | None:
+    """Compute the dedup key for an escalation description (issue #157).
+
+    Primary key: sorted tuple of members from a ``Members involved:`` line
+    (works for ``contradictions`` runs over sourced auto-memory passages).
+
+    Fallback key: SHA-1 prefix over the two ``Passage N:`` blobs from the
+    description (works for runs where the detector lacked source attribution).
+
+    Returns ``None`` when neither key can be derived — caller should always
+    append in that case (no dedup possible without a stable key).
+    """
+    members: list[str] | None = None
+    passages: list[str] = []
+    for raw in description.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("Members involved:"):
+            payload = stripped.removeprefix("Members involved:").strip()
+            members = [m.strip() for m in payload.split(",") if m.strip()]
+        elif stripped.startswith("Passage ") and ":" in stripped:
+            # Capture body after the first colon, regardless of digit.
+            _, _, body = stripped.partition(":")
+            body = body.strip()
+            if body:
+                passages.append(body)
+    if members and len(members) >= 2:
+        return tuple(sorted(set(members)))
+    if len(passages) >= 2:
+        # Use the first two passages (typical contradiction shape); join
+        # with a stable separator so passage order does NOT change the key
+        # — sort to make (P1,P2) and (P2,P1) collapse.
+        norm = sorted(p.strip() for p in passages[:2])
+        h = hashlib.sha1((norm[0] + "\n---\n" + norm[1]).encode("utf-8")).hexdigest()[
+            :16
+        ]
+        return ("__passage_hash__", h)
+    return None
+
+
+def _append_also_affects(block: str, entity_name: str) -> str:
+    """Merge ``entity_name`` into a block's ``**Also affects**:`` line.
+
+    Creates the line immediately AFTER the ``**Description**:`` block (or
+    after ``**Conflict type**:`` if no description) when missing. Idempotent
+    — never lists the same entity twice and never lists the primary entity.
+    Preserves all other content (proposal block, auto-resolved checkbox,
+    answer body) verbatim.
+    """
+    # Extract primary entity from the header to avoid self-listing.
+    lines = block.splitlines()
+    primary_entity = ""
+    if lines and lines[0].startswith("## "):
+        m = re.search(r'Entity:\s*"((?:[^"\\]|\\.)*)"', lines[0])
+        if m:
+            primary_entity = m.group(1).replace("\\\\", "\\").replace('\\"', '"')
+    if entity_name == primary_entity:
+        return block
+
+    # Find existing **Also affects** line.
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("**Also affects**:"):
+            payload = line.split(":", 1)[1].strip()
+            existing = [n.strip() for n in payload.split(",") if n.strip()]
+            if entity_name in existing or entity_name == primary_entity:
+                return block
+            existing.append(entity_name)
+            lines[idx] = "**Also affects**: " + ", ".join(existing)
+            return "\n".join(lines) + ("\n" if block.endswith("\n") else "")
+
+    # No existing line — insert after the description block. The description
+    # may span multiple lines; we insert right before the FIRST blank line
+    # that follows **Description**:, OR before the proposal block / answer
+    # body if there is no blank gap. Falling back: append at end-of-block.
+    desc_idx: int | None = None
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("**Description**:"):
+            desc_idx = idx
+            break
+    insert_at = len(lines)
+    if desc_idx is not None:
+        # Walk forward through continuation lines until blank or **Key**.
+        i = desc_idx + 1
+        while i < len(lines):
+            s = lines[i].strip()
+            if s == "" or s.startswith("**"):
+                insert_at = i
+                break
+            i += 1
+        else:
+            insert_at = i
+    else:
+        # No description — insert after conflict type if present, else end.
+        for idx, line in enumerate(lines):
+            if line.strip().startswith("**Conflict type**:"):
+                insert_at = idx + 1
+                break
+
+    new_line = f"**Also affects**: {entity_name}"
+    lines.insert(insert_at, new_line)
+    return "\n".join(lines) + ("\n" if block.endswith("\n") else "")
+
+
 def tier4_escalate(
     items: list[EscalationItem],
     pending_path: Path,
@@ -562,17 +665,56 @@ def tier4_escalate(
     )
     resolver_model_id = _resolver_model(config) if config is not None else None
 
+    # Issue #157: dedup escalations by source-memory pair (Members involved
+    # tuple, or sha1(passages) fallback). Default ON; escape hatch via the
+    # ATHENAEUM_TIER4_DEDUP env var so a downstream user can force the
+    # legacy always-append behavior.
+    dedup_enabled = os.environ.get(
+        "ATHENAEUM_TIER4_DEDUP", "true"
+    ).strip().lower() not in ("false", "0", "no", "off")
+
+    # Build the open-pair index from the file's currently-open ([ ]) blocks.
+    # Archived/[x] blocks are deliberately excluded — a previously-answered
+    # pair that re-fires deserves a fresh block (resurrection case).
+    from athenaeum.answers import parse_pending_questions
+
+    open_index: dict[tuple[str, ...], str] = {}
+    if dedup_enabled and pending_path.exists():
+        for pq in parse_pending_questions(pending_path):
+            if pq.answered:
+                continue
+            key = _pair_key_from_description(pq.description)
+            if key is not None and key not in open_index:
+                # First-seen wins — if the file already has duplicates from a
+                # pre-#157 run, only the first is merged into.
+                open_index[key] = pq.raw_block
+
     today = date.today().isoformat()
     sections: list[str] = []
+    # In-batch pair index: key -> position in `sections`. Items in the same
+    # batch sharing a key collapse before the file write happens.
+    batch_index: dict[tuple[str, ...], int] = {}
+    # File-merge plan: original raw_block -> list of entity names to append.
+    file_merges: dict[str, list[str]] = {}
+
     for item in items:
+        key = _pair_key_from_description(item.description) if dedup_enabled else None
+
+        # Path A: pair already lives in the file as an open block.
+        if key is not None and key in open_index:
+            file_merges.setdefault(open_index[key], []).append(item.entity_name)
+            continue
+
+        # Path B: pair already rendered earlier in THIS batch.
+        if key is not None and key in batch_index:
+            slot = batch_index[key]
+            sections[slot] = _append_also_affects(sections[slot], item.entity_name)
+            continue
+
+        # Path C: brand new — render and append.
         question = _question_from_description(
             item.description, item.entity_name, item.conflict_type
         )
-        # Escape backslashes first, then quotes — paired with the parser's
-        # unescape logic in athenaeum.answers so entity names containing
-        # double quotes round-trip cleanly. raw_ref is NOT escaped: paths
-        # should survive in storage untouched; the parser anchors to the
-        # final ")\n" to tolerate parens inside refs.
         escaped_entity = item.entity_name.replace("\\", "\\\\").replace('"', '\\"')
         block = (
             f'## [{today}] Entity: "{escaped_entity}" (from {item.raw_ref})\n'
@@ -593,18 +735,53 @@ def tier4_escalate(
                 proposal.confidence,
                 threshold,
             )
+        if key is not None:
+            batch_index[key] = len(sections)
         sections.append(block)
 
-    new_content = "\n---\n\n".join(sections)
-
+    # Apply file-merges to the existing pending text (if any).
     if pending_path.exists():
-        existing = pending_path.read_text(encoding="utf-8")
-        if existing.strip():
-            new_content = existing.rstrip() + "\n\n---\n\n" + new_content
-        else:
-            new_content = "# Pending Questions\n\n" + new_content
+        existing_text = pending_path.read_text(encoding="utf-8")
     else:
-        new_content = "# Pending Questions\n\n" + new_content
+        existing_text = ""
 
-    pending_path.write_text(new_content + "\n", encoding="utf-8")
-    log.info("Escalated %d items to %s", len(items), pending_path)
+    if file_merges:
+        for original_block, new_entities in file_merges.items():
+            updated_block = original_block
+            for ent in new_entities:
+                updated_block = _append_also_affects(updated_block, ent)
+            # Replace verbatim — raw_block came from parse, so it lives
+            # inside existing_text byte-for-byte. Guard with `count=1` to
+            # avoid clobbering text that happens to repeat.
+            if original_block in existing_text:
+                existing_text = existing_text.replace(original_block, updated_block, 1)
+            else:
+                # Should not happen — log and skip the merge for this pair.
+                log.warning(
+                    "tier4 dedup: open block disappeared between parse and "
+                    "rewrite; dropping merge for entities=%s",
+                    new_entities,
+                )
+
+    # Assemble the final file content.
+    if sections:
+        new_section_text = "\n---\n\n".join(sections)
+        if existing_text.strip():
+            new_content = existing_text.rstrip() + "\n\n---\n\n" + new_section_text
+        else:
+            new_content = "# Pending Questions\n\n" + new_section_text
+        pending_path.write_text(new_content + "\n", encoding="utf-8")
+    elif file_merges:
+        # Only file-merges happened — rewrite existing text in place.
+        pending_path.write_text(
+            existing_text if existing_text.endswith("\n") else existing_text + "\n",
+            encoding="utf-8",
+        )
+
+    log.info(
+        "Escalated %d item(s) to %s (new_blocks=%d, file_merges=%d)",
+        len(items),
+        pending_path,
+        len(sections),
+        sum(len(v) for v in file_merges.values()),
+    )

--- a/tests/test_auto_resolve.py
+++ b/tests/test_auto_resolve.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the issue #156 auto-apply lane.
+
+Covers:
+
+- ``resolve_auto_apply`` env > yaml > default precedence.
+- ``resolve_auto_apply_threshold`` env > yaml > default + range validation.
+- ``_get_model`` precedence (env > yaml > default).
+- ``apply_auto_resolution`` idempotency.
+- Round-trip: an auto-resolved block survives ``ingest_answers`` and the
+  ``Auto-resolved`` marker lands in the raw answer file.
+- Integration: ``tier4_escalate`` flips only high-confidence (>= threshold)
+  blocks; low-confidence stay ``- [ ]``. Exact-threshold matches are inclusive.
+- ``auto_apply=False`` short-circuits even at confidence 1.0.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athenaeum.answers import ingest_answers
+from athenaeum.models import EscalationItem
+from athenaeum.resolutions import (
+    DEFAULT_AUTO_APPLY,
+    DEFAULT_AUTO_APPLY_THRESHOLD,
+    DEFAULT_RESOLVE_MODEL,
+    ResolutionProposal,
+    _get_model,
+    apply_auto_resolution,
+    resolve_auto_apply,
+    resolve_auto_apply_threshold,
+)
+from athenaeum.tiers import tier4_escalate
+
+
+def _make_proposal(
+    confidence: float, rationale: str = "user > unsourced"
+) -> ResolutionProposal:
+    return ResolutionProposal(
+        recommended_winner="a",
+        action="keep_a",
+        rationale=rationale,
+        confidence=confidence,
+        source_precedence_used=["a:user > b:unsourced"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config resolution — resolve_auto_apply
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAutoApply:
+    def test_env_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY", "true")
+        assert resolve_auto_apply({"resolve": {"auto_apply": False}}) is True
+
+    def test_env_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY", "false")
+        assert resolve_auto_apply({"resolve": {"auto_apply": True}}) is False
+
+    def test_env_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY", "YES")
+        assert resolve_auto_apply(None) is True
+
+    def test_env_invalid_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY", "maybe")
+        # Falls through to yaml setting.
+        assert resolve_auto_apply({"resolve": {"auto_apply": False}}) is False
+
+    def test_yaml_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY", raising=False)
+        assert resolve_auto_apply({"resolve": {"auto_apply": True}}) is True
+
+    def test_yaml_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY", raising=False)
+        assert resolve_auto_apply({"resolve": {"auto_apply": False}}) is False
+
+    def test_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY", raising=False)
+        assert resolve_auto_apply(None) is DEFAULT_AUTO_APPLY is True
+
+
+# ---------------------------------------------------------------------------
+# Config resolution — resolve_auto_apply_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAutoApplyThreshold:
+    def test_env_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "0.95")
+        assert resolve_auto_apply_threshold(None) == 0.95
+
+    def test_env_out_of_range_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "1.5")
+        with pytest.raises(ValueError, match="ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD"):
+            resolve_auto_apply_threshold(None)
+
+    def test_env_non_numeric_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "abc")
+        with pytest.raises(ValueError, match="ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD"):
+            resolve_auto_apply_threshold(None)
+
+    def test_yaml_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", raising=False)
+        cfg = {"resolve": {"auto_apply_threshold": 0.85}}
+        assert resolve_auto_apply_threshold(cfg) == 0.85
+
+    def test_yaml_out_of_range_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", raising=False)
+        cfg = {"resolve": {"auto_apply_threshold": 2.0}}
+        with pytest.raises(ValueError, match="resolve.auto_apply_threshold"):
+            resolve_auto_apply_threshold(cfg)
+
+    def test_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", raising=False)
+        assert (
+            resolve_auto_apply_threshold(None) == DEFAULT_AUTO_APPLY_THRESHOLD == 0.90
+        )
+
+
+# ---------------------------------------------------------------------------
+# _get_model precedence
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelPrecedence:
+    def test_env_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_MODEL", "env-model")
+        cfg = {"resolve": {"model": "yaml-model"}}
+        assert _get_model(cfg) == "env-model"
+
+    def test_yaml_wins_over_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        cfg = {"resolve": {"model": "yaml-model"}}
+        assert _get_model(cfg) == "yaml-model"
+
+    def test_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        assert _get_model(None) == DEFAULT_RESOLVE_MODEL
+
+
+# ---------------------------------------------------------------------------
+# apply_auto_resolution idempotency + shape
+# ---------------------------------------------------------------------------
+
+
+_BLOCK = (
+    '## [2026-05-23] Entity: "Tristan" (from wiki/tristan.md)\n'
+    "- [ ] Is Tristan German or American?\n"
+    "\n"
+    "**Conflict type**: factual\n"
+    "**Description**: Snippet A says German; snippet B says American.\n"
+)
+
+
+class TestApplyAutoResolution:
+    def test_flips_checkbox(self) -> None:
+        out = apply_auto_resolution(_BLOCK, _make_proposal(0.93), model="m-1")
+        assert "- [x] Is Tristan German or American?" in out
+        assert "- [ ] Is Tristan German or American?" not in out
+
+    def test_inserts_answer_block_before_conflict_type(self) -> None:
+        out = apply_auto_resolution(_BLOCK, _make_proposal(0.93), model="m-1")
+        answer_pos = out.index("**Answer:**")
+        conflict_pos = out.index("**Conflict type**:")
+        assert answer_pos < conflict_pos
+        assert "**Auto-resolved**: true" in out
+        assert "**Resolver model**: m-1" in out
+        assert "**Resolver confidence**: 0.93" in out
+
+    def test_idempotent(self) -> None:
+        once = apply_auto_resolution(_BLOCK, _make_proposal(0.93), model="m-1")
+        twice = apply_auto_resolution(once, _make_proposal(0.93), model="m-1")
+        assert once == twice
+
+    def test_no_unchecked_returns_unchanged(self) -> None:
+        already = _BLOCK.replace("- [ ]", "- [x]")
+        out = apply_auto_resolution(already, _make_proposal(0.93), model="m-1")
+        assert out == already
+
+
+# ---------------------------------------------------------------------------
+# Round-trip through ingest_answers
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_auto_resolved_block_survives_ingest(self, tmp_path: Path) -> None:
+        wiki = tmp_path / "wiki"
+        wiki.mkdir()
+        pending = wiki / "_pending_questions.md"
+
+        item = EscalationItem(
+            raw_ref="wiki/tristan.md",
+            entity_name="Tristan",
+            conflict_type="factual",
+            description="A says German; B says American.",
+            proposal=_make_proposal(0.95, rationale="user direct overrides unsourced"),
+        )
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
+        tier4_escalate([item], pending, config=cfg)
+
+        written = pending.read_text(encoding="utf-8")
+        assert "- [x]" in written
+        assert "**Auto-resolved**: true" in written
+
+        # Now ingest — the [x] block should be archived and a raw answer
+        # file should be written.
+        raw_root = tmp_path / "raw"
+        n = ingest_answers(pending, raw_root)
+        assert n == 1
+
+        answer_files = list((raw_root / "answers").glob("*.md"))
+        assert len(answer_files) == 1
+        body = answer_files[0].read_text(encoding="utf-8")
+        assert "Auto-resolved" in body
+        assert "Resolver confidence" in body
+
+        # Archive carries the original block.
+        archive = (pending.parent / "_pending_questions_archive.md").read_text(
+            encoding="utf-8"
+        )
+        assert "Auto-resolved" in archive
+
+
+# ---------------------------------------------------------------------------
+# tier4_escalate integration — high-conf flipped, low-conf untouched
+# ---------------------------------------------------------------------------
+
+
+class TestTier4Integration:
+    def test_mixed_confidence(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
+        items = [
+            EscalationItem(
+                raw_ref="wiki/high.md",
+                entity_name="HighConfEntity",
+                conflict_type="factual",
+                description="conflict A vs B",
+                proposal=_make_proposal(0.95),
+            ),
+            EscalationItem(
+                raw_ref="wiki/low.md",
+                entity_name="LowConfEntity",
+                conflict_type="factual",
+                description="conflict C vs D",
+                proposal=_make_proposal(0.50),
+            ),
+        ]
+        tier4_escalate(items, pending, config=cfg)
+        text = pending.read_text(encoding="utf-8")
+
+        # High-conf block flipped.
+        high_idx = text.index("HighConfEntity")
+        low_idx = text.index("LowConfEntity")
+        high_block = text[high_idx:low_idx]
+        low_block = text[low_idx:]
+        assert "- [x]" in high_block
+        assert "**Auto-resolved**: true" in high_block
+
+        # Low-conf untouched.
+        assert "- [ ]" in low_block
+        assert "**Auto-resolved**" not in low_block
+
+    def test_exact_threshold_inclusive(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
+        item = EscalationItem(
+            raw_ref="wiki/edge.md",
+            entity_name="EdgeEntity",
+            conflict_type="factual",
+            description="exactly at threshold",
+            proposal=_make_proposal(0.90),
+        )
+        tier4_escalate([item], pending, config=cfg)
+        text = pending.read_text(encoding="utf-8")
+        assert "- [x]" in text
+        assert "**Auto-resolved**: true" in text
+
+    def test_auto_apply_disabled_short_circuit(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": False, "auto_apply_threshold": 0.90}}
+        item = EscalationItem(
+            raw_ref="wiki/highest.md",
+            entity_name="HighestEntity",
+            conflict_type="factual",
+            description="confidence one point oh",
+            proposal=_make_proposal(1.0),
+        )
+        tier4_escalate([item], pending, config=cfg)
+        text = pending.read_text(encoding="utf-8")
+        assert "- [ ]" in text
+        assert "**Auto-resolved**" not in text
+
+    def test_no_config_no_auto_apply(self, tmp_path: Path) -> None:
+        """Legacy callers (config=None) get pre-#156 behavior."""
+        pending = tmp_path / "_pending_questions.md"
+        item = EscalationItem(
+            raw_ref="wiki/legacy.md",
+            entity_name="LegacyEntity",
+            conflict_type="factual",
+            description="d",
+            proposal=_make_proposal(0.99),
+        )
+        tier4_escalate([item], pending)
+        text = pending.read_text(encoding="utf-8")
+        assert "- [ ]" in text
+        assert "**Auto-resolved**" not in text

--- a/tests/test_tier4_dedup.py
+++ b/tests/test_tier4_dedup.py
@@ -1,0 +1,354 @@
+"""Tests for tier4 source-memory-pair dedup (issue #157).
+
+`tier4_escalate` collapses escalations that share a source-memory pair
+(``Members involved:`` tuple or, when absent, a passage-hash fallback)
+into a single block annotated with ``**Also affects**: ...``. Archived
+blocks are NOT in the open set, so a previously-resolved pair that
+re-fires gets a fresh block (resurrection).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athenaeum.answers import ingest_answers, parse_pending_questions
+from athenaeum.models import EscalationItem
+from athenaeum.tiers import (
+    _append_also_affects,
+    _pair_key_from_description,
+    tier4_escalate,
+)
+
+
+def _desc_with_members(a: str, b: str, extra: str = "") -> str:
+    """Build a description that mimics merge.py's contradictions output."""
+    parts = []
+    if extra:
+        parts.append(extra)
+    parts.append("Passage 1: foo")
+    parts.append("Passage 2: bar")
+    parts.append(f"Members involved: {a}, {b}")
+    return "\n".join(parts)
+
+
+def _desc_unsourced(p1: str, p2: str) -> str:
+    """Description with passages but no Members involved line."""
+    return f"Rationale text.\nPassage 1: {p1}\nPassage 2: {p2}"
+
+
+def _item(entity: str, description: str, raw_ref: str = "wiki/x.md") -> EscalationItem:
+    return EscalationItem(
+        raw_ref=raw_ref,
+        entity_name=entity,
+        conflict_type="principled",
+        description=description,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pair-key helper
+# ---------------------------------------------------------------------------
+
+
+class TestPairKey:
+    def test_members_order_independent(self) -> None:
+        k1 = _pair_key_from_description(_desc_with_members("a.md", "b.md"))
+        k2 = _pair_key_from_description(_desc_with_members("b.md", "a.md"))
+        assert k1 == k2
+        assert k1 == ("a.md", "b.md")
+
+    def test_no_members_uses_passage_hash(self) -> None:
+        d = _desc_unsourced("foo", "bar")
+        k = _pair_key_from_description(d)
+        assert k is not None
+        assert k[0] == "__passage_hash__"
+
+    def test_passage_hash_stable(self) -> None:
+        k1 = _pair_key_from_description(_desc_unsourced("foo", "bar"))
+        k2 = _pair_key_from_description(_desc_unsourced("foo", "bar"))
+        assert k1 == k2
+
+    def test_passage_hash_order_independent(self) -> None:
+        # swapped passage order should collapse to the same key.
+        k1 = _pair_key_from_description(_desc_unsourced("foo", "bar"))
+        k2 = _pair_key_from_description(_desc_unsourced("bar", "foo"))
+        assert k1 == k2
+
+    def test_passage_hash_distinguishes_content(self) -> None:
+        k1 = _pair_key_from_description(_desc_unsourced("foo", "bar"))
+        k2 = _pair_key_from_description(_desc_unsourced("baz", "qux"))
+        assert k1 != k2
+
+    def test_returns_none_for_unkeyable(self) -> None:
+        # Single member, single passage — cannot form a stable key.
+        assert _pair_key_from_description("Members involved: solo.md") is None
+        assert _pair_key_from_description("Passage 1: only") is None
+        assert _pair_key_from_description("plain text only") is None
+
+
+# ---------------------------------------------------------------------------
+# Helper: _append_also_affects
+# ---------------------------------------------------------------------------
+
+
+class TestAppendAlsoAffects:
+    def test_inserts_after_description(self) -> None:
+        block = (
+            '## [2026-05-23] Entity: "Alpha" (from wiki/x.md)\n'
+            "- [ ] q?\n\n"
+            "**Conflict type**: principled\n"
+            "**Description**: line1\n"
+        )
+        out = _append_also_affects(block, "Beta")
+        assert "**Also affects**: Beta" in out
+        # Order: description before also affects.
+        assert out.index("**Description**:") < out.index("**Also affects**:")
+
+    def test_idempotent_for_same_entity(self) -> None:
+        block = (
+            '## [2026-05-23] Entity: "Alpha" (from wiki/x.md)\n'
+            "- [ ] q?\n\n"
+            "**Conflict type**: principled\n"
+            "**Description**: d\n"
+            "**Also affects**: Beta\n"
+        )
+        out = _append_also_affects(block, "Beta")
+        # Only one occurrence of "Beta" on the also-affects line.
+        affects_line = next(
+            ln for ln in out.splitlines() if ln.startswith("**Also affects**:")
+        )
+        assert affects_line.count("Beta") == 1
+
+    def test_skips_primary_entity(self) -> None:
+        block = (
+            '## [2026-05-23] Entity: "Alpha" (from wiki/x.md)\n'
+            "- [ ] q?\n\n"
+            "**Conflict type**: principled\n"
+            "**Description**: d\n"
+        )
+        out = _append_also_affects(block, "Alpha")
+        assert "**Also affects**" not in out
+
+    def test_appends_to_existing_line(self) -> None:
+        block = (
+            '## [2026-05-23] Entity: "Alpha" (from wiki/x.md)\n'
+            "- [ ] q?\n\n"
+            "**Conflict type**: principled\n"
+            "**Description**: d\n"
+            "**Also affects**: Beta\n"
+        )
+        out = _append_also_affects(block, "Gamma")
+        assert "**Also affects**: Beta, Gamma" in out
+
+
+# ---------------------------------------------------------------------------
+# tier4_escalate dedup behavior
+# ---------------------------------------------------------------------------
+
+
+class TestTier4Dedup:
+    def test_dedup_happy_path(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        # One block, not two.
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta" in content
+        # Primary entity stays Alpha.
+        assert 'Entity: "Alpha"' in content
+        assert 'Entity: "Beta"' not in content
+
+    def test_no_dedup_for_distinct_pairs(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Gamma", _desc_with_members("c.md", "d.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 2
+        assert "**Also affects**" not in content
+
+    def test_order_independent_pair_collapse(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("b.md", "a.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta" in content
+
+    def test_triple_collapse(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+            _item("Gamma", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta, Gamma" in content
+        # Primary never repeats in the list.
+        affects_line = next(
+            ln for ln in content.splitlines() if ln.startswith("**Also affects**:")
+        )
+        assert "Alpha" not in affects_line
+
+    def test_idempotent_same_entity_twice(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        affects_line = next(
+            ln for ln in content.splitlines() if ln.startswith("**Also affects**:")
+        )
+        # Beta listed exactly once.
+        assert affects_line.count("Beta") == 1
+
+    def test_cross_batch_file_merge(self, tmp_path: Path) -> None:
+        """Batch 2 with the same pair as an open block in the file merges in-place."""
+        pending = tmp_path / "_pending_questions.md"
+        tier4_escalate([_item("Alpha", _desc_with_members("a.md", "b.md"))], pending)
+        # New batch — same pair, different entity.
+        tier4_escalate([_item("Beta", _desc_with_members("a.md", "b.md"))], pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta" in content
+
+    def test_resurrection_creates_new_block(self, tmp_path: Path) -> None:
+        """Once a block is archived ([x]), the same pair re-firing makes a NEW block."""
+        pending = tmp_path / "_pending_questions.md"
+        raw_root = tmp_path / "raw"
+
+        tier4_escalate([_item("Alpha", _desc_with_members("a.md", "b.md"))], pending)
+        # Flip the checkbox to [x] and let ingest archive the block.
+        text = pending.read_text().replace("- [ ]", "- [x]", 1)
+        # Add an answer body so the archive writer is happy.
+        text = text.replace("- [x]", "- [x]\n\nresolved by hand\n", 1)
+        pending.write_text(text)
+        ingested = ingest_answers(pending, raw_root)
+        assert ingested == 1
+        # Open file should now be just the header.
+        assert "## [" not in pending.read_text()
+
+        # Same pair re-fires — must produce a fresh block.
+        tier4_escalate([_item("Alpha", _desc_with_members("a.md", "b.md"))], pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**" not in content
+
+    def test_unsourced_fallback_dedup(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_unsourced("payload-X", "payload-Y")),
+            _item("Beta", _desc_unsourced("payload-X", "payload-Y")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 1
+        assert "**Also affects**: Beta" in content
+
+    def test_unsourced_distinct_passages_no_dedup(self, tmp_path: Path) -> None:
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_unsourced("payload-X", "payload-Y")),
+            _item("Beta", _desc_unsourced("other-A", "other-B")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        assert content.count("## [") == 2
+
+    def test_disable_via_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATHENAEUM_TIER4_DEDUP", "false")
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        content = pending.read_text()
+        # Disabled — two blocks, no Also affects line.
+        assert content.count("## [") == 2
+        assert "**Also affects**" not in content
+
+    def test_deduped_block_round_trips_through_parser(self, tmp_path: Path) -> None:
+        """The **Also affects**: line must NOT leak into answer_lines."""
+        pending = tmp_path / "_pending_questions.md"
+        items = [
+            _item("Alpha", _desc_with_members("a.md", "b.md")),
+            _item("Beta", _desc_with_members("a.md", "b.md")),
+        ]
+        tier4_escalate(items, pending)
+        pqs = parse_pending_questions(pending)
+        assert len(pqs) == 1
+        pq = pqs[0]
+        assert pq.answered is False
+        assert pq.answer_lines == []
+        assert pq.also_affects == ["Beta"]
+
+
+# ---------------------------------------------------------------------------
+# Auto-apply (#156) interaction
+# ---------------------------------------------------------------------------
+
+
+class _StubProposal:
+    """Minimal proposal stand-in for the auto-apply gate."""
+
+    def __init__(self, confidence: float = 0.95) -> None:
+        self.confidence = confidence
+        self.action = "prefer_left"
+        self.rationale = "stub rationale"
+        self.winning_uid = "uid_alpha"
+
+
+class TestTier4DedupAutoApply:
+    def test_also_affects_survives_auto_apply(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stub out apply_auto_resolution to keep the test independent of
+        # the resolutions module's exact rendering — we only care that
+        # the **Also affects** line survives the rewrite pass.
+        from athenaeum import resolutions
+
+        def fake_apply(block: str, proposal, model=None):  # noqa: ANN001
+            # Flip checkbox + tack on a marker line — that's what the
+            # real auto-apply does in spirit, and it's enough to exercise
+            # the interaction with _append_also_affects.
+            block = block.replace("- [ ]", "- [x]", 1)
+            return block + "\n_auto-resolved_\n"
+
+        monkeypatch.setattr(resolutions, "apply_auto_resolution", fake_apply)
+        monkeypatch.setattr(resolutions, "resolve_auto_apply", lambda c: True)
+        monkeypatch.setattr(resolutions, "resolve_auto_apply_threshold", lambda c: 0.5)
+
+        pending = tmp_path / "_pending_questions.md"
+        proposal = _StubProposal(confidence=0.95)
+        a = _item("Alpha", _desc_with_members("a.md", "b.md"))
+        a.proposal = proposal
+        b = _item("Beta", _desc_with_members("a.md", "b.md"))
+        b.proposal = proposal
+        tier4_escalate([a, b], pending, config={})
+
+        content = pending.read_text()
+        assert "_auto-resolved_" in content
+        assert "**Also affects**: Beta" in content
+        # Survives parser.
+        pqs = parse_pending_questions(pending)
+        assert len(pqs) == 1
+        assert pqs[0].also_affects == ["Beta"]

--- a/tests/test_tier4_dedup.py
+++ b/tests/test_tier4_dedup.py
@@ -15,6 +15,7 @@ import pytest
 
 from athenaeum.answers import ingest_answers, parse_pending_questions
 from athenaeum.models import EscalationItem
+from athenaeum.resolutions import ResolutionProposal
 from athenaeum.tiers import (
     _append_also_affects,
     _pair_key_from_description,
@@ -307,48 +308,131 @@ class TestTier4Dedup:
 # ---------------------------------------------------------------------------
 
 
-class _StubProposal:
-    """Minimal proposal stand-in for the auto-apply gate."""
-
-    def __init__(self, confidence: float = 0.95) -> None:
-        self.confidence = confidence
-        self.action = "prefer_left"
-        self.rationale = "stub rationale"
-        self.winning_uid = "uid_alpha"
+def _make_proposal(
+    confidence: float, rationale: str = "user > unsourced"
+) -> ResolutionProposal:
+    return ResolutionProposal(
+        recommended_winner="a",
+        action="keep_a",
+        rationale=rationale,
+        confidence=confidence,
+        source_precedence_used=["a:user > b:unsourced"],
+    )
 
 
 class TestTier4DedupAutoApply:
-    def test_also_affects_survives_auto_apply(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    def test_dedup_picks_highest_confidence_proposal_for_auto_apply(
+        self, tmp_path: Path
     ) -> None:
-        # Stub out apply_auto_resolution to keep the test independent of
-        # the resolutions module's exact rendering — we only care that
-        # the **Also affects** line survives the rewrite pass.
-        from athenaeum import resolutions
-
-        def fake_apply(block: str, proposal, model=None):  # noqa: ANN001
-            # Flip checkbox + tack on a marker line — that's what the
-            # real auto-apply does in spirit, and it's enough to exercise
-            # the interaction with _append_also_affects.
-            block = block.replace("- [ ]", "- [x]", 1)
-            return block + "\n_auto-resolved_\n"
-
-        monkeypatch.setattr(resolutions, "apply_auto_resolution", fake_apply)
-        monkeypatch.setattr(resolutions, "resolve_auto_apply", lambda c: True)
-        monkeypatch.setattr(resolutions, "resolve_auto_apply_threshold", lambda c: 0.5)
-
+        """A low-confidence first item + a high-confidence second item with the
+        same source pair should produce a single block that is auto-applied
+        using the second item's proposal."""
         pending = tmp_path / "_pending_questions.md"
-        proposal = _StubProposal(confidence=0.95)
-        a = _item("Alpha", _desc_with_members("a.md", "b.md"))
-        a.proposal = proposal
-        b = _item("Beta", _desc_with_members("a.md", "b.md"))
-        b.proposal = proposal
-        tier4_escalate([a, b], pending, config={})
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
 
+        low = _item("Alpha", _desc_with_members("a.md", "b.md"))
+        low.proposal = _make_proposal(0.50, rationale="LOW-CONF rationale")
+        high = _item("Beta", _desc_with_members("a.md", "b.md"))
+        high.proposal = _make_proposal(0.95, rationale="HIGH-CONF rationale")
+
+        tier4_escalate([low, high], pending, config=cfg)
         content = pending.read_text()
-        assert "_auto-resolved_" in content
+
+        # One block — collapsed.
+        assert content.count("## [") == 1
+        # Auto-applied via HIGH-conf proposal.
+        assert "- [x]" in content
         assert "**Also affects**: Beta" in content
-        # Survives parser.
+        assert "**Auto-resolved**: true" in content
+        # HIGH-conf rationale won — LOW-conf rationale must not appear.
+        assert "HIGH-CONF rationale" in content
+        assert "LOW-CONF rationale" not in content
+        # Confidence reflects the winning proposal.
+        assert "**Resolver confidence**: 0.95" in content
+
+        # Parser sees one block, answered, with Beta in also_affects.
         pqs = parse_pending_questions(pending)
         assert len(pqs) == 1
-        assert pqs[0].also_affects == ["Beta"]
+        pq = pqs[0]
+        assert pq.answered is True
+        assert pq.also_affects == ["Beta"]
+
+    def test_cross_batch_existing_open_block_gets_auto_applied(
+        self, tmp_path: Path
+    ) -> None:
+        """An existing [ ] block in the file with a low-confidence/no-op
+        proposal gets rewritten to [x] when a fresh batch arrives with a
+        high-confidence proposal for the same source pair (Path A)."""
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
+
+        # Batch 1: no proposal → block written as [ ].
+        first = _item("Alpha", _desc_with_members("a.md", "b.md"))
+        tier4_escalate([first], pending, config=cfg)
+        first_text = pending.read_text()
+        assert "- [ ]" in first_text
+        assert "**Auto-resolved**" not in first_text
+
+        # Batch 2: high-conf proposal for the SAME source pair.
+        second = _item("Beta", _desc_with_members("a.md", "b.md"))
+        second.proposal = _make_proposal(0.97, rationale="HIGH-CONF cross-batch")
+        tier4_escalate([second], pending, config=cfg)
+        content = pending.read_text()
+
+        # Still one block, now auto-applied with Beta in also_affects.
+        assert content.count("## [") == 1
+        assert "- [x]" in content
+        assert "**Also affects**: Beta" in content
+        assert "**Auto-resolved**: true" in content
+        assert "HIGH-CONF cross-batch" in content
+        assert "**Resolver confidence**: 0.97" in content
+
+    def test_cross_batch_already_applied_is_idempotent(self, tmp_path: Path) -> None:
+        """If the file block is already [x] (auto-resolved), a new
+        high-confidence proposal for the same pair must NOT clobber the
+        existing answer. It just merges the entity name in."""
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
+
+        first = _item("Alpha", _desc_with_members("a.md", "b.md"))
+        first.proposal = _make_proposal(0.93, rationale="FIRST rationale")
+        tier4_escalate([first], pending, config=cfg)
+
+        second = _item("Beta", _desc_with_members("a.md", "b.md"))
+        second.proposal = _make_proposal(0.99, rationale="SECOND rationale")
+        tier4_escalate([second], pending, config=cfg)
+        content = pending.read_text()
+
+        # Second batch only collapses (block is already [x]; merge into open
+        # blocks would not see it — Path A only indexes pq.answered=False).
+        # So Beta arrives as a fresh block. Acceptable behavior: the spec
+        # says re-apply is a no-op via marker; cross-batch resurrection of
+        # an already-answered pair gets its own block.
+        # The key invariant: first block's [x] + FIRST rationale survive.
+        assert "- [x]" in content
+        assert "FIRST rationale" in content
+        assert "**Resolver confidence**: 0.93" in content
+
+    def test_also_affects_round_trips_through_ingest(self, tmp_path: Path) -> None:
+        """The **Also affects** line must survive ingest_answers into the
+        ``_pending_questions_archive.md`` file (the durable audit trail).
+        Raw answer files under ``raw/answers/`` only carry the user-facing
+        answer body by design — the audit-trail home for ``Also affects``
+        is the archive, which preserves the original block verbatim."""
+        pending = tmp_path / "_pending_questions.md"
+        raw_root = tmp_path / "raw"
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.90}}
+
+        low = _item("Alpha", _desc_with_members("a.md", "b.md"))
+        low.proposal = _make_proposal(0.50)
+        high = _item("Beta", _desc_with_members("a.md", "b.md"))
+        high.proposal = _make_proposal(0.95)
+        tier4_escalate([low, high], pending, config=cfg)
+
+        ingested = ingest_answers(pending, raw_root)
+        assert ingested == 1
+
+        # Archive carries the also-affects line verbatim.
+        archive = pending.parent / "_pending_questions_archive.md"
+        assert archive.exists()
+        assert "**Also affects**: Beta" in archive.read_text()


### PR DESCRIPTION
## Summary

Fast-forward promotion of `develop` → `main` for release 0.5.0.

The `promote-main` workflow's direct refs API push was blocked by branch protection ("Changes must be made through a pull request") — the `kromatic-workflow-bot` App migration (#155) does not yet have main-branch bypass configured. Falling back to a PR-based promotion until that bypass is in place.

## What's in this promotion

- #156 / PR #158 — auto-apply lane for high-confidence Opus resolutions
- #157 / PR #159 — source-pair dedup at escalation time
- PR #160 — highest-confidence-wins auto-apply when items collapse into existing blocks
- PR #161 — version bump to 0.5.0 + CHANGELOG

See CHANGELOG.md entry for full 0.5.0 release notes.

## Test plan

- [x] CI green on develop tip (`a80a783`, 3.11/3.12/3.13)
- [x] 735 tests passing, 1 skipped, no warnings (apart from chromadb deprecation)
- [ ] Merge → tag `v0.5.0` on main → release workflow publishes to PyPI

## Follow-up

File an issue to add `kromatic-workflow-bot` as a main-branch bypass actor so future `promote-main` workflow runs can complete without the PR fallback.
