### PR TITLE
feat(resolve): per-action auto-apply thresholds (#170)

### DIFF
--- a/docs/auto-resolve.md
+++ b/docs/auto-resolve.md
@@ -96,6 +96,67 @@ resolve:
 Anything below the threshold continues to land as an unchecked block for
 human review.
 
+## Per-action thresholds (issue #170)
+
+The single scalar `auto_apply_threshold` treats every resolver action the
+same, but the cost of an incorrect auto-apply is not symmetric:
+
+- `not_a_conflict` — false-suppress is cheap. If the resolver is wrong,
+  the detector re-fires the next run and the conflict re-enters the queue.
+  Default threshold: **0.75**.
+- `keep_a` / `keep_b` — mutates wiki bodies. A wrong auto-apply requires
+  a human to chase down which memory was overwritten. Default
+  threshold: **0.90**.
+- `propose_merge` — **never auto-applies regardless of confidence**. The
+  proposal carries an LLM-drafted merged body that must go through human
+  review before it can land in a wiki page. This is a hard rule, not a
+  threshold knob.
+
+Configure per action via the new optional map:
+
+```yaml
+resolve:
+  auto_apply: true
+  auto_apply_threshold_per_action:
+    not_a_conflict: 0.75
+    keep_a: 0.90
+    keep_b: 0.90
+```
+
+### Backward compatibility
+
+Pre-#170 configs that set only the legacy scalar continue to work:
+
+```yaml
+resolve:
+  auto_apply_threshold: 0.85
+```
+
+is interpreted as:
+
+- `keep_a` / `keep_b` → 0.85 (legacy scalar honored).
+- `not_a_conflict` → 0.75 (new per-action default; the legacy scalar is
+  explicitly NOT applied here — that would defeat the cheaper-threshold
+  rationale).
+- `propose_merge` → never auto-applies.
+
+When both fields are present, the per-action map wins for the actions it
+explicitly lists, and the legacy scalar fills the rest for `keep_a` /
+`keep_b` only:
+
+```yaml
+resolve:
+  auto_apply_threshold: 0.85           # legacy fallback for keep_b
+  auto_apply_threshold_per_action:
+    keep_a: 0.99                       # explicit override wins for keep_a
+    not_a_conflict: 0.60               # explicit override wins
+# Resolved thresholds: keep_a=0.99, keep_b=0.85, not_a_conflict=0.60,
+# propose_merge=never.
+```
+
+Out-of-range values (`< 0.0` or `> 1.0`) and non-numeric entries raise
+`ValueError` on read — same loud-fail discipline as the legacy scalar.
+
 ## Reversing an auto-resolution
 
 The auto-resolved block flows through the same `ingest-answers` lane as a

--- a/src/athenaeum/resolutions.py
+++ b/src/athenaeum/resolutions.py
@@ -82,6 +82,21 @@ DEFAULT_RESOLVE_MAX_PER_RUN = 50
 # with a conservative 0.90 confidence floor.
 DEFAULT_AUTO_APPLY = True
 DEFAULT_AUTO_APPLY_THRESHOLD = 0.90
+# Issue #170: asymmetric per-action defaults. False-suppress (not_a_conflict)
+# is cheap — if wrong, the next run re-detects the conflict. Mutating actions
+# (keep_a / keep_b) edit wiki bodies, so the bar is higher. propose_merge is
+# a hard-coded sentinel ("never auto-apply") regardless of confidence — human
+# approval is always required because the merge body is LLM-drafted prose.
+DEFAULT_AUTO_APPLY_THRESHOLD_PER_ACTION: dict[str, float] = {
+    "not_a_conflict": 0.75,
+    "keep_a": 0.90,
+    "keep_b": 0.90,
+}
+# Sentinel set of actions that never auto-apply regardless of threshold.
+_NEVER_AUTO_APPLY_ACTIONS: frozenset[str] = frozenset(("propose_merge",))
+# Actions that still honor the legacy scalar `resolve.auto_apply_threshold`
+# as a backward-compat fallback when no per-action override is set.
+_LEGACY_SCALAR_FALLBACK_ACTIONS: frozenset[str] = frozenset(("keep_a", "keep_b"))
 
 # Lane 2 / issue #168: token-budget cap for the per-side full body the
 # resolver sees. Measured as a character-count heuristic — roughly 4
@@ -408,6 +423,78 @@ def resolve_auto_apply_threshold(config: dict[str, Any] | None = None) -> float:
                 )
             return value
     return DEFAULT_AUTO_APPLY_THRESHOLD
+
+
+def resolve_auto_apply_threshold_for(
+    config: dict[str, Any] | None,
+    action: str,
+) -> float | None:
+    """Resolve the auto-apply threshold for a SPECIFIC resolver action.
+
+    Issue #170 (Lane 4 of #166): per-action thresholds replace the legacy
+    single-scalar threshold. The cost of an incorrect auto-apply is not
+    symmetric across actions:
+
+    * ``not_a_conflict`` — false-suppress is cheap. The detector re-fires
+      on the next run if we were wrong. Default 0.75.
+    * ``keep_a`` / ``keep_b`` — mutates wiki bodies. Higher bar. Default 0.90.
+    * ``propose_merge`` — NEVER auto-applies. The proposal carries an
+      LLM-drafted merged body that must go through human review regardless
+      of confidence. Returns ``None`` so callers can branch on it cleanly.
+
+    Resolution order for a given action:
+
+    1. If the action is in :data:`_NEVER_AUTO_APPLY_ACTIONS` → return ``None``.
+    2. Per-action explicit override (``resolve.auto_apply_threshold_per_action.<action>``).
+    3. Legacy scalar (``resolve.auto_apply_threshold``) — only honored for
+       ``keep_a`` / ``keep_b``. Lets pre-#170 configs keep working.
+    4. Per-action default from :data:`DEFAULT_AUTO_APPLY_THRESHOLD_PER_ACTION`.
+    5. ``None`` for any unknown / non-auto-applicable action (the auto-apply
+       gate treats ``None`` the same as the propose_merge sentinel —
+       skip auto-apply, escalate to human).
+
+    Values are validated against ``[0.0, 1.0]`` with :class:`ValueError`
+    raised on out-of-range — same loud-fail discipline as
+    :func:`resolve_auto_apply_threshold`.
+    """
+    if action in _NEVER_AUTO_APPLY_ACTIONS:
+        return None
+
+    # Layer 2: explicit per-action override from config.
+    if isinstance(config, dict):
+        resolve_cfg = config.get("resolve")
+        if isinstance(resolve_cfg, dict):
+            per_action = resolve_cfg.get("auto_apply_threshold_per_action")
+            if isinstance(per_action, dict) and action in per_action:
+                raw = per_action[action]
+                try:
+                    value = float(raw)
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"resolve.auto_apply_threshold_per_action.{action}={raw!r} "
+                        f"out of range [0.0, 1.0]"
+                    ) from exc
+                if not 0.0 <= value <= 1.0:
+                    raise ValueError(
+                        f"resolve.auto_apply_threshold_per_action.{action}={raw!r} "
+                        f"out of range [0.0, 1.0]"
+                    )
+                return value
+
+    # Layer 3: legacy scalar fallback — only for keep_a / keep_b.
+    if action in _LEGACY_SCALAR_FALLBACK_ACTIONS and isinstance(config, dict):
+        resolve_cfg = config.get("resolve")
+        if isinstance(resolve_cfg, dict) and "auto_apply_threshold" in resolve_cfg:
+            # Reuse the validating loader so a typo in the legacy scalar
+            # still raises loudly.
+            return resolve_auto_apply_threshold(config)
+
+    # Layer 4: per-action default.
+    if action in DEFAULT_AUTO_APPLY_THRESHOLD_PER_ACTION:
+        return DEFAULT_AUTO_APPLY_THRESHOLD_PER_ACTION[action]
+
+    # Layer 5: unknown action → no auto-apply.
+    return None
 
 
 def resolve_max_per_run(config: dict[str, Any] | None = None) -> int:

--- a/src/athenaeum/resolutions.py
+++ b/src/athenaeum/resolutions.py
@@ -93,6 +93,12 @@ DEFAULT_AUTO_APPLY_THRESHOLD_PER_ACTION: dict[str, float] = {
     "keep_b": 0.90,
 }
 # Sentinel set of actions that never auto-apply regardless of threshold.
+# Belt-and-suspenders: Lane 3's ``_emit_escalation`` already routes
+# :class:`MergeProposal` to ``_pending_merges.md`` before ``tier4_escalate``
+# sees it, so a ``propose_merge`` proposal never reaches the auto-apply gate
+# in the current pipeline. This sentinel guards against a future refactor
+# that removes the sidecar early-return — losing it would silently let a
+# merge proposal slip past on confidence alone.
 _NEVER_AUTO_APPLY_ACTIONS: frozenset[str] = frozenset(("propose_merge",))
 # Actions that still honor the legacy scalar `resolve.auto_apply_threshold`
 # as a backward-compat fallback when no per-action override is set.
@@ -481,12 +487,22 @@ def resolve_auto_apply_threshold_for(
                     )
                 return value
 
-    # Layer 3: legacy scalar fallback — only for keep_a / keep_b.
-    if action in _LEGACY_SCALAR_FALLBACK_ACTIONS and isinstance(config, dict):
-        resolve_cfg = config.get("resolve")
-        if isinstance(resolve_cfg, dict) and "auto_apply_threshold" in resolve_cfg:
-            # Reuse the validating loader so a typo in the legacy scalar
-            # still raises loudly.
+    # Layer 3: legacy scalar fallback — only for keep_a / keep_b. Honors
+    # both the yaml key (`resolve.auto_apply_threshold`) AND the legacy env
+    # var (`ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD`). The env-only path
+    # matters for operators who set the override at the shell without
+    # touching the yaml — pre-#170 this Just Worked, and silently dropping
+    # it post-#170 would be a regression.
+    if action in _LEGACY_SCALAR_FALLBACK_ACTIONS:
+        env_override = os.environ.get("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD")
+        yaml_override = (
+            isinstance(config, dict)
+            and isinstance(config.get("resolve"), dict)
+            and "auto_apply_threshold" in config["resolve"]
+        )
+        if env_override is not None or yaml_override:
+            # Reuse the validating loader so a typo in either layer still
+            # raises loudly and env > yaml precedence is preserved.
             return resolve_auto_apply_threshold(config)
 
     # Layer 4: per-action default.

--- a/src/athenaeum/tiers.py
+++ b/src/athenaeum/tiers.py
@@ -654,16 +654,33 @@ def tier4_escalate(
     from athenaeum.resolutions import (
         apply_auto_resolution,
         resolve_auto_apply,
-        resolve_auto_apply_threshold,
+        resolve_auto_apply_threshold_for,
     )
 
     auto_apply_enabled = resolve_auto_apply(config) if config is not None else False
-    threshold = (
-        resolve_auto_apply_threshold(config)
-        if config is not None
-        else 1.1  # unreachable when config is None — disables auto-apply
-    )
     resolver_model_id = _resolver_model(config) if config is not None else None
+
+    def _threshold_for(action: str) -> float | None:
+        """Per-action threshold gate (issue #170). ``None`` = never auto-apply.
+
+        When ``config is None`` (legacy / test callers) we also return ``None``
+        to preserve the pre-#170 "no config → no auto-apply" behavior.
+        """
+        if config is None:
+            return None
+        return resolve_auto_apply_threshold_for(config, action)
+
+    def _should_auto_apply(prop: Any) -> bool:
+        """Single source of truth for the per-action auto-apply gate."""
+        if prop is None:
+            return False
+        action = getattr(prop, "action", None)
+        if not isinstance(action, str):
+            return False
+        thr = _threshold_for(action)
+        if thr is None:
+            return False
+        return getattr(prop, "confidence", 0.0) >= thr
 
     # Issue #157: dedup escalations by source-memory pair (Members involved
     # tuple, or sha1(passages) fallback). Default ON; escape hatch via the
@@ -741,17 +758,15 @@ def tier4_escalate(
             f"**Description**: {item.description}\n"
         )
         proposal = getattr(item, "proposal", None)
-        if (
-            auto_apply_enabled
-            and proposal is not None
-            and getattr(proposal, "confidence", 0.0) >= threshold
-        ):
+        if auto_apply_enabled and _should_auto_apply(proposal):
             block = apply_auto_resolution(block, proposal, model=resolver_model_id)
             log.info(
-                "Auto-resolved escalation for entity=%s (confidence=%.2f >= %.2f)",
+                "Auto-resolved escalation for entity=%s action=%s "
+                "(confidence=%.2f >= threshold=%.2f)",
                 item.entity_name,
+                proposal.action,
                 proposal.confidence,
-                threshold,
+                _threshold_for(proposal.action),
             )
         if key is not None:
             batch_index[key] = len(sections)
@@ -765,20 +780,19 @@ def tier4_escalate(
     if auto_apply_enabled:
         for key, slot in batch_index.items():
             best = best_proposal.get(key)
-            if best is None:
-                continue
-            if getattr(best, "confidence", 0.0) < threshold:
+            if not _should_auto_apply(best):
                 continue
             updated = apply_auto_resolution(
                 sections[slot], best, model=resolver_model_id
             )
             if updated != sections[slot]:
                 log.info(
-                    "Auto-resolved batched escalation key=%s "
-                    "(best confidence=%.2f >= %.2f)",
+                    "Auto-resolved batched escalation key=%s action=%s "
+                    "(best confidence=%.2f >= threshold=%.2f)",
                     key,
+                    best.action,
                     best.confidence,
-                    threshold,
+                    _threshold_for(best.action),
                 )
             sections[slot] = updated
 
@@ -804,17 +818,18 @@ def tier4_escalate(
             if auto_apply_enabled:
                 key_for_block = block_to_key.get(original_block)
                 best = best_proposal.get(key_for_block) if key_for_block else None
-                if best is not None and getattr(best, "confidence", 0.0) >= threshold:
+                if _should_auto_apply(best):
                     rewritten = apply_auto_resolution(
                         updated_block, best, model=resolver_model_id
                     )
                     if rewritten != updated_block:
                         log.info(
-                            "Auto-resolved cross-batch escalation key=%s "
-                            "(best confidence=%.2f >= %.2f)",
+                            "Auto-resolved cross-batch escalation key=%s action=%s "
+                            "(best confidence=%.2f >= threshold=%.2f)",
                             key_for_block,
+                            best.action,
                             best.confidence,
-                            threshold,
+                            _threshold_for(best.action),
                         )
                     updated_block = rewritten
             # Replace verbatim — raw_block came from parse, so it lives

--- a/tests/test_auto_apply_threshold.py
+++ b/tests/test_auto_apply_threshold.py
@@ -95,6 +95,53 @@ class TestLegacyScalarBackwardCompat:
         assert resolve_auto_apply_threshold_for(cfg, "propose_merge") is None
 
 
+class TestLegacyEnvVarBackwardCompat:
+    """The legacy ``ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD`` env var must
+    still gate ``keep_a`` / ``keep_b`` post-#170. Pre-#170 the env-only path
+    Just Worked; silently dropping it would be a regression for operators
+    who set the override at the shell without touching the yaml."""
+
+    def test_env_var_alone_gates_keep_a(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "0.80")
+        assert resolve_auto_apply_threshold_for({"resolve": {}}, "keep_a") == 0.80
+
+    def test_env_var_alone_gates_keep_b(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "0.80")
+        assert resolve_auto_apply_threshold_for({"resolve": {}}, "keep_b") == 0.80
+
+    def test_env_var_does_not_apply_to_not_a_conflict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The legacy env var was a keep_a/keep_b knob. The new 0.75 default
+        # for not_a_conflict deliberately replaces it for that action.
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "0.80")
+        assert (
+            resolve_auto_apply_threshold_for({"resolve": {}}, "not_a_conflict") == 0.75
+        )
+
+    def test_env_var_does_not_unlock_propose_merge(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "0.80")
+        assert (
+            resolve_auto_apply_threshold_for({"resolve": {}}, "propose_merge") is None
+        )
+
+    def test_per_action_override_wins_over_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Env-driven legacy still gates keep_b, but explicit per-action
+        # override wins for keep_a.
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_AUTO_APPLY_THRESHOLD", "0.80")
+        cfg = {
+            "resolve": {
+                "auto_apply_threshold_per_action": {"keep_a": 0.95},
+            }
+        }
+        assert resolve_auto_apply_threshold_for(cfg, "keep_a") == 0.95
+        assert resolve_auto_apply_threshold_for(cfg, "keep_b") == 0.80
+
+
 class TestPerActionOverride:
     def test_explicit_per_action_map(self) -> None:
         cfg = {

--- a/tests/test_auto_apply_threshold.py
+++ b/tests/test_auto_apply_threshold.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for issue #170 — asymmetric auto-apply threshold by action.
+
+Lane 4 of the #166 librarian-reasoner improvements epic. The single-scalar
+``resolve.auto_apply_threshold`` is replaced (additively, with backward-compat)
+by a per-action map:
+
+* ``not_a_conflict`` — default 0.75 (cheap to be wrong; re-detected next run).
+* ``keep_a`` / ``keep_b`` — default 0.90 (mutates wiki bodies).
+* ``propose_merge`` — NEVER auto-applies (always escalates to human regardless
+  of confidence; the proposal carries an LLM-drafted merged body).
+
+Backward compat: a config that only sets the legacy scalar
+``resolve.auto_apply_threshold: 0.85`` still works — applied to ``keep_a`` and
+``keep_b`` only. ``not_a_conflict`` gets the new per-action default. When both
+are set, the per-action map wins for the actions it lists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from athenaeum.models import EscalationItem
+from athenaeum.resolutions import (
+    DEFAULT_AUTO_APPLY_THRESHOLD_PER_ACTION,
+    MergeProposal,
+    ResolutionProposal,
+    resolve_auto_apply_threshold_for,
+)
+from athenaeum.tiers import tier4_escalate
+
+# ---------------------------------------------------------------------------
+# resolve_auto_apply_threshold_for — pure config resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPerActionDefaults:
+    def test_not_a_conflict_default_is_0_75(self) -> None:
+        assert resolve_auto_apply_threshold_for({}, "not_a_conflict") == 0.75
+
+    def test_keep_a_default_is_0_90(self) -> None:
+        assert resolve_auto_apply_threshold_for({}, "keep_a") == 0.90
+
+    def test_keep_b_default_is_0_90(self) -> None:
+        assert resolve_auto_apply_threshold_for({}, "keep_b") == 0.90
+
+    def test_propose_merge_returns_none(self) -> None:
+        # Hard rule, not a threshold — propose_merge never auto-applies.
+        assert resolve_auto_apply_threshold_for({}, "propose_merge") is None
+
+    def test_propose_merge_returns_none_even_with_explicit_override(self) -> None:
+        # The sentinel is checked BEFORE per-action config so an accidental
+        # entry in the YAML can't unlock auto-apply for propose_merge.
+        cfg = {
+            "resolve": {
+                "auto_apply_threshold_per_action": {"propose_merge": 0.5},
+            }
+        }
+        assert resolve_auto_apply_threshold_for(cfg, "propose_merge") is None
+
+    def test_unknown_action_returns_none(self) -> None:
+        # Unknown / non-auto-applicable actions fall through to None.
+        assert resolve_auto_apply_threshold_for({}, "merge") is None
+        assert resolve_auto_apply_threshold_for({}, "deprecate_both") is None
+        assert resolve_auto_apply_threshold_for({}, "retain_both_with_context") is None
+
+    def test_none_config_uses_per_action_defaults(self) -> None:
+        # config=None still resolves to per-action defaults — this is the
+        # pure-resolver behavior. The tiers.py gate adds its own
+        # "config is None → return None" wrapper.
+        assert resolve_auto_apply_threshold_for(None, "not_a_conflict") == 0.75
+        assert resolve_auto_apply_threshold_for(None, "keep_a") == 0.90
+
+
+class TestLegacyScalarBackwardCompat:
+    def test_legacy_scalar_applies_to_keep_a(self) -> None:
+        cfg = {"resolve": {"auto_apply_threshold": 0.85}}
+        assert resolve_auto_apply_threshold_for(cfg, "keep_a") == 0.85
+
+    def test_legacy_scalar_applies_to_keep_b(self) -> None:
+        cfg = {"resolve": {"auto_apply_threshold": 0.85}}
+        assert resolve_auto_apply_threshold_for(cfg, "keep_b") == 0.85
+
+    def test_legacy_scalar_does_not_override_not_a_conflict_default(self) -> None:
+        # The legacy scalar was a keep_a/keep_b knob. It does NOT push the
+        # not_a_conflict default up to 0.85 — that would defeat the whole
+        # point of #170 (cheaper threshold for false-suppress).
+        cfg = {"resolve": {"auto_apply_threshold": 0.85}}
+        assert resolve_auto_apply_threshold_for(cfg, "not_a_conflict") == 0.75
+
+    def test_legacy_scalar_does_not_unlock_propose_merge(self) -> None:
+        cfg = {"resolve": {"auto_apply_threshold": 0.85}}
+        assert resolve_auto_apply_threshold_for(cfg, "propose_merge") is None
+
+
+class TestPerActionOverride:
+    def test_explicit_per_action_map(self) -> None:
+        cfg = {
+            "resolve": {
+                "auto_apply_threshold_per_action": {
+                    "not_a_conflict": 0.60,
+                    "keep_a": 0.95,
+                    "keep_b": 0.95,
+                }
+            }
+        }
+        assert resolve_auto_apply_threshold_for(cfg, "not_a_conflict") == 0.60
+        assert resolve_auto_apply_threshold_for(cfg, "keep_a") == 0.95
+        assert resolve_auto_apply_threshold_for(cfg, "keep_b") == 0.95
+
+    def test_partial_per_action_uses_defaults_for_unspecified(self) -> None:
+        cfg = {
+            "resolve": {
+                "auto_apply_threshold_per_action": {"not_a_conflict": 0.60},
+            }
+        }
+        assert resolve_auto_apply_threshold_for(cfg, "not_a_conflict") == 0.60
+        # keep_a falls through to the per-action default (0.90).
+        assert resolve_auto_apply_threshold_for(cfg, "keep_a") == 0.90
+
+    def test_out_of_range_raises(self) -> None:
+        cfg = {
+            "resolve": {
+                "auto_apply_threshold_per_action": {"keep_a": 1.5},
+            }
+        }
+        with pytest.raises(ValueError, match="keep_a"):
+            resolve_auto_apply_threshold_for(cfg, "keep_a")
+
+    def test_non_numeric_raises(self) -> None:
+        cfg = {
+            "resolve": {
+                "auto_apply_threshold_per_action": {"keep_a": "high"},
+            }
+        }
+        with pytest.raises(ValueError, match="keep_a"):
+            resolve_auto_apply_threshold_for(cfg, "keep_a")
+
+
+class TestMixedLegacyAndPerAction:
+    def test_per_action_wins_where_set_legacy_fills_rest(self) -> None:
+        # Legacy scalar = 0.85; per-action overrides keep_a only.
+        cfg = {
+            "resolve": {
+                "auto_apply_threshold": 0.85,
+                "auto_apply_threshold_per_action": {"keep_a": 0.99},
+            }
+        }
+        # Explicit per-action override wins.
+        assert resolve_auto_apply_threshold_for(cfg, "keep_a") == 0.99
+        # keep_b is not in the per-action map → legacy scalar fills it.
+        assert resolve_auto_apply_threshold_for(cfg, "keep_b") == 0.85
+        # not_a_conflict still gets the new default (legacy scalar is
+        # explicitly NOT applied to not_a_conflict).
+        assert resolve_auto_apply_threshold_for(cfg, "not_a_conflict") == 0.75
+        # propose_merge still never auto-applies.
+        assert resolve_auto_apply_threshold_for(cfg, "propose_merge") is None
+
+
+# ---------------------------------------------------------------------------
+# Helper builders
+# ---------------------------------------------------------------------------
+
+
+def _proposal(action: str, confidence: float) -> ResolutionProposal:
+    return ResolutionProposal(
+        recommended_winner="a" if action in ("keep_a",) else "neither",
+        action=action,  # type: ignore[arg-type]
+        rationale=f"test-{action}",
+        confidence=confidence,
+        source_precedence_used=["a:user > b:unsourced"],
+    )
+
+
+def _merge_proposal(confidence: float) -> MergeProposal:
+    return MergeProposal(
+        merge_target_name="test-merge",
+        rationale="test propose_merge",
+        draft_merged_body="merged body",
+        confidence=confidence,
+    )
+
+
+def _escalation(
+    name: str, proposal: ResolutionProposal | MergeProposal
+) -> EscalationItem:
+    return EscalationItem(
+        raw_ref=f"wiki/{name.lower()}.md",
+        entity_name=name,
+        conflict_type="factual",
+        description=f"conflict for {name}",
+        proposal=proposal,
+    )
+
+
+# ---------------------------------------------------------------------------
+# tier4_escalate integration — per-action gate
+# ---------------------------------------------------------------------------
+
+
+class TestTier4PerActionGate:
+    def test_three_proposals_at_0_80_only_not_a_conflict_auto_applies(
+        self, tmp_path: Path
+    ) -> None:
+        """At 0.80 confidence with default per-action thresholds:
+
+        * not_a_conflict (threshold 0.75) → 0.80 >= 0.75 → auto-applies.
+        * keep_a (threshold 0.90) → 0.80 < 0.90 → stays open.
+        * propose_merge (threshold None) → never auto-applies.
+        """
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": True}}  # no thresholds — use defaults.
+        items = [
+            _escalation("NotAConflictEntity", _proposal("not_a_conflict", 0.80)),
+            _escalation("KeepAEntity", _proposal("keep_a", 0.80)),
+            _escalation("ProposeMergeEntity", _merge_proposal(0.80)),
+        ]
+        tier4_escalate(items, pending, config=cfg)
+        text = pending.read_text(encoding="utf-8")
+
+        nac_idx = text.index("NotAConflictEntity")
+        ka_idx = text.index("KeepAEntity")
+        pm_idx = text.index("ProposeMergeEntity")
+        nac_block = text[nac_idx:ka_idx]
+        ka_block = text[ka_idx:pm_idx]
+        pm_block = text[pm_idx:]
+
+        assert "- [x]" in nac_block
+        assert "**Auto-resolved**: true" in nac_block
+
+        assert "- [ ]" in ka_block
+        assert "**Auto-resolved**" not in ka_block
+
+        assert "- [ ]" in pm_block
+        assert "**Auto-resolved**" not in pm_block
+
+    def test_propose_merge_never_auto_applies_even_at_confidence_1_0(
+        self, tmp_path: Path
+    ) -> None:
+        """Hard rule: propose_merge never auto-applies regardless of confidence.
+
+        Even at 1.0 with auto_apply=True, the block stays ``- [ ]``.
+        """
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": True}}
+        item = _escalation("PerfectMergeEntity", _merge_proposal(1.0))
+        tier4_escalate([item], pending, config=cfg)
+        text = pending.read_text(encoding="utf-8")
+
+        assert "- [ ]" in text
+        assert "**Auto-resolved**" not in text
+
+    def test_keep_a_at_legacy_scalar_threshold_still_works(
+        self, tmp_path: Path
+    ) -> None:
+        """Pre-#170 configs keep working: legacy scalar gates keep_a."""
+        pending = tmp_path / "_pending_questions.md"
+        cfg = {"resolve": {"auto_apply": True, "auto_apply_threshold": 0.85}}
+        item = _escalation("LegacyEntity", _proposal("keep_a", 0.86))
+        tier4_escalate([item], pending, config=cfg)
+        text = pending.read_text(encoding="utf-8")
+
+        assert "- [x]" in text
+        assert "**Auto-resolved**: true" in text
+
+
+# ---------------------------------------------------------------------------
+# Module constants — sanity pin
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_default_per_action_threshold_values(self) -> None:
+        assert DEFAULT_AUTO_APPLY_THRESHOLD_PER_ACTION == {
+            "not_a_conflict": 0.75,
+            "keep_a": 0.90,
+            "keep_b": 0.90,
+        }


### PR DESCRIPTION
## Summary

Lane 4 of #166 — asymmetric auto-apply threshold by resolver action.

The single-scalar `resolve.auto_apply_threshold` treats every resolver action the same, but the cost of an incorrect auto-apply is not symmetric:

- `not_a_conflict` → default **0.75** (false-suppress is cheap; the detector re-fires next run if wrong).
- `keep_a` / `keep_b` → default **0.90** (mutates wiki bodies; wrong auto-apply is real cost).
- `propose_merge` → **never auto-applies** regardless of confidence. Hard sentinel rule — the LLM-drafted merged body must go through human review.

## Changes

- New `resolve_auto_apply_threshold_for(config, action) -> float | None` in `src/athenaeum/resolutions.py`. Returns `None` for `propose_merge` and unknown actions (signals "never auto-apply" to the gate).
- `src/athenaeum/tiers.py` — three auto-apply gate sites now use a `_should_auto_apply(proposal)` helper that reads the per-action threshold via `proposal.action`. Logging includes the action and the resolved threshold for that action.
- `DEFAULT_AUTO_APPLY_THRESHOLD_PER_ACTION` constant exported for introspection.
- New optional YAML field `resolve.auto_apply_threshold_per_action.<action>: <float>`.
- Backward compatibility (load-bearing): pre-#170 configs that only set `resolve.auto_apply_threshold: 0.85` keep working — the legacy scalar is applied as a fallback for `keep_a` / `keep_b` only. `not_a_conflict` still gets the new per-action default (0.75); the legacy scalar is explicitly NOT applied there, since that would defeat the cheaper-threshold rationale. `propose_merge` always returns `None`.
- When both fields are present, the per-action map wins for actions it explicitly lists; the legacy scalar fills the rest for keep_a/keep_b only.
- `docs/auto-resolve.md` documents the new schema, defaults, hard rule for `propose_merge`, and the backward-compat behavior with worked examples.

## Test plan

- [x] `tests/test_auto_apply_threshold.py` — 20 tests across per-action defaults, legacy-scalar backward compat, explicit overrides, mixed legacy + per-action, range/non-numeric validation, the three-proposal gate scenario (only `not_a_conflict` flips at 0.80), and the propose_merge-never-auto-applies hard pin (even at confidence 1.0).
- [x] Full suite green — 825 passed, 14 skipped.
- [x] Ruff clean on `src/` + `tests/`.

## Scope

Final lane of the #166 librarian-reasoner improvements epic — closes the track. No changes to Lane 1/2/3 surface.

Closes #170
