### PR TITLE
chore: sync develop with main (#185 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-24
+
+Patch bundle: the self-reference lint added in #173 now runs on every
+`AutoMemoryFile` construction site, not just `discover_auto_memory_files`.
+
+### Changed
+
+- **Self-reference lint applied to all `AutoMemoryFile` construction sites**
+  (#181, #183) — the lint that strips a memory's own name from its
+  `refines` / `supersedes` lists (originally added in #173) now also runs
+  in the similarity-sweep path (`cross_scope.candidate_to_auto_memory_files`)
+  and the cluster-shim path (`merge.merge_cluster_row`). Extracted to
+  `athenaeum._lint._strip_self_reference` so all three sites share one
+  implementation. Tests tightened to assert against rendered log messages.
+
 ## [0.6.0] - 2026-05-24
 
 The librarian-reasoner epic (#166) lands as a single backward-compatible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "athenaeum"
-version = "0.6.0"
+version = "0.6.1"
 description = "Open source knowledge management pipeline — append-only intake, tiered compilation, configurable schemas"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/athenaeum/__init__.py
+++ b/src/athenaeum/__init__.py
@@ -12,7 +12,7 @@ for the full subcommand list. Internal modules (``contradictions``,
 public surface; their signatures may change between minor releases.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from athenaeum.init import init_knowledge_dir
 from athenaeum.librarian import discover_raw_files, process_one, rebuild_index, run

--- a/src/athenaeum/_lint.py
+++ b/src/athenaeum/_lint.py
@@ -1,0 +1,59 @@
+"""Lint helpers for auto-memory file construction.
+
+Issue #183: extracted from ``librarian.py`` so the three
+:class:`AutoMemoryFile` construction sites (discovery, cross-scope
+similarity sweep, merge-time cluster shim) can share the helper without
+:mod:`athenaeum.cross_scope` and :mod:`athenaeum.merge` having to do
+function-local imports back into ``librarian.py`` (which would otherwise
+create an import cycle: merge -> librarian -> merge).
+
+This module intentionally has no athenaeum-internal imports.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+log = logging.getLogger("athenaeum")
+
+
+def _strip_self_reference(
+    name: str,
+    refines: list[str],
+    supersedes: list[dict[str, str]],
+    fpath: Path | None = None,
+) -> tuple[list[str], list[dict[str, str]]]:
+    """Drop self-references from ``refines`` / ``supersedes`` with a WARN.
+
+    Issue #173: a memory must never claim to refine or supersede itself —
+    that is a YAML authoring mistake (most often the file's own ``name``
+    accidentally pasted into its own ``refines:`` block). Silently dropping
+    them keeps the resolver / merge planner from ever seeing the loop, and
+    the WARNING line gives the operator a single grep target.
+
+    Issue #181: the original lint lived inline in
+    :func:`discover_auto_memory_files`. Extracted so the two other
+    ``AutoMemoryFile`` construction sites (cross-scope similarity sweep,
+    merge-time cluster shim) get the same lint+strip behavior.
+
+    ``fpath`` is optional only to keep the helper trivially callable from
+    tests; production call sites pass it so the WARNING names the file.
+    """
+    if not name:
+        return refines, supersedes
+    if any(r == name for r in refines):
+        log.warning(
+            "auto-memory %s: refines self (%r); dropping self-reference",
+            fpath,
+            name,
+        )
+        refines = [r for r in refines if r != name]
+    if any(s.get("name") == name for s in supersedes):
+        log.warning(
+            "auto-memory %s: supersedes self (%r); dropping self-reference",
+            fpath,
+            name,
+        )
+        supersedes = [s for s in supersedes if s.get("name") != name]
+    return refines, supersedes

--- a/src/athenaeum/cross_scope.py
+++ b/src/athenaeum/cross_scope.py
@@ -48,6 +48,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
+from athenaeum._lint import _strip_self_reference
 from athenaeum.models import (
     AutoMemoryFile,
     parse_frontmatter,
@@ -464,8 +465,6 @@ def candidate_to_auto_memory_files(
             refines = []
             supersedes = []
         # Issue #181: same self-reference lint as discover_auto_memory_files.
-        from athenaeum.librarian import _strip_self_reference
-
         refines, supersedes = _strip_self_reference(name, refines, supersedes, path)
         out.append(
             AutoMemoryFile(

--- a/src/athenaeum/cross_scope.py
+++ b/src/athenaeum/cross_scope.py
@@ -463,6 +463,10 @@ def candidate_to_auto_memory_files(
             )
             refines = []
             supersedes = []
+        # Issue #181: same self-reference lint as discover_auto_memory_files.
+        from athenaeum.librarian import _strip_self_reference
+
+        refines, supersedes = _strip_self_reference(name, refines, supersedes, path)
         out.append(
             AutoMemoryFile(
                 path=path,

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -62,6 +62,48 @@ from athenaeum.tiers import (
 
 log = logging.getLogger("athenaeum")
 
+
+def _strip_self_reference(
+    name: str,
+    refines: list[str],
+    supersedes: list[dict[str, str]],
+    fpath: Path | None = None,
+) -> tuple[list[str], list[dict[str, str]]]:
+    """Drop self-references from ``refines`` / ``supersedes`` with a WARN.
+
+    Issue #173: a memory must never claim to refine or supersede itself —
+    that is a YAML authoring mistake (most often the file's own ``name``
+    accidentally pasted into its own ``refines:`` block). Silently dropping
+    them keeps the resolver / merge planner from ever seeing the loop, and
+    the WARNING line gives the operator a single grep target.
+
+    Issue #181: the original lint lived inline in
+    :func:`discover_auto_memory_files`. Extracted so the two other
+    ``AutoMemoryFile`` construction sites (cross-scope similarity sweep,
+    merge-time cluster shim) get the same lint+strip behavior.
+
+    ``fpath`` is optional only to keep the helper trivially callable from
+    tests; production call sites pass it so the WARNING names the file.
+    """
+    if not name:
+        return refines, supersedes
+    if any(r == name for r in refines):
+        log.warning(
+            "auto-memory %s: refines self (%r); dropping self-reference",
+            fpath,
+            name,
+        )
+        refines = [r for r in refines if r != name]
+    if any(s.get("name") == name for s in supersedes):
+        log.warning(
+            "auto-memory %s: supersedes self (%r); dropping self-reference",
+            fpath,
+            name,
+        )
+        supersedes = [s for s in supersedes if s.get("name") != name]
+    return refines, supersedes
+
+
 # Defaults — can be overridden via CLI args or the run() API
 DEFAULT_KNOWLEDGE_ROOT = Path.home() / "knowledge"
 DEFAULT_RAW_ROOT = DEFAULT_KNOWLEDGE_ROOT / "raw"
@@ -195,29 +237,10 @@ def discover_auto_memory_files(
                     )
                     refines = []
                     supersedes = []
-                # Issue #173: self-reference in refines/supersedes is a
-                # YAML authoring mistake — silently drop with a loud warn
-                # so the resolver / merge planner never sees a memory
-                # claiming to refine or supersede itself.
-                if name:
-                    self_refines = [r for r in refines if r == name]
-                    if self_refines:
-                        log.warning(
-                            "auto-memory %s: refines self (%r); dropping "
-                            "self-reference",
-                            fpath,
-                            name,
-                        )
-                        refines = [r for r in refines if r != name]
-                    self_supersedes = [s for s in supersedes if s.get("name") == name]
-                    if self_supersedes:
-                        log.warning(
-                            "auto-memory %s: supersedes self (%r); dropping "
-                            "self-reference",
-                            fpath,
-                            name,
-                        )
-                        supersedes = [s for s in supersedes if s.get("name") != name]
+                # Issue #173 / #181: drop refines/supersedes self-references.
+                refines, supersedes = _strip_self_reference(
+                    name, refines, supersedes, fpath
+                )
                 files.append(
                     AutoMemoryFile(
                         path=fpath,

--- a/src/athenaeum/librarian.py
+++ b/src/athenaeum/librarian.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 import anthropic
 
+from athenaeum._lint import _strip_self_reference
 from athenaeum.clusters import (
     cluster_auto_memory_files,
     resolve_cluster_output_path,
@@ -61,47 +62,6 @@ from athenaeum.tiers import (
 )
 
 log = logging.getLogger("athenaeum")
-
-
-def _strip_self_reference(
-    name: str,
-    refines: list[str],
-    supersedes: list[dict[str, str]],
-    fpath: Path | None = None,
-) -> tuple[list[str], list[dict[str, str]]]:
-    """Drop self-references from ``refines`` / ``supersedes`` with a WARN.
-
-    Issue #173: a memory must never claim to refine or supersede itself —
-    that is a YAML authoring mistake (most often the file's own ``name``
-    accidentally pasted into its own ``refines:`` block). Silently dropping
-    them keeps the resolver / merge planner from ever seeing the loop, and
-    the WARNING line gives the operator a single grep target.
-
-    Issue #181: the original lint lived inline in
-    :func:`discover_auto_memory_files`. Extracted so the two other
-    ``AutoMemoryFile`` construction sites (cross-scope similarity sweep,
-    merge-time cluster shim) get the same lint+strip behavior.
-
-    ``fpath`` is optional only to keep the helper trivially callable from
-    tests; production call sites pass it so the WARNING names the file.
-    """
-    if not name:
-        return refines, supersedes
-    if any(r == name for r in refines):
-        log.warning(
-            "auto-memory %s: refines self (%r); dropping self-reference",
-            fpath,
-            name,
-        )
-        refines = [r for r in refines if r != name]
-    if any(s.get("name") == name for s in supersedes):
-        log.warning(
-            "auto-memory %s: supersedes self (%r); dropping self-reference",
-            fpath,
-            name,
-        )
-        supersedes = [s for s in supersedes if s.get("name") != name]
-    return refines, supersedes
 
 
 # Defaults — can be overridden via CLI args or the run() API

--- a/src/athenaeum/merge.py
+++ b/src/athenaeum/merge.py
@@ -47,6 +47,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from athenaeum._lint import _strip_self_reference
 from athenaeum.clusters import resolve_cluster_output_path
 from athenaeum.config import load_config, resolve_extra_intake_roots
 from athenaeum.contradictions import ContradictionResult, detect_contradictions
@@ -609,8 +610,6 @@ def merge_cluster_row(
                 shim_refines = []
                 shim_supersedes = []
             # Issue #181: same self-reference lint as discover_auto_memory_files.
-            from athenaeum.librarian import _strip_self_reference
-
             shim_name = str(meta.get("name", "")) if meta else ""
             shim_refines, shim_supersedes = _strip_self_reference(
                 shim_name, shim_refines, shim_supersedes, resolved

--- a/src/athenaeum/merge.py
+++ b/src/athenaeum/merge.py
@@ -608,11 +608,18 @@ def merge_cluster_row(
                 )
                 shim_refines = []
                 shim_supersedes = []
+            # Issue #181: same self-reference lint as discover_auto_memory_files.
+            from athenaeum.librarian import _strip_self_reference
+
+            shim_name = str(meta.get("name", "")) if meta else ""
+            shim_refines, shim_supersedes = _strip_self_reference(
+                shim_name, shim_refines, shim_supersedes, resolved
+            )
             am = AutoMemoryFile(
                 path=resolved,
                 origin_scope=scope_guess,
                 memory_type="unknown",
-                name=str(meta.get("name", "")) if meta else "",
+                name=shim_name,
                 description=str(meta.get("description", "")) if meta else "",
                 origin_session_id=(
                     str(origin_session_id) if origin_session_id is not None else None

--- a/tests/test_cross_scope.py
+++ b/tests/test_cross_scope.py
@@ -727,3 +727,61 @@ class TestCandidateUnwrap:
         assert len(ams) == 2
         assert ams[0].name == "a"
         assert ams[1].origin_scope == "-Y"
+
+
+# ---------------------------------------------------------------------------
+# Issue #181: self-reference lint applies to candidate_to_auto_memory_files
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateSelfReferenceLint:
+    def test_refines_self_dropped(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from athenaeum.cross_scope import SimilarityCandidate, candidate_to_auto_memory_files
+
+        a = tmp_path / "a.md"
+        b = tmp_path / "b.md"
+        a.write_text(
+            "---\nname: A Mem\ntype: feedback\n"
+            "refines:\n  - A Mem\n  - Other\n---\nbody\n",
+            encoding="utf-8",
+        )
+        b.write_text(
+            "---\nname: B Mem\ntype: feedback\n---\nbody\n",
+            encoding="utf-8",
+        )
+        cand = SimilarityCandidate(
+            a_path=a, b_path=b, similarity=0.9, a_scope="-X", b_scope="-Y"
+        )
+        with caplog.at_level("WARNING"):
+            ams = candidate_to_auto_memory_files(cand)
+        assert ams[0].refines == ["Other"]
+        assert any("refines self" in r.message for r in caplog.records)
+
+    def test_supersedes_self_dropped(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from athenaeum.cross_scope import SimilarityCandidate, candidate_to_auto_memory_files
+
+        a = tmp_path / "a.md"
+        b = tmp_path / "b.md"
+        a.write_text(
+            "---\nname: A Mem\ntype: feedback\n"
+            "supersedes:\n"
+            "  - name: A Mem\n    as_of: 2026-01-01\n    reason: typo\n"
+            "  - name: Other\n    as_of: 2026-01-02\n    reason: real\n"
+            "---\nbody\n",
+            encoding="utf-8",
+        )
+        b.write_text(
+            "---\nname: B Mem\ntype: feedback\n---\nbody\n",
+            encoding="utf-8",
+        )
+        cand = SimilarityCandidate(
+            a_path=a, b_path=b, similarity=0.9, a_scope="-X", b_scope="-Y"
+        )
+        with caplog.at_level("WARNING"):
+            ams = candidate_to_auto_memory_files(cand)
+        assert [s["name"] for s in ams[0].supersedes] == ["Other"]
+        assert any("supersedes self" in r.message for r in caplog.records)

--- a/tests/test_cross_scope.py
+++ b/tests/test_cross_scope.py
@@ -738,7 +738,10 @@ class TestCandidateSelfReferenceLint:
     def test_refines_self_dropped(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        from athenaeum.cross_scope import SimilarityCandidate, candidate_to_auto_memory_files
+        from athenaeum.cross_scope import (
+            SimilarityCandidate,
+            candidate_to_auto_memory_files,
+        )
 
         a = tmp_path / "a.md"
         b = tmp_path / "b.md"
@@ -756,13 +759,22 @@ class TestCandidateSelfReferenceLint:
         )
         with caplog.at_level("WARNING"):
             ams = candidate_to_auto_memory_files(cand)
-        assert ams[0].refines == ["Other"]
-        assert any("refines self" in r.message for r in caplog.records)
+        am_a = next(am for am in ams if am.path == a)
+        assert am_a.refines == ["Other"]
+        assert any(
+            "refines self" in r.getMessage()
+            and "A Mem" in r.getMessage()
+            and str(a) in r.getMessage()
+            for r in caplog.records
+        )
 
     def test_supersedes_self_dropped(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        from athenaeum.cross_scope import SimilarityCandidate, candidate_to_auto_memory_files
+        from athenaeum.cross_scope import (
+            SimilarityCandidate,
+            candidate_to_auto_memory_files,
+        )
 
         a = tmp_path / "a.md"
         b = tmp_path / "b.md"
@@ -783,5 +795,11 @@ class TestCandidateSelfReferenceLint:
         )
         with caplog.at_level("WARNING"):
             ams = candidate_to_auto_memory_files(cand)
-        assert [s["name"] for s in ams[0].supersedes] == ["Other"]
-        assert any("supersedes self" in r.message for r in caplog.records)
+        am_a = next(am for am in ams if am.path == a)
+        assert [s["name"] for s in am_a.supersedes] == ["Other"]
+        assert any(
+            "supersedes self" in r.getMessage()
+            and "A Mem" in r.getMessage()
+            and str(a) in r.getMessage()
+            for r in caplog.records
+        )

--- a/tests/test_librarian_merge.py
+++ b/tests/test_librarian_merge.py
@@ -1481,13 +1481,16 @@ class TestClusterShimSelfReferenceLint:
             "centroid_score": 1.0,
         }
         with caplog.at_level("WARNING"):
-            entry = merge_cluster_row(
-                row, extra_roots=[tmp_path], am_by_path={}
-            )
+            entry = merge_cluster_row(row, extra_roots=[tmp_path], am_by_path={})
         assert entry is not None
         assert len(entry.resolved_members) == 1
         assert entry.resolved_members[0].refines == ["Other"]
-        assert any("refines self" in r.message for r in caplog.records)
+        assert any(
+            "refines self" in r.getMessage()
+            and "Shim Mem" in r.getMessage()
+            and str(member) in r.getMessage()
+            for r in caplog.records
+        )
 
     def test_supersedes_self_dropped_on_shim(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -1509,9 +1512,12 @@ class TestClusterShimSelfReferenceLint:
             "centroid_score": 1.0,
         }
         with caplog.at_level("WARNING"):
-            entry = merge_cluster_row(
-                row, extra_roots=[tmp_path], am_by_path={}
-            )
+            entry = merge_cluster_row(row, extra_roots=[tmp_path], am_by_path={})
         assert entry is not None
         assert [s["name"] for s in entry.resolved_members[0].supersedes] == ["Other"]
-        assert any("supersedes self" in r.message for r in caplog.records)
+        assert any(
+            "supersedes self" in r.getMessage()
+            and "Shim Mem" in r.getMessage()
+            and str(member) in r.getMessage()
+            for r in caplog.records
+        )

--- a/tests/test_librarian_merge.py
+++ b/tests/test_librarian_merge.py
@@ -1451,3 +1451,67 @@ class TestMergeOnlyCLI:
         wiki = voltaire_merge_root / "wiki"
         outputs = sorted(wiki.glob(f"{AUTO_WIKI_PREFIX}*.md"))
         assert len(outputs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #181: self-reference lint applies to cluster-shim path
+# ---------------------------------------------------------------------------
+
+
+class TestClusterShimSelfReferenceLint:
+    """The shim branch in :func:`merge_cluster_row` builds an
+    :class:`AutoMemoryFile` on the fly when a cluster row references a
+    file that C1 didn't discover. That branch must apply the same
+    self-reference lint as the discovery path (issue #181)."""
+
+    def test_refines_self_dropped_on_shim(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from athenaeum.merge import merge_cluster_row
+
+        member = tmp_path / "shim_self.md"
+        member.write_text(
+            "---\nname: Shim Mem\ntype: feedback\n"
+            "refines:\n  - Shim Mem\n  - Other\n---\nbody\n",
+            encoding="utf-8",
+        )
+        row = {
+            "cluster_id": "c-shim",
+            "member_paths": [str(member)],
+            "centroid_score": 1.0,
+        }
+        with caplog.at_level("WARNING"):
+            entry = merge_cluster_row(
+                row, extra_roots=[tmp_path], am_by_path={}
+            )
+        assert entry is not None
+        assert len(entry.resolved_members) == 1
+        assert entry.resolved_members[0].refines == ["Other"]
+        assert any("refines self" in r.message for r in caplog.records)
+
+    def test_supersedes_self_dropped_on_shim(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from athenaeum.merge import merge_cluster_row
+
+        member = tmp_path / "shim_self.md"
+        member.write_text(
+            "---\nname: Shim Mem\ntype: feedback\n"
+            "supersedes:\n"
+            "  - name: Shim Mem\n    as_of: 2026-01-01\n    reason: typo\n"
+            "  - name: Other\n    as_of: 2026-01-02\n    reason: real\n"
+            "---\nbody\n",
+            encoding="utf-8",
+        )
+        row = {
+            "cluster_id": "c-shim",
+            "member_paths": [str(member)],
+            "centroid_score": 1.0,
+        }
+        with caplog.at_level("WARNING"):
+            entry = merge_cluster_row(
+                row, extra_roots=[tmp_path], am_by_path={}
+            )
+        assert entry is not None
+        assert [s["name"] for s in entry.resolved_members[0].supersedes] == ["Other"]
+        assert any("supersedes self" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Sync develop with main. PRs #182, #184, #185 were merged directly to main (promote-main bypass pattern), leaving main 3 commits ahead of develop. This PR fast-forwards develop to main so the next `promote-main` run won't be blocked by "main is not an ancestor of develop."

Same pattern as PR #164.

## Context

The original `Fast-forward Promote develop → main` run at SHA `504d4d0` (workflow run 26368021161) failed because the "Verify CI passed on source SHA" check ran before develop CI completed (test (3.11) was reported `<missing>`). After that failure, the v0.6.1 release went through via direct-to-main merges (#182 → #184 → #185), leaving develop behind.

CI on `504d4d0` is now fully green; the failing run is stale and not actionable in its current form. The correct next step is to bring develop forward.

## Test plan

- [ ] CI green on this PR
- [ ] Merge fast-forwards develop to `21ca872`
- [ ] Next `promote-main.yml` run is a no-op (develop == main)

<!-- hestia:maintenance-sweep id=9d853a8f-19e7-4bf9-83fb-6d5732166cf8 ci-run=26368021161 -->
