### PR TITLE
config: resolver model reads models.resolve like the other three knobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`models.resolve` — the resolver model joins the `models:` block (#513).**
+  #232 introduced the `models:` yaml section and the shared
+  `config.resolve_model()` precedence helper, but routed only three of the four
+  model knobs through it; the contradiction resolver kept a hand-rolled
+  env/yaml/default chain reading a standalone `resolve.model` key. That was a
+  config-surface inconsistency (users set three model ids in one block and the
+  fourth somewhere else) and a drift hazard (two copies of the same precedence
+  logic, so a future change to the shared helper would silently skip the
+  resolver). `resolutions._get_model` now delegates to `config.resolve_model`
+  with knob `resolve`. **Backward compatible — no config edit required:** the
+  pre-#232 `resolve.model` key is still honored, threaded in as the helper's
+  default so it sits below `models.resolve` but above the code default. Full
+  precedence, highest first: `ATHENAEUM_RESOLVE_MODEL` env >
+  `models.resolve` > `resolve.model` (legacy) > `DEFAULT_RESOLVE_MODEL`.
+  The config template and `docs/configuration.md` now advertise
+  `models.resolve` as the preferred key and mark `resolve.model` legacy.
+  Not to be confused with #234 (multi-provider support) — all four knobs
+  remain free-form model-id strings passed to the Anthropic SDK.
+
 - **Bulk PII migration + corpus-wide PII lint (#495).** #479 shipped
   `athenaeum storage migrate-pii` as a single-page tool, but the live corpus
   needs the transform over ~11.5k entity pages, and 790 pages carry an email in

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,15 +167,17 @@ Behavior and guards:
 ## Models
 
 All model values are free-form model-id strings passed to the Anthropic SDK.
-The first three live under the `models:` yaml block (#232); the resolver model
-is configured separately under `resolve:`.
+All four live under the `models:` yaml block (#232); the resolver model
+additionally accepts the legacy `resolve.model` key for backward compatibility.
 
 | Knob | Env var | YAML key | Default | Used by |
 |---|---|---|---|---|
 | Classifier | `ATHENAEUM_CLASSIFY_MODEL` | `models.classify` | `claude-haiku-4-5-20251001` | Tier-2 classifier **and** the C4 contradiction detector — one knob by design. |
 | Writer | `ATHENAEUM_WRITE_MODEL` | `models.write` | `claude-sonnet-4-6` | Tier-3 wiki writer. |
 | Topic extractor | `ATHENAEUM_TOPIC_MODEL` | `models.topic` | `claude-haiku-4-5-20251001` | `athenaeum query-topics` recall query rewriting. |
-| Resolver | `ATHENAEUM_RESOLVE_MODEL` | `resolve.model` | `claude-opus-4-7` | Contradiction resolver (proposes a winner once the detector flags a conflict). |
+| Resolver | `ATHENAEUM_RESOLVE_MODEL` | `models.resolve` (_also_ `resolve.model`¹) | `claude-opus-4-7` | Contradiction resolver (proposes a winner once the detector flags a conflict). |
+
+> ¹ The legacy `resolve.model` key is checked as a fallback when neither the `ATHENAEUM_RESOLVE_MODEL` env var nor `models.resolve` is set. Prefer `models.resolve` for consistency with the other model knobs.
 
 ## LLM provider selection (#330)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,8 +167,9 @@ Behavior and guards:
 ## Models
 
 All model values are free-form model-id strings passed to the Anthropic SDK.
-All four live under the `models:` yaml block (#232); the resolver model
-additionally accepts the legacy `resolve.model` key for backward compatibility.
+All four live under the `models:` yaml block (#232, #513) and share one
+resolver helper (`config.resolve_model`). The resolver model additionally
+accepts the pre-#232 `resolve.model` key for backward compatibility.
 
 | Knob | Env var | YAML key | Default | Used by |
 |---|---|---|---|---|
@@ -313,8 +314,10 @@ spend:
 
 ## Contradiction detection and resolver
 
-Detection knobs live under the `contradiction:` yaml block; resolver knobs
-under `resolve:`. Pipeline walkthrough:
+Detection knobs live under the `contradiction:` yaml block; resolver behavior
+knobs under `resolve:`. The resolver *model* lives under `models.resolve` with
+the other model knobs (`resolve.model` is the legacy fallback — see
+[Models](#models)). Pipeline walkthrough:
 [contradiction-detection.md](contradiction-detection.md); auto-apply lane:
 [auto-resolve.md](auto-resolve.md).
 
@@ -489,6 +492,7 @@ models:
   classify: claude-haiku-4-5-20251001
   write: claude-sonnet-4-6
   topic: claude-haiku-4-5-20251001
+  resolve: claude-opus-4-7
 
 contradiction:
   cross_scope_mode: ancestor
@@ -499,7 +503,7 @@ contradiction:
   not_a_conflict_ttl_days: 0  # 0 = disabled; >0 decays stale auto not_a_conflict (#251)
 
 resolve:
-  model: claude-opus-4-7
+  # model: claude-opus-4-7   # legacy — prefer models.resolve above
   auto_apply: true
   auto_apply_threshold: 0.90
   full_body_token_cap: 1500

--- a/src/athenaeum/config.py
+++ b/src/athenaeum/config.py
@@ -1263,8 +1263,9 @@ def resolve_model(
     single run without editing config, and the yaml key is read only when
     the operator actually set it — no seed in ``_DEFAULTS`` (issue #231).
     Non-string or blank yaml values fall through to *default*. The
-    contradiction-resolver model is NOT routed through here; it stays at
-    ``resolve.model`` (see :func:`athenaeum.resolutions._get_model`).
+    contradiction-resolver model resolves via
+    :func:`athenaeum.resolutions._get_model`, which checks
+    ``models.resolve`` first, then falls back to ``resolve.model``.
     """
     env = os.environ.get(env_var)
     if env:

--- a/src/athenaeum/config.py
+++ b/src/athenaeum/config.py
@@ -1263,9 +1263,10 @@ def resolve_model(
     single run without editing config, and the yaml key is read only when
     the operator actually set it — no seed in ``_DEFAULTS`` (issue #231).
     Non-string or blank yaml values fall through to *default*. The
-    contradiction-resolver model resolves via
-    :func:`athenaeum.resolutions._get_model`, which checks
-    ``models.resolve`` first, then falls back to ``resolve.model``.
+    contradiction-resolver model routes through here too, via
+    :func:`athenaeum.resolutions._get_model` (knob ``resolve``); that
+    wrapper threads the legacy ``resolve.model`` yaml key in as *default*
+    so it sits below ``models.resolve`` but above the code default.
     """
     env = os.environ.get(env_var)
     if env:
@@ -1560,12 +1561,14 @@ search_backend: fts5
 #   (env: ATHENAEUM_CLASSIFY_MODEL).
 # write: Tier-3 writer (env: ATHENAEUM_WRITE_MODEL).
 # topic: recall query-topic extraction (env: ATHENAEUM_TOPIC_MODEL).
-# The contradiction-resolver model is configured separately under
-# ``resolve.model`` below (env: ATHENAEUM_RESOLVE_MODEL).
+# resolve: contradiction resolver (env: ATHENAEUM_RESOLVE_MODEL). The legacy
+#   ``resolve.model`` key below still works, but is checked only when
+#   ``models.resolve`` is unset. Prefer this block for all four knobs.
 # models:
 #   classify: claude-haiku-4-5-20251001
 #   write: claude-sonnet-4-6
 #   topic: claude-haiku-4-5-20251001
+#   resolve: claude-opus-4-7
 
 # Cross-scope contradiction detection (issue #125).
 # cross_scope_mode: off | ancestor (default) | similarity | both.
@@ -1592,7 +1595,9 @@ search_backend: fts5
 
 # Contradiction resolver (issue #126). See docs/auto-resolve.md for the
 # full knob set (auto_apply, auto_apply_threshold, full_body_token_cap).
-# model: model used to propose a winner once Haiku flags a contradiction.
+# model: LEGACY key for the model used to propose a winner once Haiku flags a
+#   contradiction. Prefer ``models.resolve`` above; this key is read only when
+#   ``models.resolve`` is unset, and is kept working for pre-existing configs.
 #   Defaults to claude-opus-4-7. Env override: ATHENAEUM_RESOLVE_MODEL.
 # resolve:
 #   model: claude-opus-4-7

--- a/src/athenaeum/resolutions.py
+++ b/src/athenaeum/resolutions.py
@@ -63,6 +63,7 @@ from datetime import date, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+from athenaeum.config import resolve_model as _resolve_model_knob
 from athenaeum.contradictions import ContradictionResult
 from athenaeum.json_utils import extract_json_object
 from athenaeum.models import (
@@ -610,31 +611,42 @@ _JSON_REPAIR_NUDGE = (
 
 
 def _get_model(config: dict[str, Any] | None = None) -> str:
-    """Resolve the resolver model from env > config > default.
+    """Resolve the resolver model from env > yaml > default.
 
-    Mirrors the env > yaml > default precedence used in
-    :func:`athenaeum.config.resolve_model` so users can set the resolver
-    model under the ``models:`` block (``models.resolve``) alongside the
-    classifier, writer, and topic knobs. The legacy ``resolve.model`` yaml
-    key is supported as a backward-compatible fallback.
+    Routed through the shared :func:`athenaeum.config.resolve_model` helper
+    (issue #232) so the resolver reads ``models.resolve`` from the same
+    ``models:`` block as the classifier, writer, and topic knobs instead of
+    hand-rolling a second copy of the precedence chain. #232 originally left
+    this knob at the standalone ``resolve.model`` key; that split was a
+    config-surface inconsistency, not a design decision worth keeping
+    (issue #513).
+
+    Full precedence, highest first:
+
+    1. ``ATHENAEUM_RESOLVE_MODEL`` env var
+    2. ``models.resolve`` yaml key (preferred)
+    3. ``resolve.model`` yaml key (legacy, pre-#232 — still honored so
+       existing ``athenaeum.yaml`` files keep working unchanged)
+    4. :data:`DEFAULT_RESOLVE_MODEL`
+
+    The legacy key is threaded in as the *default* passed to the shared
+    helper, which is what places it below ``models.resolve`` but above the
+    code default. Non-string or blank values at either yaml layer fall
+    through, matching the other three knobs.
     """
-    env = os.environ.get("ATHENAEUM_RESOLVE_MODEL")
-    if env:
-        return env
+    legacy = ""
     if isinstance(config, dict):
-        # models.resolve — consistent with the other model knobs.
-        models = config.get("models")
-        if isinstance(models, dict):
-            raw = models.get("resolve")
-            if isinstance(raw, str) and raw.strip():
-                return raw.strip()
-        # Legacy fallback: resolve.model (pre-#232 yaml path).
         resolve_cfg = config.get("resolve")
         if isinstance(resolve_cfg, dict):
             raw = resolve_cfg.get("model")
             if isinstance(raw, str) and raw.strip():
-                return raw.strip()
-    return DEFAULT_RESOLVE_MODEL
+                legacy = raw.strip()
+    return _resolve_model_knob(
+        "resolve",
+        "ATHENAEUM_RESOLVE_MODEL",
+        legacy or DEFAULT_RESOLVE_MODEL,
+        config,
+    )
 
 
 def resolve_auto_apply(config: dict[str, Any] | None = None) -> bool:

--- a/src/athenaeum/resolutions.py
+++ b/src/athenaeum/resolutions.py
@@ -612,14 +612,23 @@ _JSON_REPAIR_NUDGE = (
 def _get_model(config: dict[str, Any] | None = None) -> str:
     """Resolve the resolver model from env > config > default.
 
-    Mirrors the env > yaml > default precedence used elsewhere. Env wins
-    so an operator can swap models for a single run without editing the
-    yaml.
+    Mirrors the env > yaml > default precedence used in
+    :func:`athenaeum.config.resolve_model` so users can set the resolver
+    model under the ``models:`` block (``models.resolve``) alongside the
+    classifier, writer, and topic knobs. The legacy ``resolve.model`` yaml
+    key is supported as a backward-compatible fallback.
     """
     env = os.environ.get("ATHENAEUM_RESOLVE_MODEL")
     if env:
         return env
     if isinstance(config, dict):
+        # models.resolve — consistent with the other model knobs.
+        models = config.get("models")
+        if isinstance(models, dict):
+            raw = models.get("resolve")
+            if isinstance(raw, str) and raw.strip():
+                return raw.strip()
+        # Legacy fallback: resolve.model (pre-#232 yaml path).
         resolve_cfg = config.get("resolve")
         if isinstance(resolve_cfg, dict):
             raw = resolve_cfg.get("model")

--- a/tests/test_config_parity.py
+++ b/tests/test_config_parity.py
@@ -4,9 +4,11 @@
 Covers:
 - ``--max-files`` gains ``ATHENAEUM_MAX_FILES`` env + ``librarian.max_files``
   yaml, mirroring the #220 ``--max-api-calls`` precedence chain.
-- New ``models:`` yaml section for the three previously env-only model knobs
+- New ``models:`` yaml section for the previously env-only model knobs
   (``models.classify`` / ``models.write`` / ``models.topic``). Env wins over
-  yaml per knob; the resolver model stays at ``resolve.model`` (untouched).
+  yaml per knob. The resolver model joined the same block as
+  ``models.resolve`` in the #232 follow-up (issue #513); the pre-#232
+  ``resolve.model`` key is still honored as a lower-precedence fallback.
 - Regression guard: none of the new keys are seeded into ``config._DEFAULTS``
   (the #231 shadowing bug) — yaml is read only when the operator set it.
 
@@ -595,29 +597,106 @@ class TestModelPlumbingProductionPath:
 
 
 # ---------------------------------------------------------------------------
-# Resolver model stays at resolve.model — NOT routed through models:
+# Resolver model: env > models.resolve > resolve.model (legacy) > default
 # ---------------------------------------------------------------------------
 
 
-class TestResolverModelUntouched:
-    """The contradiction-resolver model must ignore the new ``models:``
-    section and keep resolving from env > ``resolve.model`` > default."""
+class TestResolverModelPrecedence:
+    """The contradiction-resolver model reads ``models.resolve`` like every
+    other knob, with the pre-#232 ``resolve.model`` key kept working as a
+    lower-precedence fallback (issue #513).
 
+    Ordering under test, highest first: ``ATHENAEUM_RESOLVE_MODEL`` env >
+    ``models.resolve`` > ``resolve.model`` > ``DEFAULT_RESOLVE_MODEL``.
+    """
+
+    # A ``models:`` block that sets the OTHER three knobs but not ``resolve``.
     _MODELS_ONLY = {"models": {"classify": "x", "write": "y", "topic": "z"}}
 
-    def test_models_section_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_other_knobs_do_not_leak_into_resolver(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """classify/write/topic must never be mistaken for the resolver knob."""
         monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
         assert (
             resolutions_mod._get_model(self._MODELS_ONLY)
             == resolutions_mod.DEFAULT_RESOLVE_MODEL
         )
 
-    def test_resolve_model_still_resolves(
+    def test_models_resolve_is_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        cfg = {"models": {**self._MODELS_ONLY["models"], "resolve": "new-resolver"}}
+        assert resolutions_mod._get_model(cfg) == "new-resolver"
+
+    def test_legacy_resolve_model_still_resolves(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Backward compat: pre-#232 configs keep working untouched."""
         monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
         cfg = {**self._MODELS_ONLY, "resolve": {"model": "my-resolver"}}
         assert resolutions_mod._get_model(cfg) == "my-resolver"
+
+    def test_models_resolve_wins_over_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        cfg = {
+            "models": {"resolve": "new-resolver"},
+            "resolve": {"model": "legacy-resolver"},
+        }
+        assert resolutions_mod._get_model(cfg) == "new-resolver"
+
+    def test_env_wins_over_both_yaml_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATHENAEUM_RESOLVE_MODEL", "env-resolver")
+        cfg = {
+            "models": {"resolve": "new-resolver"},
+            "resolve": {"model": "legacy-resolver"},
+        }
+        assert resolutions_mod._get_model(cfg) == "env-resolver"
+
+    @pytest.mark.parametrize("bad", ["", "   ", 42, None, ["claude"], {"a": 1}])
+    def test_blank_or_non_string_models_resolve_falls_through_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch, bad: Any
+    ) -> None:
+        """Matches the other three knobs: junk at the yaml layer falls through
+        rather than being passed to the SDK as a model id."""
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        cfg = {"models": {"resolve": bad}, "resolve": {"model": "legacy-resolver"}}
+        assert resolutions_mod._get_model(cfg) == "legacy-resolver"
+
+    @pytest.mark.parametrize("bad", ["", "   ", 42, None])
+    def test_blank_legacy_falls_through_to_default(
+        self, monkeypatch: pytest.MonkeyPatch, bad: Any
+    ) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        cfg = {"resolve": {"model": bad}}
+        assert resolutions_mod._get_model(cfg) == resolutions_mod.DEFAULT_RESOLVE_MODEL
+
+    def test_non_dict_sections_degrade_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        cfg = {"models": "not-a-dict", "resolve": "not-a-dict"}
+        assert resolutions_mod._get_model(cfg) == resolutions_mod.DEFAULT_RESOLVE_MODEL
+
+    def test_no_config_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        assert resolutions_mod._get_model(None) == resolutions_mod.DEFAULT_RESOLVE_MODEL
+
+    def test_end_to_end_through_load_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """models.resolve must survive load_config's merge (issue #231:
+        the key is NOT seeded into _DEFAULTS, so it passes through only
+        when the operator actually set it)."""
+        monkeypatch.delenv("ATHENAEUM_RESOLVE_MODEL", raising=False)
+        (tmp_path / "athenaeum.yaml").write_text(
+            "models:\n  resolve: claude-opus-test\n", encoding="utf-8"
+        )
+        cfg = load_config(tmp_path)
+        assert resolutions_mod._get_model(cfg) == "claude-opus-test"
 
 
 # ---------------------------------------------------------------------------
@@ -663,3 +742,5 @@ class TestTemplateAdvertisesNewKeys:
         assert "#   classify:" in _DEFAULT_CONFIG_CONTENT
         assert "#   write:" in _DEFAULT_CONFIG_CONTENT
         assert "#   topic:" in _DEFAULT_CONFIG_CONTENT
+        # Issue #513: the resolver knob joined the same block.
+        assert "#   resolve: claude-opus-4-7" in _DEFAULT_CONFIG_CONTENT


### PR DESCRIPTION
Fixes #513. Refs #234.

Routes the contradiction-resolver model through the shared
`config.resolve_model()` helper so it reads `models.resolve` alongside
`models.classify` / `models.write` / `models.topic`, instead of hand-rolling a
second copy of the env > yaml > default precedence chain against a standalone
`resolve.model` key.

**Backward compatible — no config edit required.** The pre-#232 `resolve.model`
key is still honored, threaded in as the shared helper's `default` so it sits
below `models.resolve` but above the code default.

Precedence, highest first:

1. `ATHENAEUM_RESOLVE_MODEL` env var
2. `models.resolve` (preferred)
3. `resolve.model` (legacy)
4. `DEFAULT_RESOLVE_MODEL`

## Changes

- `resolutions._get_model` delegates to `config.resolve_model("resolve", ...)`.
  Removes the duplicated precedence logic — the drift hazard that motivated
  #513, since a future change to the shared helper would otherwise silently
  skip the resolver.
- `_DEFAULT_CONFIG_CONTENT`: `# models:` block gains `#   resolve:`, and the
  "configured separately under `resolve.model`" sentence (made false by this
  change) is rewritten. The `# resolve:` block is retained and marked legacy —
  `test_config.py::test_template_names_live_resolver_model_key` asserts on it.
- `docs/configuration.md`: model table, section prose, and example yaml.
- `CHANGELOG.md`: entry under `[Unreleased]`.
- `tests/test_config_parity.py`: `TestResolverModelUntouched` encoded the old
  contract in its name and docstring ("must ignore the new `models:` section").
  Rewritten as `TestResolverModelPrecedence` with full coverage — `models.resolve`
  is read, legacy still resolves, `models.resolve` wins over legacy, env wins
  over both, blank/non-string values fall through at each layer, non-dict
  sections degrade, and an end-to-end pass through `load_config`.

## Not in scope

This is **not** multi-provider support (#234). No adapter seam, no non-Anthropic
SDK, no usage normalization — all four knobs remain free-form model-id strings
passed to the Anthropic SDK. #234 stays open as a demand-tracking issue; this PR
only references it.

## Verification

- `ruff check src/ tests/` — clean.
- Full suite: 3140 passed, 23 skipped. The one failure,
  `test_skill_packaging.py::test_built_wheel_contains_skill`, is a local
  environment issue (`hatchling.build` backend not installed) that reproduces
  identically on a clean `develop` checkout — unrelated to this change.

---
Original contribution by @Mr-Neutr0n. Maintainer follow-up commit refactored the
implementation onto the shared helper, updated the config template and tests,
and corrected the issue linkage — see the PR comment for detail.
